### PR TITLE
Fix no line breaks in logs

### DIFF
--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -127,7 +127,7 @@ pub fn setup_log(config: &Config) -> Result<Arc<RotatingLogger>, String> {
 			println!("{}", ret);
 		}
 
-		write!(buf, "{}", ret)
+		writeln!(buf, "{}", ret)
     };
 
 	builder.format(format);


### PR DESCRIPTION
After #9294 update of `env_logger`, line breaks were missing from the log output.