### PR TITLE
Remove prepare_trace_output and make sure prepare_trace_call and trace*call are balanced

### DIFF
--- a/ethcore/src/trace/mod.rs
+++ b/ethcore/src/trace/mod.rs
@@ -38,7 +38,6 @@ pub use self::types::filter::{Filter, AddressesFilter};
 
 use ethereum_types::{H256, U256, Address};
 use kvdb::DBTransaction;
-use bytes::Bytes;
 use self::trace::{Call, Create};
 use vm::ActionParams;
 use header::BlockNumber;
@@ -58,9 +57,6 @@ pub trait Tracer: Send {
 	/// This is called before a create has been executed.
 	fn prepare_trace_create(&self, params: &ActionParams) -> Option<Create>;
 
-	/// Prepare trace output. Noop tracer should return None.
-	fn prepare_trace_output(&self) -> Option<Bytes>;
-
 	/// Stores trace call info.
 	///
 	/// This is called after a call has completed successfully.
@@ -68,7 +64,7 @@ pub trait Tracer: Send {
 		&mut self,
 		call: Option<Call>,
 		gas_used: U256,
-		output: Option<Bytes>,
+		output: &[u8],
 		subs: Vec<Self::Output>,
 	);
 
@@ -79,7 +75,7 @@ pub trait Tracer: Send {
 		&mut self,
 		create: Option<Create>,
 		gas_used: U256,
-		code: Option<Bytes>,
+		code: &[u8],
 		address: Address,
 		subs: Vec<Self::Output>
 	);

--- a/ethcore/src/trace/noop_tracer.rs
+++ b/ethcore/src/trace/noop_tracer.rs
@@ -17,7 +17,6 @@
 //! Nonoperative tracer.
 
 use ethereum_types::{U256, Address};
-use bytes::Bytes;
 use vm::ActionParams;
 use trace::{Tracer, VMTracer, FlatTrace, TraceError};
 use trace::trace::{Call, Create, VMTrace, RewardType};
@@ -36,18 +35,12 @@ impl Tracer for NoopTracer {
 		None
 	}
 
-	fn prepare_trace_output(&self) -> Option<Bytes> {
-		None
-	}
-
-	fn trace_call(&mut self, call: Option<Call>, _: U256, output: Option<Bytes>, _: Vec<FlatTrace>) {
+	fn trace_call(&mut self, call: Option<Call>, _: U256, _: &[u8], _: Vec<FlatTrace>) {
 		assert!(call.is_none(), "self.prepare_trace_call().is_none(): so we can't be tracing: qed");
-		assert!(output.is_none(), "self.prepare_trace_output().is_none(): so we can't be tracing: qed");
 	}
 
-	fn trace_create(&mut self, create: Option<Create>, _: U256, code: Option<Bytes>, _: Address, _: Vec<FlatTrace>) {
+	fn trace_create(&mut self, create: Option<Create>, _: U256, _: &[u8], _: Address, _: Vec<FlatTrace>) {
 		assert!(create.is_none(), "self.prepare_trace_create().is_none(): so we can't be tracing: qed");
-		assert!(code.is_none(), "self.prepare_trace_output().is_none(): so we can't be tracing: qed");
 	}
 
 	fn trace_failed_call(&mut self, call: Option<Call>, _: Vec<FlatTrace>, _: TraceError) {


### PR DESCRIPTION
This refactors `prepare_trace_output` to instead directly take the reference of return values, so that it's simpler and we save a stack item. This should also fixes [the issue](https://github.com/paritytech/parity-ethereum/pull/9236#issuecomment-408444995) @udoprog is facing. Replaces #9236 