### PR TITLE
Avoid using $HOME if not necessary

### DIFF
--- a/parity/helpers.rs
+++ b/parity/helpers.rs
@@ -261,7 +261,7 @@ pub fn execute_upgrades(
 
 	upgrade_data_paths(base_path, dirs, pruning);
 
-	match upgrade(Some(&dirs.path)) {
+	match upgrade(&dirs.path) {
 		Ok(upgrades_applied) if upgrades_applied > 0 => {
 			debug!("Executed {} upgrade scripts - ok", upgrades_applied);
 		},

--- a/parity/upgrade.rs
+++ b/parity/upgrade.rs
@@ -105,7 +105,9 @@ fn upgrade_from_version(previous_version: &Version) -> Result<usize, Error> {
 fn with_locked_version<F>(db_path: Option<&str>, script: F) -> Result<usize, Error>
 	where F: Fn(&Version) -> Result<usize, Error>
 {
-	let mut path = db_path.map_or({
+	let mut path = db_path.map_or_else(|| {
+		// Note: this can panic on device such as Android where $HOME isn't set
+		// That's why the `map_or_else` is important compared to `map_or`.
 		let mut path = env::home_dir().expect("Applications should have a home dir");
 		path.push(".parity");
 		path

--- a/parity/upgrade.rs
+++ b/parity/upgrade.rs
@@ -102,16 +102,10 @@ fn upgrade_from_version(previous_version: &Version) -> Result<usize, Error> {
 	Ok(count)
 }
 
-fn with_locked_version<F>(db_path: Option<&str>, script: F) -> Result<usize, Error>
+fn with_locked_version<F>(db_path: &str, script: F) -> Result<usize, Error>
 	where F: Fn(&Version) -> Result<usize, Error>
 {
-	let mut path = db_path.map_or_else(|| {
-		// Note: this can panic on device such as Android where $HOME isn't set
-		// That's why the `map_or_else` is important compared to `map_or`.
-		let mut path = env::home_dir().expect("Applications should have a home dir");
-		path.push(".parity");
-		path
-	}, PathBuf::from);
+	let mut path = PathBuf::from(db_path);
 	create_dir_all(&path).map_err(|_| Error::CannotCreateConfigPath)?;
 	path.push("ver.lock");
 
@@ -133,7 +127,7 @@ fn with_locked_version<F>(db_path: Option<&str>, script: F) -> Result<usize, Err
 	result
 }
 
-pub fn upgrade(db_path: Option<&str>) -> Result<usize, Error> {
+pub fn upgrade(db_path: &str) -> Result<usize, Error> {
 	with_locked_version(db_path, |ver| {
 		upgrade_from_version(ver)
 	})
@@ -207,6 +201,10 @@ fn upgrade_user_defaults(dirs: &DatabaseDirectories) {
 }
 
 pub fn upgrade_data_paths(base_path: &str, dirs: &DatabaseDirectories, pruning: Algorithm) {
+	if env::home_dir().is_none() {
+		return;
+	}
+
 	let legacy_root_path = replace_home("", "$HOME/.parity");
 	let default_path = default_data_path();
 	if legacy_root_path != base_path && base_path == default_path {

--- a/util/dir/src/helpers.rs
+++ b/util/dir/src/helpers.rs
@@ -20,7 +20,12 @@ use std::env;
 /// Replaces `$HOME` str with home directory path.
 pub fn replace_home(base: &str, arg: &str) -> String {
 	// the $HOME directory on mac os should be `~/Library` or `~/Library/Application Support`
-	let r = arg.replace("$HOME", env::home_dir().unwrap().to_str().unwrap());
+	// We use an `if` so that we don't need to call `home_dir()` if not necessary.
+	let r = if arg.contains("$HOME") {
+		arg.replace("$HOME", env::home_dir().expect("$HOME isn't defined").to_str().unwrap())
+	} else {
+		arg.to_owned()
+	};
 	let r = r.replace("$BASE", base);
 	r.replace("/", &::std::path::MAIN_SEPARATOR.to_string())
 }


### PR DESCRIPTION
When Parity is used within an Android application, the `$HOME` environment variable isn't set. This will cause Parity to panic.

This commit fixes it by avoiding to load the value of `$HOME` if it is not required.