### PR TITLE
Add debug getbadblocks

### DIFF
--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -1387,8 +1387,8 @@ impl BlockChain {
 		blacklist
 	}
 
-	pub fn bad_blocks(&self) -> HashMap<H256, BlockInfo> {
-		self.bad_blocks.read().clone()
+	pub fn bad_blocks(&self) -> Vec<H256> {
+		self.bad_blocks.read().iter().map(|(hash, _)| *hash).collect::<Vec<H256>>()
 	}
 
 	/// Get best block hash.

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -213,6 +213,7 @@ pub struct BlockChain {
 	block_hashes: RwLock<HashMap<BlockNumber, H256>>,
 	transaction_addresses: RwLock<HashMap<H256, TransactionAddress>>,
 	block_receipts: RwLock<HashMap<H256, BlockReceipts>>,
+	bad_blocks: RwLock<HashMap<H256, BlockInfo>>,
 
 	db: Arc<BlockChainDB>,
 
@@ -527,6 +528,7 @@ impl BlockChain {
 			block_hashes: RwLock::new(HashMap::new()),
 			transaction_addresses: RwLock::new(HashMap::new()),
 			block_receipts: RwLock::new(HashMap::new()),
+			bad_blocks: RwLock::new(HashMap::new()),
 			db: db.clone(),
 			cache_man: Mutex::new(cache_man),
 			pending_best_block: RwLock::new(None),
@@ -985,6 +987,11 @@ impl BlockChain {
 
 		let info = self.block_info(&header, route, &extras);
 
+		if self.is_blacklisted_hash(hash) {
+			self.bad_blocks.write().insert(hash, info);
+			return ImportRoute::none();
+		}
+
 		if let BlockLocation::BranchBecomingCanonChain(ref d) = info.location {
 			info!(target: "reorg", "Reorg to {} ({} {} {})",
 				Colour::Yellow.bold().paint(format!("#{} {}", info.number, info.hash)),
@@ -1362,6 +1369,26 @@ impl BlockChain {
 				Some((start_number, blooms))
 			}
 		}
+	}
+
+	/// Determine if a hash is blacklisted (part of a hard fork)
+	fn is_blacklisted_hash(&self, hash: H256) -> bool {
+		if self.blacklisted_hashes().contains_key(&hash) {
+			return true
+		}
+		false
+	}
+
+	/// Get all blacklisted hashes
+	fn blacklisted_hashes(&self) -> HashMap<H256, bool> {
+		let mut blacklist = HashMap::new();
+		blacklist.insert("05bef30ef572270f654746da22639a7a0c97dd97a7050b9e252391996aaeb689".into(), true);
+		blacklist.insert("7d05d08cbc596a2e5e4f13b80a743e53e09221b5323c3a61946b20873e58583f".into(), true);
+		blacklist
+	}
+
+	pub fn bad_blocks(&self) -> HashMap<H256, BlockInfo> {
+		self.bad_blocks.read().clone()
 	}
 
 	/// Get best block hash.

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1650,6 +1650,16 @@ impl BlockChainClient for Client {
 		Self::block_hash(&chain, id)
 	}
 
+	fn bad_blocks(&self) -> Option<Vec<H256>> {
+		let blocks = self.chain.read().bad_blocks();
+
+		if blocks.len() > 0 {
+			Some(blocks)
+		} else {
+			None
+		}
+	}
+
 	fn code(&self, address: &Address, state: StateOrBlock) -> Option<Option<Bytes>> {
 		let result = match state {
 			StateOrBlock::State(s) => s.code(address).ok(),

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -324,6 +324,12 @@ impl TestBlockChainClient {
 		}
 	}
 
+	fn bad_blocks(&self) -> Option<Vec<H256>> {
+		let mut bad_block = Vec::new();
+		bad_block.push("05bef30ef572270f654746da22639a7a0c97dd97a7050b9e252391996aaeb689".into());
+		Some(bad_block)
+	}
+
 	/// Inserts a transaction with given gas price to miners transactions queue.
 	pub fn insert_transaction_with_gas_price_to_queue(&self, gas_price: U256) -> H256 {
 		let keypair = Random.generate().unwrap();
@@ -620,6 +626,10 @@ impl BlockChainClient for TestBlockChainClient {
 
 	fn block_hash(&self, id: BlockId) -> Option<H256> {
 		Self::block_hash(self, id)
+	}
+
+	fn bad_blocks(&self) -> Option<Vec<H256>> {
+		Self::bad_blocks(self)
 	}
 
 	fn storage_root(&self, _address: &Address, _id: BlockId) -> Option<H256> {

--- a/ethcore/src/client/traits.rs
+++ b/ethcore/src/client/traits.rs
@@ -233,6 +233,9 @@ pub trait BlockChainClient : Sync + Send + AccountData + BlockChain + CallContra
 	/// Get block hash.
 	fn block_hash(&self, id: BlockId) -> Option<H256>;
 
+	/// Get all known bad blocks in chain.
+	fn bad_blocks(&self) -> Option<Vec<H256>>;
+
 	/// Get address code at given block's state.
 	fn code(&self, address: &Address, state: StateOrBlock) -> Option<Option<Bytes>>;
 

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -819,10 +819,13 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 
 	fn bad_blocks(&self, include_txs: bool) -> BoxFuture<Vec<RichBlock>> {
 		let blocks = self.client.bad_blocks()
-			.unwrap()
-			.iter()
-			.map(|hash| self.rich_block(BlockNumberOrId::Id(BlockId::Hash(*hash)), include_txs).unwrap().unwrap())
-			.collect();
+			.and_then(|vec| {
+				vec.iter()
+					.filter_map(|hash| {
+						self.rich_block(BlockNumberOrId::Id(BlockId::Hash(*hash)), include_txs).ok()
+					})
+					.collect()
+			});
 
 		Box::new(future::done(Ok(blocks)))
 	}

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -818,9 +818,13 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 	}
 
 	fn bad_blocks(&self, include_txs: bool) -> BoxFuture<Vec<RichBlock>> {
-		let blocks = self.client.bad_blocks().and_then(|vec| vec.iter().map(|hash| self.rich_block(BlockNumberOrId::Id(BlockId::Hash(*hash)), include_txs)).collect());
+		let blocks = self.client.bad_blocks()
+			.unwrap()
+			.iter()
+			.map(|hash| self.rich_block(BlockNumberOrId::Id(BlockId::Hash(*hash)), include_txs).unwrap().unwrap())
+			.collect();
 
-		Box::new(future::done(blocks))
+		Box::new(future::done(Ok(blocks)))
 	}
 
 	fn send_raw_transaction(&self, raw: Bytes) -> Result<RpcH256> {

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -827,7 +827,10 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 					.collect()
 			});
 
-		Box::new(future::done(Ok(blocks)))
+		match blocks {
+			Some(b) => Box::new(future::done(Ok(b))),
+			None => Box::new(future::done(Ok(<Vec<RichBlock>>::new())))
+		}
 	}
 
 	fn send_raw_transaction(&self, raw: Bytes) -> Result<RpcH256> {

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -818,10 +818,7 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 	}
 
 	fn bad_blocks(&self, include_txs: bool) -> BoxFuture<Vec<RichBlock>> {
-		let blocks = self.client.bad_blocks()
-			.and_then(|vec| {
-				vec.iter().map(|hash| self.rich_block(BlockNumberOrId::Id(BlockId::Hash(*hash)), include_txs)).collect()
-			}).ok_or(Err("No bad blocks"));
+		let blocks = self.client.bad_blocks().and_then(|vec| vec.iter().map(|hash| self.rich_block(BlockNumberOrId::Id(BlockId::Hash(*hash)), include_txs)).collect());
 
 		Box::new(future::done(blocks))
 	}

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -817,6 +817,15 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 		Ok(true)
 	}
 
+	fn bad_blocks(&self, include_txs: bool) -> BoxFuture<Vec<RichBlock>> {
+		let blocks = self.client.bad_blocks()
+			.and_then(|vec| {
+				vec.iter().map(|hash| self.rich_block(BlockNumberOrId::Id(BlockId::Hash(*hash)), include_txs)).collect()
+			}).ok_or(Err("No bad blocks"));
+
+		Box::new(future::done(blocks))
+	}
+
 	fn send_raw_transaction(&self, raw: Bytes) -> Result<RpcH256> {
 		Rlp::new(&raw.into_vec()).as_val()
 			.map_err(errors::rlp)

--- a/rpc/src/v1/impls/light/eth.rs
+++ b/rpc/src/v1/impls/light/eth.rs
@@ -528,6 +528,10 @@ impl<T: LightChainClient + 'static> Eth for EthClient<T> {
 	fn submit_hashrate(&self, _rate: RpcU256, _id: RpcH256) -> Result<bool> {
 		Err(errors::light_unimplemented(None))
 	}
+
+	fn bad_blocks(&self, _include_txs: bool) -> BoxFuture<Vec<RichBlock>> {
+		Box::new(future::done(Ok(<Vec<RichBlock>>::new())))
+	}
 }
 
 // This trait implementation triggers a blanked impl of `EthFilter`.

--- a/rpc/src/v1/traits/eth.rs
+++ b/rpc/src/v1/traits/eth.rs
@@ -174,6 +174,10 @@ build_rpc_trait! {
 		/// Used for submitting mining hashrate.
 		#[rpc(name = "eth_submitHashrate")]
 		fn submit_hashrate(&self, U256, H256) -> Result<bool>;
+
+		/// Used for finding bad blocks in current chain.
+		#[rpc(name = "debug_getBadBlocks")]
+		fn bad_blocks(&self, bool) -> BoxFuture<Vec<RichBlock>>;
 	}
 }
 


### PR DESCRIPTION
Blockchain implementation will now have a blacklist of hashes that will allow for it to add bad blocks to a HashMap and in order to get all bad blocks we return a vector of hashes. This then allows for the rpc api to then return all of the current bad blocks that are within the current blockchain. 

This will resolve https://github.com/paritytech/parity-ethereum/issues/8761 when merged. 