### PR TITLE
Added --tx-queue-no-early-reject flag to disable early tx queue rejects

### DIFF
--- a/ethcore/private-tx/src/private_transactions.rs
+++ b/ethcore/private-tx/src/private_transactions.rs
@@ -67,7 +67,7 @@ impl Default for VerificationStore {
 					minimal_gas_price: 0.into(),
 					block_gas_limit: 8_000_000.into(),
 					tx_gas_limit: U256::max_value(),
-					tx_queue_no_early_reject: false
+					no_early_reject: false
 				},
 				pool::PrioritizationStrategy::GasPriceOnly,
 			)

--- a/ethcore/private-tx/src/private_transactions.rs
+++ b/ethcore/private-tx/src/private_transactions.rs
@@ -67,6 +67,7 @@ impl Default for VerificationStore {
 					minimal_gas_price: 0.into(),
 					block_gas_limit: 8_000_000.into(),
 					tx_gas_limit: U256::max_value(),
+					tx_queue_no_early_reject: false
 				},
 				pool::PrioritizationStrategy::GasPriceOnly,
 			)

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -165,6 +165,7 @@ impl Default for MinerOptions {
 				minimal_gas_price: DEFAULT_MINIMAL_GAS_PRICE.into(),
 				block_gas_limit: U256::max_value(),
 				tx_gas_limit: U256::max_value(),
+				tx_queue_no_early_reject: false,
 			},
 		}
 	}
@@ -272,6 +273,7 @@ impl Miner {
 				minimal_gas_price,
 				block_gas_limit: U256::max_value(),
 				tx_gas_limit: U256::max_value(),
+				tx_queue_no_early_reject: false,
 			},
 			reseal_min_period: Duration::from_secs(0),
 			..Default::default()
@@ -1297,12 +1299,14 @@ mod tests {
 				tx_queue_penalization: Penalization::Disabled,
 				tx_queue_strategy: PrioritizationStrategy::GasPriceOnly,
 				tx_queue_no_unfamiliar_locals: false,
+				tx_queue_no_early_reject: false,
 				refuse_service_transactions: false,
 				pool_limits: Default::default(),
 				pool_verification_options: pool::verifier::Options {
 					minimal_gas_price: 0.into(),
 					block_gas_limit: U256::max_value(),
 					tx_gas_limit: U256::max_value(),
+					tx_queue_no_early_reject: false,
 				},
 			},
 			GasPricer::new_fixed(0u64.into()),

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -165,7 +165,7 @@ impl Default for MinerOptions {
 				minimal_gas_price: DEFAULT_MINIMAL_GAS_PRICE.into(),
 				block_gas_limit: U256::max_value(),
 				tx_gas_limit: U256::max_value(),
-				tx_queue_no_early_reject: false,
+				no_early_reject: false,
 			},
 		}
 	}
@@ -273,7 +273,7 @@ impl Miner {
 				minimal_gas_price,
 				block_gas_limit: U256::max_value(),
 				tx_gas_limit: U256::max_value(),
-				tx_queue_no_early_reject: false,
+				no_early_reject: false,
 			},
 			reseal_min_period: Duration::from_secs(0),
 			..Default::default()
@@ -1299,14 +1299,13 @@ mod tests {
 				tx_queue_penalization: Penalization::Disabled,
 				tx_queue_strategy: PrioritizationStrategy::GasPriceOnly,
 				tx_queue_no_unfamiliar_locals: false,
-				tx_queue_no_early_reject: false,
 				refuse_service_transactions: false,
 				pool_limits: Default::default(),
 				pool_verification_options: pool::verifier::Options {
 					minimal_gas_price: 0.into(),
 					block_gas_limit: U256::max_value(),
 					tx_gas_limit: U256::max_value(),
-					tx_queue_no_early_reject: false,
+					no_early_reject: false,
 				},
 			},
 			GasPricer::new_fixed(0u64.into()),

--- a/miner/src/pool/queue.rs
+++ b/miner/src/pool/queue.rs
@@ -243,7 +243,7 @@ impl TransactionQueue {
 		let options = self.options.read().clone();
 
 		let transaction_to_replace = {
-			if options.tx_queue_no_early_reject {
+			if options.no_early_reject {
 				None
 			} else {
 				let pool = self.pool.read();

--- a/miner/src/pool/queue.rs
+++ b/miner/src/pool/queue.rs
@@ -243,11 +243,15 @@ impl TransactionQueue {
 		let options = self.options.read().clone();
 
 		let transaction_to_replace = {
-			let pool = self.pool.read();
-			if pool.is_full() {
-				pool.worst_transaction().map(|worst| (pool.scoring().clone(), worst))
-			} else {
+			if options.tx_queue_no_early_reject {
 				None
+			} else {
+				let pool = self.pool.read();
+				if pool.is_full() {
+					pool.worst_transaction().map(|worst| (pool.scoring().clone(), worst))
+				} else {
+					None
+				}
 			}
 		};
 

--- a/miner/src/pool/tests/mod.rs
+++ b/miner/src/pool/tests/mod.rs
@@ -37,6 +37,7 @@ fn new_queue() -> TransactionQueue {
 			minimal_gas_price: 1.into(),
 			block_gas_limit: 1_000_000.into(),
 			tx_gas_limit: 1_000_000.into(),
+			no_early_reject: false,
 		},
 		PrioritizationStrategy::GasPriceOnly,
 	)
@@ -54,6 +55,7 @@ fn should_return_correct_nonces_when_dropped_because_of_limit() {
 			minimal_gas_price: 1.into(),
 			block_gas_limit: 1_000_000.into(),
 			tx_gas_limit: 1_000_000.into(),
+			no_early_reject: false,
 		},
 		PrioritizationStrategy::GasPriceOnly,
 	);
@@ -105,6 +107,7 @@ fn should_never_drop_local_transactions_from_different_senders() {
 			minimal_gas_price: 1.into(),
 			block_gas_limit: 1_000_000.into(),
 			tx_gas_limit: 1_000_000.into(),
+			no_early_reject: false,
 		},
 		PrioritizationStrategy::GasPriceOnly,
 	);
@@ -479,6 +482,7 @@ fn should_prefer_current_transactions_when_hitting_the_limit() {
 			minimal_gas_price: 1.into(),
 			block_gas_limit: 1_000_000.into(),
 			tx_gas_limit: 1_000_000.into(),
+			no_early_reject: false,
 		},
 		PrioritizationStrategy::GasPriceOnly,
 	);
@@ -891,6 +895,7 @@ fn should_include_local_transaction_to_a_full_pool() {
 			minimal_gas_price: 1.into(),
 			block_gas_limit: 1_000_000.into(),
 			tx_gas_limit: 1_000_000.into(),
+			no_early_reject: false,
 		},
 		PrioritizationStrategy::GasPriceOnly,
 	);
@@ -922,6 +927,7 @@ fn should_avoid_verifying_transaction_already_in_pool() {
 			minimal_gas_price: 1.into(),
 			block_gas_limit: 1_000_000.into(),
 			tx_gas_limit: 1_000_000.into(),
+			no_early_reject: false,
 		},
 		PrioritizationStrategy::GasPriceOnly,
 	);
@@ -956,6 +962,7 @@ fn should_avoid_reverifying_recently_rejected_transactions() {
 			minimal_gas_price: 1.into(),
 			block_gas_limit: 1_000_000.into(),
 			tx_gas_limit: 1_000_000.into(),
+			no_early_reject: false,
 		},
 		PrioritizationStrategy::GasPriceOnly,
 	);
@@ -997,6 +1004,7 @@ fn should_reject_early_in_case_gas_price_is_less_than_min_effective() {
 			minimal_gas_price: 1.into(),
 			block_gas_limit: 1_000_000.into(),
 			tx_gas_limit: 1_000_000.into(),
+			no_early_reject: false,
 		},
 		PrioritizationStrategy::GasPriceOnly,
 	);

--- a/miner/src/pool/verifier.rs
+++ b/miner/src/pool/verifier.rs
@@ -43,8 +43,8 @@ pub struct Options {
 	pub block_gas_limit: U256,
 	/// Maximal gas limit for a single transaction.
 	pub tx_gas_limit: U256,
-	/// Skip check checks
-	pub tx_queue_no_early_reject: bool,
+	/// Skip checks for early rejection, to make sure that local transactions are always imported.
+	pub no_early_reject: bool,
 }
 
 #[cfg(test)]
@@ -54,7 +54,7 @@ impl Default for Options {
 			minimal_gas_price: 0.into(),
 			block_gas_limit: U256::max_value(),
 			tx_gas_limit: U256::max_value(),
-			tx_queue_no_early_reject: false,
+			no_early_reject: false,
 		}
 	}
 }

--- a/miner/src/pool/verifier.rs
+++ b/miner/src/pool/verifier.rs
@@ -43,6 +43,8 @@ pub struct Options {
 	pub block_gas_limit: U256,
 	/// Maximal gas limit for a single transaction.
 	pub tx_gas_limit: U256,
+	/// Skip check checks
+	pub tx_queue_no_early_reject: bool,
 }
 
 #[cfg(test)]
@@ -52,6 +54,7 @@ impl Default for Options {
 			minimal_gas_price: 0.into(),
 			block_gas_limit: U256::max_value(),
 			tx_gas_limit: U256::max_value(),
+			tx_queue_no_early_reject: false,
 		}
 	}
 }
@@ -204,7 +207,7 @@ impl<C: Client> txpool::Verifier<Transaction> for Verifier<C, ::pool::scoring::N
 		//
 		// We're checking if the transaction is below configured minimal gas price
 		// or the effective minimal gas price in case the pool is full.
-		if  !tx.gas_price().is_zero() && !is_own {
+		if !tx.gas_price().is_zero() && !is_own {
 			if tx.gas_price() < &self.options.minimal_gas_price {
 				trace!(
 					target: "txqueue",

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -652,6 +652,10 @@ usage! {
 			"--tx-queue-no-unfamiliar-locals",
 			"Local transactions sent through JSON-RPC (HTTP, WebSockets, etc) will be treated as 'external' if the sending account is unknown.",
 
+			FLAG flag_tx_queue_no_early_reject: (bool) = false, or |c: &Config| c.mining.as_ref()?.tx_queue_no_early_reject.clone(),
+			"--tx-queue-no-early-reject",
+			"Disables transaction queue optimization to early reject transactions below minimal effective gas price. This allows local transactions to always enter the pool, despite it being full, but requires additional ecrecover on every transaction.",
+
 			FLAG flag_refuse_service_transactions: (bool) = false, or |c: &Config| c.mining.as_ref()?.refuse_service_transactions.clone(),
 			"--refuse-service-transactions",
 			"Always refuse service transactions.",
@@ -1308,6 +1312,7 @@ struct Mining {
 	tx_queue_ban_count: Option<u16>,
 	tx_queue_ban_time: Option<u16>,
 	tx_queue_no_unfamiliar_locals: Option<bool>,
+	tx_queue_no_early_reject: Option<bool>,
 	remove_solved: Option<bool>,
 	notify_work: Option<Vec<String>>,
 	refuse_service_transactions: Option<bool>,
@@ -1996,6 +2001,7 @@ mod tests {
 				tx_queue_ban_count: None,
 				tx_queue_ban_time: None,
 				tx_queue_no_unfamiliar_locals: None,
+				tx_queue_no_early_reject: None,
 				tx_gas_limit: None,
 				tx_time_limit: None,
 				extra_data: None,

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -1731,6 +1731,7 @@ mod tests {
 			arg_gas_cap: "6283184".into(),
 			arg_extra_data: Some("Parity".into()),
 			flag_tx_queue_no_unfamiliar_locals: false,
+			flag_tx_queue_no_early_reject: false,
 			arg_tx_queue_size: 8192usize,
 			arg_tx_queue_per_sender: None,
 			arg_tx_queue_mem_limit: 4u32,

--- a/parity/cli/tests/config.full.toml
+++ b/parity/cli/tests/config.full.toml
@@ -135,6 +135,7 @@ tx_queue_ban_time = 180 #s
 tx_gas_limit = "6283184"
 tx_time_limit = 100 #ms
 tx_queue_no_unfamiliar_locals = false
+tx_queue_no_early_reject = false
 extra_data = "Parity"
 remove_solved = false
 notify_work = ["http://localhost:3001"]

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -571,6 +571,7 @@ impl Configuration {
 				Some(ref d) => to_u256(d)?,
 				None => U256::max_value(),
 			},
+			tx_queue_no_early_reject: self.args.flag_tx_queue_no_early_reject,
 		})
 	}
 

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -571,7 +571,7 @@ impl Configuration {
 				Some(ref d) => to_u256(d)?,
 				None => U256::max_value(),
 			},
-			tx_queue_no_early_reject: self.args.flag_tx_queue_no_early_reject,
+			no_early_reject: self.args.flag_tx_queue_no_early_reject,
 		})
 	}
 

--- a/rpc/src/v1/tests/helpers/miner_service.rs
+++ b/rpc/src/v1/tests/helpers/miner_service.rs
@@ -264,6 +264,7 @@ impl MinerService for TestMinerService {
 				minimal_gas_price: 0x1312d00.into(),
 				block_gas_limit: 5_000_000.into(),
 				tx_gas_limit: 5_000_000.into(),
+				no_early_reject: false,
 			},
 			status: txpool::LightStatus {
 				mem_usage: 1_000,


### PR DESCRIPTION
This PR resolves https://github.com/paritytech/parity/issues/9087 by adding a CLI flag to selectively disable a transaction queue optimization that early rejects transactions below the minimal effective gas price, without comparing the sender to the list of local accounts of a node first.

This allows local transactions to always enter the pool, despite it being full, but requires an additional ecrecover operation on every transaction.