### PR TITLE
Allow transactions, when a configured transactionPermissionContract does not exist

### DIFF
--- a/ethcore/src/tx_filter.rs
+++ b/ethcore/src/tx_filter.rs
@@ -85,6 +85,11 @@ impl TransactionFilter {
 		}
 
 		let contract_address = self.contract_address;
+		if !client.code_hash(&contract_address, BlockId::Hash(*parent_hash)).map_or(false, |c| c != KECCAK_EMPTY) {
+			// transaction permission contract does not exist at current block, permit transaction
+			return true;
+		}
+
 		let contract_version = contract_version_cache.get_mut(parent_hash).and_then(|v| *v).or_else(||  {
 			self.contract.functions()
 				.contract_version()


### PR DESCRIPTION
We wanted to use the `transactionPermissionContract` and deployed a matching contract. Then added the contract to the chain specification. Clients, that already had a synced chain were able to sync, but clients, that performed a full sync, stopped at the first transaction (in our case at block 5), because the configured `transactionPermissionContract` did not exist at this time. If the contract does not exist, the check defaults to "not permitted" due to an error, when calling the non-existing contract, this pull request checks if the contract exists and defaults to true in such a case.

This fixes our issue, but i guess a useful extension to the `transactionPermissionContract` logic would be to use a similar config format like the [Multi-Set Validator-Set](https://wiki.parity.io/Validator-Set.html#multi-set) and define starting blocks for valid permission contracts. This would allow to change the contracts and still be able to sync the chain.