### PR TITLE
ethcore/sync `Make view macro only visible to test`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
  "rlp 0.2.1 (git+https://github.com/paritytech/parity-common)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trace-time 0.1.0",
- "transaction-pool 1.12.1",
+ "transaction-pool 1.12.2",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2167,7 +2167,7 @@ dependencies = [
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-pool 1.12.1",
+ "transaction-pool 1.12.2",
  "transient-hashmap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-pool"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethcore/sync/src/lib.rs
+++ b/ethcore/sync/src/lib.rs
@@ -26,6 +26,7 @@ extern crate ethcore_network_devp2p as devp2p;
 extern crate parity_bytes as bytes;
 extern crate ethcore_io as io;
 extern crate ethcore_transaction as transaction;
+#[cfg_attr(test, macro_use)]
 extern crate ethcore;
 extern crate ethereum_types;
 extern crate env_logger;

--- a/ethcore/sync/src/lib.rs
+++ b/ethcore/sync/src/lib.rs
@@ -26,7 +26,6 @@ extern crate ethcore_network_devp2p as devp2p;
 extern crate parity_bytes as bytes;
 extern crate ethcore_io as io;
 extern crate ethcore_transaction as transaction;
-#[macro_use]
 extern crate ethcore;
 extern crate ethereum_types;
 extern crate env_logger;


### PR DESCRIPTION
Fixes the following warning:

```bash
warning: unused `#[macro_use]` import                                                                                                                                                                                                          
  --> ethcore/sync/src/lib.rs:29:1                                                                                                                                                                                                             
   |                                                                                                                                                                                                                                           
29 | #[macro_use]                                                                                                                                                                                                                              
   | ^^^^^^^^^^^^                                                                                                                                                                                                                              
   |                                                                                                                                                                                                                                           
   = note: #[warn(unused_imports)] on by default  
```