### PR TITLE
Allow download of old blocks from peers with equal or lower difficulty

### DIFF
--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -761,14 +761,24 @@ impl ChainSync {
 						}
 					}
 
-					// Only ask for old blocks if the peer has a higher difficulty
-					if force || higher_difficulty {
+					// Only ask for old blocks if the peer has a higher difficulty than the last imported old block
+					let last_imported_old_block_difficulty = self.old_blocks.as_mut().and_then(|d| {
+						io.chain().block_total_difficulty(BlockId::Number(d.last_imported_block_number()))
+					});
+
+					if force || last_imported_old_block_difficulty.map_or(true, |ld| peer_difficulty.map_or(true, |pd| pd > ld)) {
 						if let Some(request) = self.old_blocks.as_mut().and_then(|d| d.request_blocks(io, num_active_peers)) {
 							SyncRequester::request_blocks(self, io, peer_id, request, BlockSet::OldBlocks);
 							return;
 						}
 					} else {
-						trace!(target: "sync", "peer {} is not suitable for asking old blocks", peer_id);
+						trace!(
+							target: "sync",
+							"peer {:?} is not suitable for requesting old blocks, last_imported_old_block_difficulty={:?}, peer_difficulty={:?}",
+							peer_id,
+							last_imported_old_block_difficulty,
+							peer_difficulty
+						);
 						self.deactivate_peer(io, peer_id);
 					}
 				},


### PR DESCRIPTION
Fixes #9225

Currently we only allow downloading of old blocks if the peer difficulty was greater than our syncing difficulty (see #9225).

Following a suggestion from @ngotchac: this change allows downloading of blocks from peers where the difficulty is greater than the last downloaded old block. This means that we will still request old blocks from nodes that are behind us but still might have the blocks we want.