### PR TITLE
Comply EIP-86 with the new definition

### DIFF
--- a/ethcore/evm/src/instructions.rs
+++ b/ethcore/evm/src/instructions.rs
@@ -591,7 +591,7 @@ lazy_static! {
 		arr[DELEGATECALL as usize] = Some(InstructionInfo::new("DELEGATECALL", 6, 1, GasPriceTier::Special));
 		arr[STATICCALL as usize] = Some(InstructionInfo::new("STATICCALL", 6, 1, GasPriceTier::Special));
 		arr[SUICIDE as usize] = Some(InstructionInfo::new("SUICIDE", 1, 0, GasPriceTier::Special));
-		arr[CREATE2 as usize] = Some(InstructionInfo::new("CREATE2", 3, 1, GasPriceTier::Special));
+		arr[CREATE2 as usize] = Some(InstructionInfo::new("CREATE2", 4, 1, GasPriceTier::Special));
 		arr[REVERT as usize] = Some(InstructionInfo::new("REVERT", 2, 0, GasPriceTier::Zero));
 		arr
 	};

--- a/ethcore/evm/src/interpreter/gasometer.rs
+++ b/ethcore/evm/src/interpreter/gasometer.rs
@@ -225,7 +225,11 @@ impl<Gas: evm::CostType> Gasometer<Gas> {
 			},
 			instructions::CREATE | instructions::CREATE2 => {
 				let gas = Gas::from(schedule.create_gas);
-				let mem = mem_needed(stack.peek(1), stack.peek(2))?;
+				let mem = match instruction {
+					instructions::CREATE => mem_needed(stack.peek(1), stack.peek(2))?,
+					instructions::CREATE2 => mem_needed(stack.peek(2), stack.peek(3))?,
+					_ => unreachable!("instruction can only be CREATE/CREATE2 checked above; qed"),
+				};
 
 				Request::GasMemProvide(gas, mem, None)
 			},

--- a/ethcore/evm/src/interpreter/mod.rs
+++ b/ethcore/evm/src/interpreter/mod.rs
@@ -316,6 +316,7 @@ impl<Cost: CostType> Interpreter<Cost> {
 			},
 			instructions::CREATE | instructions::CREATE2 => {
 				let endowment = stack.pop_back();
+				let salt = stack.pop_back();
 				let init_off = stack.pop_back();
 				let init_size = stack.pop_back();
 
@@ -335,7 +336,11 @@ impl<Cost: CostType> Interpreter<Cost> {
 				}
 
 				let contract_code = self.mem.read_slice(init_off, init_size);
-				let address_scheme = if instruction == instructions::CREATE { CreateContractAddress::FromSenderAndNonce } else { CreateContractAddress::FromSenderAndCodeHash };
+				let address_scheme = if instruction == instructions::CREATE {
+					CreateContractAddress::FromSenderAndNonce
+				} else {
+					CreateContractAddress::FromSenderSaltAndCodeHash(salt.into())
+				};
 
 				let create_result = ext.create(&create_gas.as_u256(), &endowment, contract_code, address_scheme);
 				return match create_result {

--- a/ethcore/evm/src/interpreter/mod.rs
+++ b/ethcore/evm/src/interpreter/mod.rs
@@ -316,7 +316,10 @@ impl<Cost: CostType> Interpreter<Cost> {
 			},
 			instructions::CREATE | instructions::CREATE2 => {
 				let endowment = stack.pop_back();
-				let salt = stack.pop_back();
+				let address_scheme = match instruction {
+					instructions::CREATE => CreateContractAddress::FromSenderAndNonce,
+					instructions::CREATE2 => CreateContractAddress::FromSenderSaltAndCodeHash(stack.pop_back().into()),
+				};
 				let init_off = stack.pop_back();
 				let init_size = stack.pop_back();
 
@@ -336,11 +339,6 @@ impl<Cost: CostType> Interpreter<Cost> {
 				}
 
 				let contract_code = self.mem.read_slice(init_off, init_size);
-				let address_scheme = if instruction == instructions::CREATE {
-					CreateContractAddress::FromSenderAndNonce
-				} else {
-					CreateContractAddress::FromSenderSaltAndCodeHash(salt.into())
-				};
 
 				let create_result = ext.create(&create_gas.as_u256(), &endowment, contract_code, address_scheme);
 				return match create_result {

--- a/ethcore/evm/src/interpreter/mod.rs
+++ b/ethcore/evm/src/interpreter/mod.rs
@@ -319,6 +319,7 @@ impl<Cost: CostType> Interpreter<Cost> {
 				let address_scheme = match instruction {
 					instructions::CREATE => CreateContractAddress::FromSenderAndNonce,
 					instructions::CREATE2 => CreateContractAddress::FromSenderSaltAndCodeHash(stack.pop_back().into()),
+					_ => unreachable!("instruction can only be CREATE/CREATE2 checked above; qed"),
 				};
 				let init_off = stack.pop_back();
 				let init_size = stack.pop_back();

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -61,10 +61,12 @@ pub fn contract_address(address_scheme: CreateContractAddress, sender: &Address,
 			stream.append(nonce);
 			(From::from(keccak(stream.as_raw())), None)
 		},
-		CreateContractAddress::FromCodeHash => {
+		CreateContractAddress::FromSenderSaltAndCodeHash(salt) => {
 			let code_hash = keccak(code);
-			let mut buffer = [0xffu8; 20 + 32];
-			&mut buffer[20..].copy_from_slice(&code_hash[..]);
+			let mut buffer = [0u8; 20 + 32 + 32];
+			&mut buffer[0..20].copy_from_slice(&sender[..]);
+			&mut buffer[20..(20+32)].copy_from_slice(&salt[..]);
+			&mut buffer[(20+32)..].copy_from_slice(&code_hash[..]);
 			(From::from(keccak(&buffer[..])), Some(code_hash))
 		},
 		CreateContractAddress::FromSenderAndCodeHash => {

--- a/ethcore/src/externalities.rs
+++ b/ethcore/src/externalities.rs
@@ -570,4 +570,44 @@ mod tests {
 
 		assert_eq!(setup.sub_state.suicides.len(), 1);
 	}
+
+	#[test]
+	fn can_create() {
+		use std::str::FromStr;
+
+		let mut setup = TestSetup::new();
+		let state = &mut setup.state;
+		let mut tracer = NoopTracer;
+		let mut vm_tracer = NoopVMTracer;
+
+		let address = {
+			let mut ext = Externalities::new(state, &setup.env_info, &setup.machine, 0, get_test_origin(), &mut setup.sub_state, OutputPolicy::InitContract(None), &mut tracer, &mut vm_tracer, false);
+			match ext.create(&U256::max_value(), &U256::zero(), &[], CreateContractAddress::FromSenderAndNonce) {
+				ContractCreateResult::Created(address, _) => address,
+				_ => panic!("Test create failed; expected Created, got Failed/Reverted."),
+			}
+		};
+
+		assert_eq!(address, Address::from_str("bd770416a3345f91e4b34576cb804a576fa48eb1").unwrap());
+	}
+
+	#[test]
+	fn can_create2() {
+		use std::str::FromStr;
+
+		let mut setup = TestSetup::new();
+		let state = &mut setup.state;
+		let mut tracer = NoopTracer;
+		let mut vm_tracer = NoopVMTracer;
+
+		let address = {
+			let mut ext = Externalities::new(state, &setup.env_info, &setup.machine, 0, get_test_origin(), &mut setup.sub_state, OutputPolicy::InitContract(None), &mut tracer, &mut vm_tracer, false);
+			match ext.create(&U256::max_value(), &U256::zero(), &[], CreateContractAddress::FromSenderSaltAndCodeHash(H256::default())) {
+				ContractCreateResult::Created(address, _) => address,
+				_ => panic!("Test create failed; expected Created, got Failed/Reverted."),
+			}
+		};
+
+		assert_eq!(address, Address::from_str("b7c227636666831278bacdb8d7f52933b8698ab9").unwrap());
+	}
 }

--- a/ethcore/src/machine.rs
+++ b/ethcore/src/machine.rs
@@ -309,12 +309,8 @@ impl EthereumMachine {
 	}
 
 	/// Returns new contract address generation scheme at given block number.
-	pub fn create_address_scheme(&self, number: BlockNumber) -> CreateContractAddress {
-		if number >= self.params().eip86_transition {
-			CreateContractAddress::FromCodeHash
-		} else {
-			CreateContractAddress::FromSenderAndNonce
-		}
+	pub fn create_address_scheme(&self, _number: BlockNumber) -> CreateContractAddress {
+		CreateContractAddress::FromSenderAndNonce
 	}
 
 	/// Verify a particular transaction is valid, regardless of order.

--- a/ethcore/vm/src/ext.rs
+++ b/ethcore/vm/src/ext.rs
@@ -53,11 +53,11 @@ pub enum MessageCallResult {
 /// Specifies how an address is calculated for a new contract.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum CreateContractAddress {
-	/// Address is calculated from nonce and sender. Pre EIP-86 (Metropolis)
+	/// Address is calculated from sender and nonce. Pre EIP-86 (Metropolis)
 	FromSenderAndNonce,
-	/// Address is calculated from code hash. Default since EIP-86
-	FromCodeHash,
-	/// Address is calculated from code hash and sender. Used by CREATE_P2SH instruction.
+	/// Address is calculated from sender, salt and code hash. EIP-86 CREATE2 scheme.
+	FromSenderSaltAndCodeHash(H256),
+	/// Address is calculated from code hash and sender. Used by pwasm create ext.
 	FromSenderAndCodeHash,
 }
 

--- a/ethcore/vm/src/schedule.rs
+++ b/ethcore/vm/src/schedule.rs
@@ -22,7 +22,7 @@ pub struct Schedule {
 	pub exceptional_failed_code_deposit: bool,
 	/// Does it have a delegate cal
 	pub have_delegate_call: bool,
-	/// Does it have a CREATE_P2SH instruction
+	/// Does it have a CREATE2 instruction
 	pub have_create2: bool,
 	/// Does it have a REVERT instruction
 	pub have_revert: bool,

--- a/rpc/src/v1/helpers/dispatch.rs
+++ b/rpc/src/v1/helpers/dispatch.rs
@@ -178,8 +178,7 @@ impl<C: miner::BlockChainClient + BlockChainClient, M: MinerService> Dispatcher 
 	}
 
 	fn enrich(&self, signed_transaction: SignedTransaction) -> RpcRichRawTransaction {
-		let block_number = self.client.best_block_header().number();
-		RpcRichRawTransaction::from_signed(signed_transaction, block_number, self.client.eip86_transition())
+		RpcRichRawTransaction::from_signed(signed_transaction)
 	}
 
 	fn dispatch_transaction(&self, signed_transaction: PendingTransaction) -> Result<H256> {
@@ -405,8 +404,7 @@ impl Dispatcher for LightDispatcher {
 	}
 
 	fn enrich(&self, signed_transaction: SignedTransaction) -> RpcRichRawTransaction {
-		let block_number = self.client.best_block_header().number();
-		RpcRichRawTransaction::from_signed(signed_transaction, block_number, self.client.eip86_transition())
+		RpcRichRawTransaction::from_signed(signed_transaction)
 	}
 
 	fn dispatch_transaction(&self, signed_transaction: PendingTransaction) -> Result<H256> {

--- a/rpc/src/v1/helpers/light_fetch.rs
+++ b/rpc/src/v1/helpers/light_fetch.rs
@@ -66,7 +66,7 @@ pub struct LightFetch {
 }
 
 /// Extract a transaction at given index.
-pub fn extract_transaction_at_index(block: encoded::Block, index: usize, eip86_transition: u64) -> Option<Transaction> {
+pub fn extract_transaction_at_index(block: encoded::Block, index: usize) -> Option<Transaction> {
 	block.transactions().into_iter().nth(index)
 		// Verify if transaction signature is correct.
 		.and_then(|tx| SignedTransaction::new(tx).ok())
@@ -85,7 +85,7 @@ pub fn extract_transaction_at_index(block: encoded::Block, index: usize, eip86_t
 				cached_sender,
 			}
 		})
-		.map(|tx| Transaction::from_localized(tx, eip86_transition))
+		.map(|tx| Transaction::from_localized(tx))
 }
 
 // extract the header indicated by the given `HeaderRef` from the given responses.
@@ -365,7 +365,7 @@ impl LightFetch {
 
 	// Get a transaction by hash. also returns the index in the block.
 	// Only returns transactions in the canonical chain.
-	pub fn transaction_by_hash(&self, tx_hash: H256, eip86_transition: u64)
+	pub fn transaction_by_hash(&self, tx_hash: H256)
 		-> impl Future<Item = Option<(Transaction, usize)>, Error = Error> + Send
 	{
 		let params = (self.sync.clone(), self.on_demand.clone());
@@ -397,7 +397,7 @@ impl LightFetch {
 						}
 
 						let index = index.index as usize;
-						let transaction = extract_transaction_at_index(blk, index, eip86_transition);
+						let transaction = extract_transaction_at_index(blk, index);
 
 						if transaction.as_ref().map_or(true, |tx| tx.hash != tx_hash.into()) {
 							// index is actively wrong: indicated block has

--- a/rpc/src/v1/impls/light/parity.rs
+++ b/rpc/src/v1/impls/light/parity.rs
@@ -59,7 +59,6 @@ pub struct ParityClient {
 	health: NodeHealth,
 	signer: Option<Arc<SignerService>>,
 	ws_address: Option<Host>,
-	eip86_transition: u64,
 	gas_price_percentile: usize,
 }
 
@@ -84,7 +83,6 @@ impl ParityClient {
 			health,
 			signer,
 			ws_address,
-			eip86_transition: client.eip86_transition(),
 			client,
 			gas_price_percentile,
 		}
@@ -268,7 +266,7 @@ impl Parity for ParityClient {
 			txq.ready_transactions(chain_info.best_block_number, chain_info.best_block_timestamp)
 				.into_iter()
 				.take(limit.unwrap_or_else(usize::max_value))
-				.map(|tx| Transaction::from_pending(tx, chain_info.best_block_number, self.eip86_transition))
+				.map(|tx| Transaction::from_pending(tx))
 				.collect::<Vec<_>>()
 		)
 	}
@@ -283,7 +281,7 @@ impl Parity for ParityClient {
 			current
 				.into_iter()
 				.chain(future.into_iter())
-				.map(|tx| Transaction::from_pending(tx, chain_info.best_block_number, self.eip86_transition))
+				.map(|tx| Transaction::from_pending(tx))
 				.collect::<Vec<_>>()
 		)
 	}
@@ -294,7 +292,7 @@ impl Parity for ParityClient {
 		Ok(
 			txq.future_transactions(chain_info.best_block_number, chain_info.best_block_timestamp)
 				.into_iter()
-				.map(|tx| Transaction::from_pending(tx, chain_info.best_block_number, self.eip86_transition))
+				.map(|tx| Transaction::from_pending(tx))
 				.collect::<Vec<_>>()
 		)
 	}

--- a/rpc/src/v1/impls/parity_set.rs
+++ b/rpc/src/v1/impls/parity_set.rs
@@ -41,7 +41,6 @@ pub struct ParitySetClient<C, M, U, F = fetch::Client> {
 	net: Arc<ManageNetwork>,
 	fetch: F,
 	pool: CpuPool,
-	eip86_transition: u64,
 }
 
 impl<C, M, U, F> ParitySetClient<C, M, U, F>
@@ -63,7 +62,6 @@ impl<C, M, U, F> ParitySetClient<C, M, U, F>
 			net: net.clone(),
 			fetch: fetch,
 			pool: pool,
-			eip86_transition: client.eip86_transition(),
 		}
 	}
 }
@@ -191,11 +189,10 @@ impl<C, M, U, F> ParitySet for ParitySetClient<C, M, U, F> where
 	}
 
 	fn remove_transaction(&self, hash: H256) -> Result<Option<Transaction>> {
-		let block_number = self.client.chain_info().best_block_number;
 		let hash = hash.into();
 
 		Ok(self.miner.remove_transaction(&hash)
-		   .map(|t| Transaction::from_pending(t.pending().clone(), block_number + 1, self.eip86_transition))
+		   .map(|t| Transaction::from_pending(t.pending().clone()))
 		)
 	}
 }

--- a/rpc/src/v1/tests/mocked/signing.rs
+++ b/rpc/src/v1/tests/mocked/signing.rs
@@ -339,7 +339,7 @@ fn should_add_sign_transaction_to_the_queue() {
 			// respond
 			let sender = signer.take(&1.into()).unwrap();
 			signer.request_confirmed(sender, Ok(ConfirmationResponse::SignTransaction(
-				RichRawTransaction::from_signed(t.into(), 0x0, u64::max_value())
+				RichRawTransaction::from_signed(t.into())
 			)));
 			break
 		}

--- a/rpc/src/v1/types/transaction.rs
+++ b/rpc/src/v1/types/transaction.rs
@@ -161,8 +161,8 @@ pub struct RichRawTransaction {
 
 impl RichRawTransaction {
 	/// Creates new `RichRawTransaction` from `SignedTransaction`.
-	pub fn from_signed(tx: SignedTransaction, block_number: u64, eip86_transition: u64) -> Self {
-		let tx = Transaction::from_signed(tx, block_number, eip86_transition);
+	pub fn from_signed(tx: SignedTransaction) -> Self {
+		let tx = Transaction::from_signed(tx);
 		RichRawTransaction {
 			raw: tx.raw.clone(),
 			transaction: tx,
@@ -172,7 +172,7 @@ impl RichRawTransaction {
 
 impl Transaction {
 	/// Convert `LocalizedTransaction` into RPC Transaction.
-	pub fn from_localized(mut t: LocalizedTransaction, _eip86_transition: u64) -> Transaction {
+	pub fn from_localized(mut t: LocalizedTransaction) -> Transaction {
 		let signature = t.signature();
 		let scheme = CreateContractAddress::FromSenderAndNonce;
 		Transaction {
@@ -206,7 +206,7 @@ impl Transaction {
 	}
 
 	/// Convert `SignedTransaction` into RPC Transaction.
-	pub fn from_signed(t: SignedTransaction, block_number: u64, _eip86_transition: u64) -> Transaction {
+	pub fn from_signed(t: SignedTransaction) -> Transaction {
 		let signature = t.signature();
 		let scheme = CreateContractAddress::FromSenderAndNonce;
 		Transaction {
@@ -240,8 +240,8 @@ impl Transaction {
 	}
 
 	/// Convert `PendingTransaction` into RPC Transaction.
-	pub fn from_pending(t: PendingTransaction, block_number: u64, eip86_transition: u64) -> Transaction {
-		let mut r = Transaction::from_signed(t.transaction, block_number, eip86_transition);
+	pub fn from_pending(t: PendingTransaction) -> Transaction {
+		let mut r = Transaction::from_signed(t.transaction);
 		r.condition = t.condition.map(|b| b.into());
 		r
 	}
@@ -249,9 +249,9 @@ impl Transaction {
 
 impl LocalTransactionStatus {
 	/// Convert `LocalTransactionStatus` into RPC `LocalTransactionStatus`.
-	pub fn from(s: miner::pool::local_transactions::Status, block_number: u64, eip86_transition: u64) -> Self {
+	pub fn from(s: miner::pool::local_transactions::Status) -> Self {
 		let convert = |tx: Arc<miner::pool::VerifiedTransaction>| {
-			Transaction::from_signed(tx.signed().clone(), block_number, eip86_transition)
+			Transaction::from_signed(tx.signed().clone())
 		};
 		use miner::pool::local_transactions::Status::*;
 		match s {

--- a/rpc/src/v1/types/transaction.rs
+++ b/rpc/src/v1/types/transaction.rs
@@ -172,9 +172,9 @@ impl RichRawTransaction {
 
 impl Transaction {
 	/// Convert `LocalizedTransaction` into RPC Transaction.
-	pub fn from_localized(mut t: LocalizedTransaction, eip86_transition: u64) -> Transaction {
+	pub fn from_localized(mut t: LocalizedTransaction, _eip86_transition: u64) -> Transaction {
 		let signature = t.signature();
-		let scheme = if t.block_number >= eip86_transition { CreateContractAddress::FromCodeHash } else { CreateContractAddress::FromSenderAndNonce };
+		let scheme = CreateContractAddress::FromSenderAndNonce;
 		Transaction {
 			hash: t.hash().into(),
 			nonce: t.nonce.into(),
@@ -206,9 +206,9 @@ impl Transaction {
 	}
 
 	/// Convert `SignedTransaction` into RPC Transaction.
-	pub fn from_signed(t: SignedTransaction, block_number: u64, eip86_transition: u64) -> Transaction {
+	pub fn from_signed(t: SignedTransaction, block_number: u64, _eip86_transition: u64) -> Transaction {
 		let signature = t.signature();
-		let scheme = if block_number >= eip86_transition { CreateContractAddress::FromCodeHash } else { CreateContractAddress::FromSenderAndNonce };
+		let scheme = CreateContractAddress::FromSenderAndNonce;
 		Transaction {
 			hash: t.hash().into(),
 			nonce: t.nonce.into(),


### PR DESCRIPTION
Fixes #9127

The current version of EIP-86 differs from the one when it was implemented in parity-ethereum in point 3 and point 4. For point 3, a new salt was added, allowing CREATE2 to create multiple contracts with the same init code. Point 4 is the same as EIP-684, which we have already implemented.

The default contract address scheme was also changed to be always the old one (sender and nonce), regardless of EIP-86.

Note that this is backward incompatible, with the assumption that none (or not many) working chains have attempted to set the `eip86Transition` flag, because it's not really useful by itself.