### PR TITLE
Allow tx pool to be Send

### DIFF
--- a/transaction-pool/Cargo.toml
+++ b/transaction-pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Generic transaction pool."
 name = "transaction-pool"
-version = "1.12.1"
+version = "1.12.2"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 

--- a/transaction-pool/src/lib.rs
+++ b/transaction-pool/src/lib.rs
@@ -111,7 +111,7 @@ pub trait VerifiedTransaction: fmt::Debug {
 	type Hash: fmt::Debug + fmt::LowerHex + Eq + Clone + Hash;
 
 	/// Transaction sender type.
-	type Sender: fmt::Debug + Eq + Clone + Hash;
+	type Sender: fmt::Debug + Eq + Clone + Hash + Send;
 
 	/// Transaction hash
 	fn hash(&self) -> &Self::Hash;

--- a/transaction-pool/src/scoring.rs
+++ b/transaction-pool/src/scoring.rs
@@ -83,7 +83,7 @@ pub enum Change<T = ()> {
 ///
 pub trait Scoring<T>: fmt::Debug {
 	/// A score of a transaction.
-	type Score: cmp::Ord + Clone + Default + fmt::Debug;
+	type Score: cmp::Ord + Clone + Default + fmt::Debug + Send;
 	/// Custom scoring update event type.
 	type Event: fmt::Debug;
 


### PR DESCRIPTION
This allows using transaction pool in `Arc` without specifying bounds all over the high level code.