### PR TITLE
rpc: fix is_major_importing sync state condition

### DIFF
--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -118,7 +118,7 @@ pub use http::{
 };
 
 pub use v1::{NetworkSettings, Metadata, Origin, informant, dispatch, signer};
-pub use v1::block_import::is_major_importing;
+pub use v1::block_import::{is_major_importing, is_major_importing_or_waiting};
 pub use v1::extractors::{RpcExtractor, WsExtractor, WsStats, WsDispatcher};
 pub use authcodes::{AuthCodes, TimeProvider};
 pub use http_common::HttpMetaExtractor;

--- a/rpc/src/v1/helpers/block_import.rs
+++ b/rpc/src/v1/helpers/block_import.rs
@@ -22,7 +22,7 @@ use sync::SyncState;
 /// Check if client is during major sync or during block import.
 pub fn is_major_importing(sync_state: Option<SyncState>, queue_info: BlockQueueInfo) -> bool {
 	let is_syncing_state = sync_state.map_or(false, |s| match s {
-		SyncState::Idle | SyncState::NewBlocks | SyncState::WaitingPeers => false,
+		SyncState::Idle | SyncState::NewBlocks => false,
 		_ => true,
 	});
 	let is_verifying = queue_info.unverified_queue_size + queue_info.verified_queue_size > 3;

--- a/rpc/src/v1/helpers/block_import.rs
+++ b/rpc/src/v1/helpers/block_import.rs
@@ -19,14 +19,21 @@
 use ethcore::client::BlockQueueInfo;
 use sync::SyncState;
 
-/// Check if client is during major sync or during block import.
-pub fn is_major_importing(sync_state: Option<SyncState>, queue_info: BlockQueueInfo) -> bool {
+/// Check if client is during major sync or during block import and allows defining whether 'waiting for peers' should
+/// be considered a syncing state.
+pub fn is_major_importing_or_waiting(sync_state: Option<SyncState>, queue_info: BlockQueueInfo, waiting_is_syncing_state: bool) -> bool {
 	let is_syncing_state = sync_state.map_or(false, |s| match s {
 		SyncState::Idle | SyncState::NewBlocks => false,
+		SyncState::WaitingPeers if !waiting_is_syncing_state => false,
 		_ => true,
 	});
 	let is_verifying = queue_info.unverified_queue_size + queue_info.verified_queue_size > 3;
 	is_verifying || is_syncing_state
+}
+
+/// Check if client is during major sync or during block import.
+pub fn is_major_importing(sync_state: Option<SyncState>, queue_info: BlockQueueInfo) -> bool {
+	is_major_importing_or_waiting(sync_state, queue_info, true)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
There's a similar definition [here](https://github.com/paritytech/parity/blob/master/ethcore/sync/src/chain/mod.rs#L271) and this makes it consistent with that.

When we're waiting for peers we're technically not syncing but we're waiting to do it.