### PR TITLE
Simple build instruction fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ sudo snap install parity --edge
 ```bash
 # download Parity-Ethereum code
 $ git clone https://github.com/paritytech/parity-ethereum
-$ cd parity
+$ cd parity-ethereum
 
 # build in release mode
 $ cargo build --release --features final


### PR DESCRIPTION
Changed `parity` dir name into  `parity-ethereum`