### PR TITLE
Removes duplicate libudev-dev from Dockerfile

### DIFF
--- a/docker/hub/Dockerfile
+++ b/docker/hub/Dockerfile
@@ -27,8 +27,7 @@ RUN apt-get update && \
         libssl-dev \
         libudev-dev \
         pkg-config \
-        dpkg-dev \
-        libudev-dev &&\
+        dpkg-dev &&\
 # install rustup
  curl https://sh.rustup.rs -sSf | sh -s -- -y && \
 # rustup directory


### PR DESCRIPTION
I've noticed that libudev-dev is installed twice in the hub/Dockerfile. This pull request just removes the duplicate.