### PR TITLE
fix typo

### DIFF
--- a/util/network-devp2p/src/host.rs
+++ b/util/network-devp2p/src/host.rs
@@ -670,7 +670,7 @@ impl Host {
 		}
 	}
 
-	fn connection_closed(&self, token: TimerToken, io: &IoContext<NetworkIoMessage>) {
+	fn connection_closed(&self, token: StreamToken, io: &IoContext<NetworkIoMessage>) {
 		trace!(target: "network", "Connection closed: {}", token);
 		self.kill_connection(token, io, true);
 	}


### PR DESCRIPTION
When a connection is closed, token should be `StreamToken` instead of `TimerToken`.