### PR TITLE
Fix bugfix hard fork logic

### DIFF
--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -1088,10 +1088,12 @@ impl miner::MinerService for Miner {
 
 		// refuse to seal the first block of the chain if it contains hard forks
 		// which should be on by default.
-		if block.block().header().number() == 1 && self.engine.params().contains_bugfix_hard_fork() {
-			warn!("Your chain specification contains one or more hard forks which are required to be \
-				on by default. Please remove these forks and start your chain again.");
-			return;
+		if block.block().header().number() == 1 {
+			if let Some(name) = self.engine.params().nonzero_bugfix_hard_fork() {
+				warn!("Your chain specification contains one or more hard forks which are required to be \
+					   on by default. Please remove these forks and start your chain again: {}.", name);
+				return;
+			}
 		}
 
 		match self.engine.seals_internally() {

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -57,7 +57,7 @@ fn fmt_err<F: ::std::fmt::Display>(f: F) -> String {
 
 /// Parameters common to ethereum-like blockchains.
 /// NOTE: when adding bugfix hard-fork parameters,
-/// add to `contains_bugfix_hard_fork`
+/// add to `nonzero_bugfix_hard_fork`
 ///
 /// we define a "bugfix" hard fork as any hard fork which
 /// you would put on-by-default in a new chain.
@@ -188,13 +188,25 @@ impl CommonParams {
 		}
 	}
 
-	/// Whether these params contain any bug-fix hard forks.
-	pub fn contains_bugfix_hard_fork(&self) -> bool {
-		self.eip98_transition != 0 && self.eip155_transition != 0 &&
-			self.validate_receipts_transition != 0 && self.eip86_transition != 0 &&
-			self.eip140_transition != 0 && self.eip210_transition != 0 &&
-			self.eip211_transition != 0 && self.eip214_transition != 0 &&
-			self.validate_chain_id_transition != 0 && self.dust_protection_transition != 0
+	/// Return Some if the current parameters contain a bugfix hard fork not on block 0.
+	pub fn nonzero_bugfix_hard_fork(&self) -> Option<&'static str> {
+		if self.eip155_transition != 0 {
+			return Some("eip155Transition");
+		}
+
+		if self.validate_receipts_transition != 0 {
+			return Some("validateReceiptsTransition");
+		}
+
+		if self.validate_chain_id_transition != 0 {
+			return Some("validateChainIdTransition");
+		}
+
+		if self.dust_protection_transition != 0 {
+			return Some("dustProtectionTransition");
+		}
+
+		None
 	}
 }
 

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -202,10 +202,6 @@ impl CommonParams {
 			return Some("validateChainIdTransition");
 		}
 
-		if self.dust_protection_transition != 0 {
-			return Some("dustProtectionTransition");
-		}
-
 		None
 	}
 }

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -189,7 +189,7 @@ impl CommonParams {
 	}
 
 	/// Return Some if the current parameters contain a bugfix hard fork not on block 0.
-	pub fn nonzero_bugfix_hard_fork(&self) -> Option<&'static str> {
+	pub fn nonzero_bugfix_hard_fork(&self) -> Option<&str> {
 		if self.eip155_transition != 0 {
 			return Some("eip155Transition");
 		}


### PR DESCRIPTION
A bugfix hard fork is something that should always be on by default. When checking, it should use `||` instead of `&&`. In addition, EIP86, EIP98, etc do not belong to this category.

This PR also changes the function to return a string instead, so it can tell the operator what needs to be changed in the chain spec config.