### PR TITLE
AuthorityRound: finalize blocks

### DIFF
--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -313,7 +313,7 @@ impl<T: ChainDataFetcher> Client<T> {
 					The node may not be able to synchronize further.", e);
 			}
 
-			let epoch_proof = self.engine.is_epoch_end(
+			let epoch_proof = self.engine.is_epoch_end_light(
 				&verified_header,
 				&|h| self.chain.block_header(BlockId::Hash(h)).and_then(|hdr| hdr.decode().ok()),
 				&|h| self.chain.pending_transition(h),

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -535,10 +535,11 @@ impl Importer {
 
 		state.journal_under(&mut batch, number, hash).expect("DB commit failed");
 
-		for ancestry_action in ancestry_actions {
-			let AncestryAction::MarkFinalized(ancestry) = ancestry_action;
-			chain.mark_finalized(&mut batch, ancestry).expect("Engine's ancestry action must be known blocks; qed");
-		}
+		let finalized: Vec<_> = ancestry_actions.into_iter().map(|ancestry_action| {
+			let AncestryAction::MarkFinalized(a) = ancestry_action;
+			chain.mark_finalized(&mut batch, a).expect("Engine's ancestry action must be known blocks; qed");
+			a
+		}).collect();
 
 		let route = chain.insert_block(&mut batch, block_data, receipts.clone(), ExtrasInsert {
 			fork_choice: fork_choice,
@@ -559,7 +560,7 @@ impl Importer {
 		client.db.read().key_value().write_buffered(batch);
 		chain.commit();
 
-		self.check_epoch_end(&header, &chain, client);
+		self.check_epoch_end(&header, &finalized, &chain, client);
 
 		client.update_last_hashes(&parent, hash);
 
@@ -666,9 +667,10 @@ impl Importer {
 	}
 
 	// check for ending of epoch and write transition if it occurs.
-	fn check_epoch_end<'a>(&self, header: &'a Header, chain: &BlockChain, client: &Client) {
+	fn check_epoch_end<'a>(&self, header: &'a Header, finalized: &'a [H256], chain: &BlockChain, client: &Client) {
 		let is_epoch_end = self.engine.is_epoch_end(
 			header,
+			finalized,
 			&(|hash| client.block_header_decoded(BlockId::Hash(hash))),
 			&(|hash| chain.get_pending_transition(hash)), // TODO: limit to current epoch.
 		);

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -473,7 +473,7 @@ impl Importer {
 		let number = header.number();
 		let parent = header.parent_hash();
 		let chain = client.chain.read();
-		let is_finalized = false;
+		let mut is_finalized = false;
 
 		// Commit results
 		let block = block.drain();
@@ -537,7 +537,14 @@ impl Importer {
 
 		let finalized: Vec<_> = ancestry_actions.into_iter().map(|ancestry_action| {
 			let AncestryAction::MarkFinalized(a) = ancestry_action;
-			chain.mark_finalized(&mut batch, a).expect("Engine's ancestry action must be known blocks; qed");
+
+			if a != header.hash() {
+				chain.mark_finalized(&mut batch, a).expect("Engine's ancestry action must be known blocks; qed");
+			} else {
+				// we're finalizing the current block
+				is_finalized = true;
+			}
+
 			a
 		}).collect();
 

--- a/ethcore/src/engines/authority_round/finality.rs
+++ b/ethcore/src/engines/authority_round/finality.rs
@@ -96,7 +96,10 @@ impl RollingFinality {
 	}
 
 	/// Get an iterator over stored hashes in order.
-	pub fn unfinalized_hashes(&self) -> Iter { Iter(self.headers.iter()) }
+	#[cfg(test)]
+	pub fn unfinalized_hashes(&self) -> impl Iterator<Item=&H256> {
+		self.headers.iter().map(|(h, _)| h)
+	}
 
 	/// Get the validator set.
 	pub fn validators(&self) -> &SimpleList { &self.signers }
@@ -142,16 +145,6 @@ impl RollingFinality {
 
 		self.last_pushed = Some(head);
 		Ok(newly_finalized)
-	}
-}
-
-pub struct Iter<'a>(::std::collections::vec_deque::Iter<'a, (H256, Vec<Address>)>);
-
-impl<'a> Iterator for Iter<'a> {
-	type Item = H256;
-
-	fn next(&mut self) -> Option<H256> {
-		self.0.next().map(|&(h, _)| h)
 	}
 }
 
@@ -220,7 +213,7 @@ mod tests {
 
 		// only the last hash has < 51% of authorities' signatures
 		assert_eq!(finality.unfinalized_hashes().count(), 1);
-		assert_eq!(finality.unfinalized_hashes().next(), Some(hashes[11].0));
+		assert_eq!(finality.unfinalized_hashes().next(), Some(&hashes[11].0));
 		assert_eq!(finality.subchain_head(), Some(hashes[11].0));
 	}
 }

--- a/ethcore/src/engines/basic_authority.rs
+++ b/ethcore/src/engines/basic_authority.rs
@@ -160,6 +160,15 @@ impl Engine<EthereumMachine> for BasicAuthority {
 		self.validators.is_epoch_end(first, chain_head)
 	}
 
+	fn is_epoch_end_light(
+		&self,
+		chain_head: &Header,
+		chain: &super::Headers<Header>,
+		transition_store: &super::PendingTransitionStore,
+	) -> Option<Vec<u8>> {
+		self.is_epoch_end(chain_head, &[], chain, transition_store)
+	}
+
 	fn epoch_verifier<'a>(&self, header: &Header, proof: &'a [u8]) -> ConstructedVerifier<'a, EthereumMachine> {
 		let first = header.number() == 0;
 

--- a/ethcore/src/engines/basic_authority.rs
+++ b/ethcore/src/engines/basic_authority.rs
@@ -150,6 +150,7 @@ impl Engine<EthereumMachine> for BasicAuthority {
 	fn is_epoch_end(
 		&self,
 		chain_head: &Header,
+		_finalized: &[H256],
 		_chain: &super::Headers<Header>,
 		_transition_store: &super::PendingTransitionStore,
 	) -> Option<Vec<u8>> {

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -333,7 +333,8 @@ pub trait Engine<M: Machine>: Sync + Send {
 	///
 	/// This either means that an immediate transition occurs or a block signalling transition
 	/// has reached finality. The `Headers` given are not guaranteed to return any blocks
-	/// from any epoch other than the current.
+	/// from any epoch other than the current. The client must keep track of finality and provide
+	/// the latest finalized headers to check against the transition store.
 	///
 	/// Return optional transition proof.
 	fn is_epoch_end(
@@ -346,6 +347,15 @@ pub trait Engine<M: Machine>: Sync + Send {
 		None
 	}
 
+	/// Whether a block is the end of an epoch.
+	///
+	/// This either means that an immediate transition occurs or a block signalling transition
+	/// has reached finality. The `Headers` given are not guaranteed to return any blocks
+	/// from any epoch other than the current. This is a specialized method to use for light
+	/// clients since the light client doesn't track finality of all blocks, and therefore finality
+	/// for blocks in the current epoch is built inside this method by the engine.
+	///
+	/// Return optional transition proof.
 	fn is_epoch_end_light(
 		&self,
 		_chain_head: &M::Header,

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -346,6 +346,15 @@ pub trait Engine<M: Machine>: Sync + Send {
 		None
 	}
 
+	fn is_epoch_end_light(
+		&self,
+		_chain_head: &M::Header,
+		_chain: &Headers<M::Header>,
+		_transition_store: &PendingTransitionStore,
+	) -> Option<Vec<u8>> {
+		None
+	}
+
 	/// Create an epoch verifier from validation proof and a flag indicating
 	/// whether finality is required.
 	fn epoch_verifier<'a>(&self, _header: &M::Header, _proof: &'a [u8]) -> ConstructedVerifier<'a, M> {

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -339,6 +339,7 @@ pub trait Engine<M: Machine>: Sync + Send {
 	fn is_epoch_end(
 		&self,
 		_chain_head: &M::Header,
+		_finalized: &[H256],
 		_chain: &Headers<M::Header>,
 		_transition_store: &PendingTransitionStore,
 	) -> Option<Vec<u8>> {

--- a/ethcore/src/engines/tendermint/mod.rs
+++ b/ethcore/src/engines/tendermint/mod.rs
@@ -653,6 +653,15 @@ impl Engine<EthereumMachine> for Tendermint {
 		None
 	}
 
+	fn is_epoch_end_light(
+		&self,
+		chain_head: &Header,
+		chain: &super::Headers<Header>,
+		transition_store: &super::PendingTransitionStore,
+	) -> Option<Vec<u8>> {
+		self.is_epoch_end(chain_head, &[], chain, transition_store)
+	}
+
 	fn epoch_verifier<'a>(&self, _header: &Header, proof: &'a [u8]) -> ConstructedVerifier<'a, EthereumMachine> {
 		let (signal_number, set_proof, finality_proof) = match destructure_proofs(proof) {
 			Ok(x) => x,

--- a/ethcore/src/engines/tendermint/mod.rs
+++ b/ethcore/src/engines/tendermint/mod.rs
@@ -635,6 +635,7 @@ impl Engine<EthereumMachine> for Tendermint {
 	fn is_epoch_end(
 		&self,
 		chain_head: &Header,
+		_finalized: &[H256],
 		_chain: &super::Headers<Header>,
 		transition_store: &super::PendingTransitionStore,
 	) -> Option<Vec<u8>> {


### PR DESCRIPTION
Implement `ancestry_actions` to mark finalized blocks using the existing rolling finality. I've also changed the `is_epoch_end` method so that it gets the recently finalized blocks as argument and can check the transition store using that.