### PR TITLE
Ensure that we always call trace_call for builtins

### DIFF
--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -440,19 +440,23 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 						ActionValue::Transfer(value) => value != U256::zero(),
 						ActionValue::Apparent(_) => false,
 					};
-					if self.depth == 0 || is_transferred {
+
+					let trace_output = if self.depth == 0 || is_transferred {
 						let mut trace_output = tracer.prepare_trace_output();
 						if let Some(out) = trace_output.as_mut() {
 							*out = output.to_owned();
 						}
+						trace_output
+					} else {
+						None
+					};
 
-						tracer.trace_call(
-							trace_info,
-							cost,
-							trace_output,
-							vec![]
-						);
-					}
+					tracer.trace_call(
+						trace_info,
+						cost,
+						trace_output,
+						vec![]
+					);
 
 					let out_len = builtin_out_buffer.len();
 					Ok(FinalizationResult {


### PR DESCRIPTION
I'm trying to implement a tracer for a simple debugger based on parity, but noticed that a contract where I'm calling `ecrecover` there is no `trace_call` to determine when a call is done which I need to maintain a call stack.