### PR TITLE
Provide read-only access to storage during tracing

### DIFF
--- a/ethcore/evm/src/evm.rs
+++ b/ethcore/evm/src/evm.rs
@@ -42,7 +42,9 @@ pub trait Finalize {
 }
 
 impl Finalize for Result<GasLeft> {
-	fn finalize<E: Ext>(self, ext: E) -> Result<FinalizationResult> {
+	fn finalize<E: Ext>(self, mut ext: E) -> Result<FinalizationResult> {
+		ext.trace_finalized();
+
 		match self {
 			Ok(GasLeft::Known(gas_left)) => Ok(FinalizationResult { gas_left: gas_left, apply_state: true, return_data: ReturnData::empty() }),
 			Ok(GasLeft::NeedsReturn { gas_left, data, apply_state }) => ext.ret(&gas_left, &data, apply_state).map(|gas_left| FinalizationResult {

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -166,6 +166,7 @@ pub mod state;
 pub mod state_db;
 pub mod trace;
 pub mod verification;
+pub mod storage;
 
 mod cache_manager;
 mod account_db;

--- a/ethcore/src/storage.rs
+++ b/ethcore/src/storage.rs
@@ -1,0 +1,53 @@
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Traits for accessing contract storage.
+
+use ethereum_types::H256;
+use ethtrie;
+use std::fmt;
+
+/// Errors from accessing storage.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StorageError {
+	/// Trie lookup error.
+	TrieError {
+		/// Underlying error.
+		error: Box<ethtrie::TrieError>,
+	},
+}
+
+impl fmt::Display for StorageError {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		use self::StorageError::*;
+
+		match *self {
+			TrieError { ref error } => write!(f, "trie error: {}", error),
+		}
+	}
+}
+
+impl From<Box<ethtrie::TrieError>> for StorageError {
+	fn from(error: Box<ethtrie::TrieError>) -> Self {
+		StorageError::TrieError { error }
+	}
+}
+
+/// Storage access for the current VM.
+pub trait StorageAccess {
+	/// Access storage at the given location.
+	fn storage_at(&self, key: &H256) -> Result<H256, StorageError>;
+}

--- a/ethcore/src/trace/executive_tracer.rs
+++ b/ethcore/src/trace/executive_tracer.rs
@@ -20,6 +20,7 @@ use ethereum_types::{U256, Address};
 use vm::{Error as VmError, ActionParams};
 use trace::trace::{Call, Create, Action, Res, CreateResult, CallResult, VMTrace, VMOperation, VMExecutedOperation, MemoryDiff, StorageDiff, Suicide, Reward, RewardType};
 use trace::{Tracer, VMTracer, FlatTrace};
+use storage::StorageAccess;
 
 /// Simple executive tracer. Traces all calls and creates. Ignores delegatecalls.
 #[derive(Default)]
@@ -244,7 +245,7 @@ impl VMTracer for ExecutiveVMTracer {
 		self.last_store_written = store_written;
 	}
 
-	fn trace_executed(&mut self, gas_used: U256, stack_push: &[U256], mem: &[u8]) {
+	fn trace_executed(&mut self, gas_used: U256, stack_push: &[U256], mem: &[u8], _storage: &StorageAccess) {
 		let mem_diff = self.last_mem_written.take().map(|(o, s)| (o, &(mem[o..o+s])));
 		let store_diff = self.last_store_written.take();
 		Self::with_trace_in_depth(&mut self.data, self.depth, move |trace| {

--- a/ethcore/src/trace/mod.rs
+++ b/ethcore/src/trace/mod.rs
@@ -40,6 +40,7 @@ use ethereum_types::{H256, U256, Address};
 use kvdb::DBTransaction;
 use vm::{Error as VmError, ActionParams};
 use header::BlockNumber;
+use storage::StorageAccess;
 
 /// This trait is used by executive to build traces.
 pub trait Tracer: Send {
@@ -86,7 +87,12 @@ pub trait VMTracer: Send {
 	fn trace_prepare_execute(&mut self, _pc: usize, _instruction: u8, _gas_cost: U256, _mem_written: Option<(usize, usize)>, _store_written: Option<(U256, U256)>) {}
 
 	/// Trace the finalised execution of a single valid instruction.
-	fn trace_executed(&mut self, _gas_used: U256, _stack_push: &[U256], _mem: &[u8]) {}
+	fn trace_executed(&mut self, _gas_used: U256, _stack_push: &[U256], _mem: &[u8], _storage: &StorageAccess) {}
+
+	/// Trace the end of a subtrace.
+	///
+	/// After this, no more instructions will be executed for this subtrace.
+	fn trace_finalized(&mut self, _storage: &StorageAccess) {}
 
 	/// Spawn subtracer which will be used to trace deeper levels of execution.
 	fn prepare_subtrace(&mut self, _code: &[u8]) {}

--- a/ethcore/vm/src/ext.rs
+++ b/ethcore/vm/src/ext.rs
@@ -165,6 +165,9 @@ pub trait Ext {
 	/// Trace the finalised execution of a single instruction.
 	fn trace_executed(&mut self, _gas_used: U256, _stack_push: &[U256], _mem: &[u8]) {}
 
+	/// Trace that the subtrace is done executing.
+	fn trace_finalized(&mut self) {}
+
 	/// Check if running in static context.
 	fn is_static(&self) -> bool;
 }

--- a/evmbin/src/display/std_json.rs
+++ b/evmbin/src/display/std_json.rs
@@ -21,7 +21,7 @@ use std::io;
 
 use ethereum_types::{H256, U256};
 use bytes::ToPretty;
-use ethcore::trace;
+use ethcore::{trace, storage};
 
 use display;
 use info as vm;
@@ -168,7 +168,7 @@ impl<Trace: Writer, Out: Writer> trace::VMTracer for Informant<Trace, Out> {
 		});
 	}
 
-	fn trace_executed(&mut self, _gas_used: U256, stack_push: &[U256], _mem: &[u8]) {
+	fn trace_executed(&mut self, _gas_used: U256, stack_push: &[U256], _mem: &[u8], _storage: &storage::StorageAccess) {
 		let subdepth = self.subdepth;
 		Self::with_informant_in_depth(self, subdepth, |informant: &mut Informant<Trace, Out>| {
 			let info = ::evm::Instruction::from_u8(informant.instruction).map(|i| i.info());


### PR DESCRIPTION
I'm putting together a debugger based on Parity and need access to storage during tracing to be able to decode solidity variables.