### PR TITLE
Lower the max size of transaction packet to prevent going oversize.

### DIFF
--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -148,7 +148,8 @@ const MAX_PEER_LAG_PROPAGATION: BlockNumber = 20;
 const MAX_NEW_HASHES: usize = 64;
 const MAX_NEW_BLOCK_AGE: BlockNumber = 20;
 // maximal packet size with transactions (cannot be greater than 16MB - protocol limitation).
-const MAX_TRANSACTION_PACKET_SIZE: usize = 8 * 1024 * 1024;
+// keep it under 8MB as well, cause it seems that it may result oversized after compression.
+const MAX_TRANSACTION_PACKET_SIZE: usize = 5 * 1024 * 1024;
 // Min number of blocks to be behind for a snapshot sync
 const SNAPSHOT_RESTORE_THRESHOLD: BlockNumber = 30000;
 const SNAPSHOT_MIN_PEERS: usize = 3;


### PR DESCRIPTION
Solves: https://github.com/paritytech/parity-ethereum/issues/9255#issuecomment-411340518

Still I'm quite unsure what could cause the packet to go oversize, it seems it might be a combination of:
1. Inefficient snappy compression
2. Imperfect `estimate_size` in RLP
3. Some additional packet headers overhead that is counted to the result but shouldn't (I suppose the packet itself can be bigger than 16MB it's just the payload that is limited)

Might be worth further debugging if someone is into it. @debris / @ngotchac ?