### PR TITLE
Light client logs should include 'from_block' when querying logs

### DIFF
--- a/rpc/src/v1/helpers/light_fetch.rs
+++ b/rpc/src/v1/helpers/light_fetch.rs
@@ -337,10 +337,10 @@ impl LightFetch {
 					BlockId::Hash(hdr.hash()) != filter.from_block
 					&& BlockId::Number(hdr.number()) != filter.from_block
 				})
-				.chain(::std::iter::once(self.client.block_header(filter.from_block).expect("checked before")))
+				.chain(Some(self.client.block_header(filter.from_block).expect("checked before")))
 				.filter(|ref hdr| {
 					let hdr_bloom = hdr.log_bloom();
-					bit_combos.iter().find(|&bloom| hdr_bloom & *bloom == *bloom).is_some()
+					bit_combos.iter().any(|bloom| hdr_bloom.contains_bloom(bloom))
 				})
 				.map(|hdr| (hdr.number(), request::BlockReceipts(hdr.into())))
 				.map(|(num, req)| self.on_demand.request(ctx, req).expect(NO_INVALID_BACK_REFS).map(move |x| (num, x)))


### PR DESCRIPTION
Fixes #8560 .

When using a websocket on logs, there was no entry displayed. The issue was that we called light client get logs method for each block (with a range of one block in the filter), but the method did not include the first block to query (with a range of one block it did include nothing).

This PR fixes this by making LightClient `log` works correctly (by including the start block of the filter).

For the websocket usecase it also increases OnDemand query a lot, so this other PR may be helpfull : #9318 (during my testing without #9318 the lightclient became a bit irresponsive after a while). There is also probably room for optimization in function 'notify_log', yet it should not directly impact network query (if OnDemand cache works as intended of course).

I did try to change as less as possible code, but from a personal point of view I would rather use : 

```rust
      let mut receipts_futures: Vec<_> = Vec::new();
      for hdr in self.client.ancestry_iter(filter.to_block) {
        let end_cond =  BlockId::Hash(hdr.hash()) == filter.from_block
          || BlockId::Number(hdr.number()) == filter.from_block;

        let hdr_bloom = hdr.log_bloom();
        if bit_combos.iter().find(|&bloom| hdr_bloom & *bloom == *bloom).is_some() {
          let hdr_number = hdr.number();
          receipts_futures.push(
            self.on_demand.request(ctx, request::BlockReceipts(hdr.into())).expect(NO_INVALID_BACK_REFS)
            .map(move |x|{ (hdr_number, x) })
            );
        }
        if end_cond { break; }
      }
      let receipts_futures = receipts_futures;
```
than

```rust
			let receipts_futures: Vec<_> = self.client.ancestry_iter(filter.to_block)
				.take_while(|ref hdr|{
					BlockId::Hash(hdr.hash()) != filter.from_block
					&& BlockId::Number(hdr.number()) != filter.from_block
				})
				.chain(::std::iter::once(self.client.block_header(filter.from_block).expect("checked before")))
				.filter(|ref hdr| {
					let hdr_bloom = hdr.log_bloom();
					bit_combos.iter().find(|&bloom| hdr_bloom & *bloom == *bloom).is_some()
				})
				.map(|hdr| (hdr.number(), request::BlockReceipts(hdr.into())))
				.map(|(num, req)| self.on_demand.request(ctx, req).expect(NO_INVALID_BACK_REFS).map(move |x| (num, x)))
				.collect();


```

So if the reviewers prefer the more imperative version please tell me.
