### PR TITLE
Move ethereum-specific H256FastMap type to own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
  "ethcore-network 1.12.0",
  "ethcore-transaction 0.1.0",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastmap 0.1.0",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashdb 0.2.0 (git+https://github.com/paritytech/parity-common)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -612,7 +613,6 @@ dependencies = [
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "patricia-trie 0.2.1 (git+https://github.com/paritytech/parity-common)",
  "patricia-trie-ethereum 0.1.0",
- "plain_hasher 0.1.0 (git+https://github.com/paritytech/parity-common)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.1 (git+https://github.com/paritytech/parity-common)",
  "rlp_derive 0.1.0",
@@ -845,6 +845,7 @@ dependencies = [
  "ethcore-transaction 0.1.0",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethkey 0.3.0",
+ "fastmap 0.1.0",
  "hashdb 0.2.0 (git+https://github.com/paritytech/parity-common)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -856,7 +857,6 @@ dependencies = [
  "macros 0.1.0",
  "parity-bytes 0.1.0 (git+https://github.com/paritytech/parity-common)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "plain_hasher 0.1.0 (git+https://github.com/paritytech/parity-common)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.1 (git+https://github.com/paritytech/parity-common)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1042,6 +1042,14 @@ version = "0.0.1"
 dependencies = [
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethkey 0.3.0",
+]
+
+[[package]]
+name = "fastmap"
+version = "0.1.0"
+dependencies = [
+ "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plain_hasher 0.1.0 (git+https://github.com/paritytech/parity-common)",
 ]
 
 [[package]]
@@ -1323,6 +1331,7 @@ version = "0.2.0"
 dependencies = [
  "ethcore-logger 1.12.0",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastmap 0.1.0",
  "hashdb 0.2.0 (git+https://github.com/paritytech/parity-common)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.1.2 (git+https://github.com/paritytech/parity-common)",
@@ -1333,7 +1342,6 @@ dependencies = [
  "memorydb 0.2.1 (git+https://github.com/paritytech/parity-common)",
  "parity-bytes 0.1.0 (git+https://github.com/paritytech/parity-common)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "plain_hasher 0.1.0 (git+https://github.com/paritytech/parity-common)",
  "rlp 0.2.1 (git+https://github.com/paritytech/parity-common)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ members = [
 	"util/triehash-ethereum",
 	"util/keccak-hasher",
 	"util/patricia-trie-ethereum",
+	"util/fastmap",
 ]
 
 [patch.crates-io]

--- a/ethcore/light/Cargo.toml
+++ b/ethcore/light/Cargo.toml
@@ -20,7 +20,7 @@ ethcore-io = { path = "../../util/io" }
 hashdb = { git = "https://github.com/paritytech/parity-common" }
 heapsize = "0.4"
 vm = { path = "../vm" }
-plain_hasher = { git = "https://github.com/paritytech/parity-common" }
+fastmap = { path = "../../util/fastmap" }
 rlp = { git = "https://github.com/paritytech/parity-common" }
 rlp_derive = { path = "../../util/rlp_derive" }
 smallvec = "0.4"

--- a/ethcore/light/src/client/header_chain.rs
+++ b/ethcore/light/src/client/header_chain.rs
@@ -41,7 +41,7 @@ use ethereum_types::{H256, H264, U256};
 use heapsize::HeapSizeOf;
 use kvdb::{DBTransaction, KeyValueDB};
 use parking_lot::{Mutex, RwLock};
-use plain_hasher::H256FastMap;
+use fastmap::H256FastMap;
 use rlp::{Encodable, Decodable, DecoderError, RlpStream, Rlp};
 use smallvec::SmallVec;
 

--- a/ethcore/light/src/lib.rs
+++ b/ethcore/light/src/lib.rs
@@ -68,7 +68,7 @@ extern crate keccak_hasher;
 extern crate memorydb;
 extern crate patricia_trie as trie;
 extern crate patricia_trie_ethereum as ethtrie;
-extern crate plain_hasher;
+extern crate fastmap;
 extern crate rand;
 extern crate rlp;
 extern crate parking_lot;

--- a/ethcore/light/src/transaction_queue.rs
+++ b/ethcore/light/src/transaction_queue.rs
@@ -29,7 +29,7 @@ use std::collections::hash_map::Entry;
 
 use transaction::{self, Condition, PendingTransaction, SignedTransaction};
 use ethereum_types::{H256, U256, Address};
-use plain_hasher::H256FastMap;
+use fastmap::H256FastMap;
 
 // Knowledge of an account's current nonce.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/ethcore/sync/Cargo.toml
+++ b/ethcore/sync/Cargo.toml
@@ -17,7 +17,7 @@ ethcore-transaction = { path = "../transaction" }
 ethcore = { path = ".." }
 ethereum-types = "0.3"
 hashdb = { git = "https://github.com/paritytech/parity-common" }
-plain_hasher = { git = "https://github.com/paritytech/parity-common" }
+fastmap = { path = "../../util/fastmap" }
 rlp = { git = "https://github.com/paritytech/parity-common" }
 rustc-hex = "1.0"
 keccak-hash = { git = "https://github.com/paritytech/parity-common" }

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -99,7 +99,7 @@ use std::time::{Duration, Instant};
 use hash::keccak;
 use heapsize::HeapSizeOf;
 use ethereum_types::{H256, U256};
-use plain_hasher::H256FastMap;
+use fastmap::H256FastMap;
 use parking_lot::RwLock;
 use bytes::Bytes;
 use rlp::{Rlp, RlpStream, DecoderError};

--- a/ethcore/sync/src/lib.rs
+++ b/ethcore/sync/src/lib.rs
@@ -31,7 +31,7 @@ extern crate ethcore;
 extern crate ethereum_types;
 extern crate env_logger;
 extern crate hashdb;
-extern crate plain_hasher;
+extern crate fastmap;
 extern crate rand;
 extern crate semver;
 extern crate parking_lot;

--- a/ethcore/sync/src/transactions_stats.rs
+++ b/ethcore/sync/src/transactions_stats.rs
@@ -17,7 +17,7 @@
 use api::TransactionStats;
 use std::collections::{HashSet, HashMap};
 use ethereum_types::{H256, H512};
-use plain_hasher::H256FastMap;
+use fastmap::H256FastMap;
 
 type NodeId = H512;
 type BlockNumber = u64;

--- a/util/fastmap/Cargo.toml
+++ b/util/fastmap/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "fastmap"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+description = "Specialized version of `HashMap` with H256 keys and fast hashing function."
+license = "GPL-3.0"
+
+[dependencies]
+ethereum-types = "0.3"
+plain_hasher = { git = "https://github.com/paritytech/parity-common" }

--- a/util/fastmap/src/lib.rs
+++ b/util/fastmap/src/lib.rs
@@ -1,0 +1,39 @@
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Provides a `H256FastMap` type with H256 keys and fast hashing function.
+
+extern crate ethereum_types;
+extern crate plain_hasher;
+
+use ethereum_types::H256;
+use std::hash;
+use std::collections::HashMap;
+use plain_hasher::PlainHasher;
+
+/// Specialized version of `HashMap` with H256 keys and fast hashing function.
+pub type H256FastMap<T> = HashMap<H256, T, hash::BuildHasherDefault<PlainHasher>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_works() {
+        let mut h = H256FastMap::default();
+        h.insert(H256::from(123), "abc");
+    }
+}

--- a/util/journaldb/Cargo.toml
+++ b/util/journaldb/Cargo.toml
@@ -15,7 +15,7 @@ kvdb = { git = "https://github.com/paritytech/parity-common" }
 log = "0.3"
 memorydb = { git = "https://github.com/paritytech/parity-common" }
 parking_lot = "0.6"
-plain_hasher = { git = "https://github.com/paritytech/parity-common" }
+fastmap = { path = "../../util/fastmap" }
 rlp = { git = "https://github.com/paritytech/parity-common" }
 
 [dev-dependencies]

--- a/util/journaldb/src/lib.rs
+++ b/util/journaldb/src/lib.rs
@@ -27,7 +27,7 @@ extern crate keccak_hasher;
 extern crate kvdb;
 extern crate memorydb;
 extern crate parking_lot;
-extern crate plain_hasher;
+extern crate fastmap;
 extern crate rlp;
 
 #[cfg(test)]

--- a/util/journaldb/src/overlayrecentdb.rs
+++ b/util/journaldb/src/overlayrecentdb.rs
@@ -29,7 +29,7 @@ use keccak_hasher::KeccakHasher;
 use kvdb::{KeyValueDB, DBTransaction};
 use memorydb::*;
 use parking_lot::RwLock;
-use plain_hasher::H256FastMap;
+use fastmap::H256FastMap;
 use rlp::{Rlp, RlpStream, encode, decode, DecoderError, Decodable, Encodable};
 use super::{DB_PREFIX_LEN, LATEST_ERA_KEY, JournalDB, error_negatively_reference_hash};
 use util::DatabaseKey;


### PR DESCRIPTION
This lets `plain_hasher` in `parity-common` support `no_std` with less pain ([PR](https://github.com/paritytech/parity-common/pull/16)).