### PR TITLE
Improve return data truncate logic

### DIFF
--- a/ethcore/evm/src/interpreter/memory.rs
+++ b/ethcore/evm/src/interpreter/memory.rs
@@ -119,14 +119,19 @@ impl Memory for Vec<u8> {
 	fn into_return_data(mut self, offset: U256, size: U256) -> ReturnData {
 		let mut offset = offset.low_u64() as usize;
 		let size = size.low_u64() as usize;
+
 		if !is_valid_range(offset, size) {
-			return ReturnData::empty()
+			return ReturnData::empty();
 		}
+
 		if self.len() - size > MAX_RETURN_WASTE_BYTES {
-			{ let _ =  self.drain(..offset); }
-			self.truncate(size);
-			self.shrink_to_fit();
-			offset = 0;
+			if offset == 0 {
+				self.truncate(size);
+				self.shrink_to_fit();
+			} else {
+				self = self[offset..size].to_vec();
+				offset = 0;
+			}
 		}
 		ReturnData::new(self, offset, size)
 	}

--- a/ethcore/evm/src/interpreter/memory.rs
+++ b/ethcore/evm/src/interpreter/memory.rs
@@ -129,7 +129,7 @@ impl Memory for Vec<u8> {
 				self.truncate(size);
 				self.shrink_to_fit();
 			} else {
-				self = self[offset..size].to_vec();
+				self = self[offset..(offset + size)].to_vec();
 				offset = 0;
 			}
 		}


### PR DESCRIPTION
Rust's `Vec` allocator will never change the init pointer, so `drain` will do copy anyway (with the unwanted tail data). This PR fixes it by only attempting to truncate if `offset` is `0`, and for other cases, just create a new `Vec`.