### PR TITLE
Better logging when mining own transactions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ dependencies = [
  "rlp 0.2.1 (git+https://github.com/paritytech/parity-common)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trace-time 0.1.0",
- "transaction-pool 1.12.3",
+ "transaction-pool 1.13.1",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2171,7 +2171,7 @@ dependencies = [
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-pool 1.12.3",
+ "transaction-pool 1.13.1",
  "transient-hashmap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-pool"
-version = "1.12.3"
+version = "1.13.1"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethcore/service/src/service.rs
+++ b/ethcore/service/src/service.rs
@@ -95,6 +95,7 @@ impl ClientService {
 		let pruning = config.pruning;
 		let client = Client::new(config, &spec, blockchain_db.clone(), miner.clone(), io_service.channel())?;
 		miner.set_io_channel(io_service.channel());
+		miner.set_in_chain_checker(&client.clone());
 
 		let snapshot_params = SnapServiceParams {
 			engine: spec.engine.clone(),

--- a/miner/src/pool/listener.rs
+++ b/miner/src/pool/listener.rs
@@ -107,8 +107,8 @@ impl txpool::Listener<Transaction> for Logger {
 		debug!(target: "txqueue", "[{:?}] Canceled by the user.", tx.hash());
 	}
 
-	fn mined(&mut self, tx: &Arc<Transaction>) {
-		debug!(target: "txqueue", "[{:?}] Mined.", tx.hash());
+	fn culled(&mut self, tx: &Arc<Transaction>) {
+		debug!(target: "txqueue", "[{:?}] Culled or mined.", tx.hash());
 	}
 }
 

--- a/miner/src/pool/queue.rs
+++ b/miner/src/pool/queue.rs
@@ -229,6 +229,13 @@ impl TransactionQueue {
 		*self.options.write() = options;
 	}
 
+	/// Sets the in-chain transaction checker for pool listener.
+	pub fn set_in_chain_checker<F>(&self, f: F) where
+		F: Fn(&H256) -> bool + Send + Sync + 'static
+	{
+		self.pool.write().listener_mut().0.set_in_chain_checker(f)
+	}
+
 	/// Import a set of transactions to the pool.
 	///
 	/// Given blockchain and state access (Client)

--- a/transaction-pool/Cargo.toml
+++ b/transaction-pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Generic transaction pool."
 name = "transaction-pool"
-version = "1.12.3"
+version = "1.13.1"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 

--- a/transaction-pool/src/listener.rs
+++ b/transaction-pool/src/listener.rs
@@ -40,8 +40,8 @@ pub trait Listener<T> {
 	/// The transaction has been canceled.
 	fn canceled(&mut self, _tx: &Arc<T>) {}
 
-	/// The transaction has been mined.
-	fn mined(&mut self, _tx: &Arc<T>) {}
+	/// The transaction has been culled from the pool.
+	fn culled(&mut self, _tx: &Arc<T>) {}
 }
 
 /// A no-op implementation of `Listener`.
@@ -78,8 +78,8 @@ impl<T, A, B> Listener<T> for (A, B) where
 		self.1.canceled(tx);
 	}
 
-	fn mined(&mut self, tx: &Arc<T>) {
-		self.0.mined(tx);
-		self.1.mined(tx);
+	fn culled(&mut self, tx: &Arc<T>) {
+		self.0.culled(tx);
+		self.1.culled(tx);
 	}
 }

--- a/transaction-pool/src/pool.rs
+++ b/transaction-pool/src/pool.rs
@@ -370,7 +370,7 @@ impl<T, S, L> Pool<T, S, L> where
 				let len = removed.len();
 				for tx in removed {
 					self.finalize_remove(tx.hash());
-					self.listener.mined(&tx);
+					self.listener.culled(&tx);
 				}
 				len
 			},

--- a/transaction-pool/src/tests/mod.rs
+++ b/transaction-pool/src/tests/mod.rs
@@ -648,8 +648,8 @@ mod listener {
 			self.0.borrow_mut().push("canceled".into());
 		}
 
-		fn mined(&mut self, _tx: &SharedTransaction) {
-			self.0.borrow_mut().push("mined".into());
+		fn culled(&mut self, _tx: &SharedTransaction) {
+			self.0.borrow_mut().push("culled".into());
 		}
 	}
 
@@ -743,6 +743,6 @@ mod listener {
 		txq.cull(None, NonceReady::new(3));
 
 		// then
-		assert_eq!(*results.borrow(), &["added", "added", "mined", "mined"]);
+		assert_eq!(*results.borrow(), &["added", "added", "culled", "culled"]);
 	}
 }


### PR DESCRIPTION
Currently we log `Transaction is mined` for every local (own) transaction that is dropped from the queue.
In fact it's not always true, if the same key is used on some other nodes or if we send multiple replacement transactions (bumping gas price, but using the same nonce) - the transaction might be removed, but some other transaction with the same (sender, nonce) was actually included in the blockchain.

This PR attempts to fix the logging for local transactions by checking if the transaction is in chain before printing the log line.

Since we don't have a `client` instance in the miner, we do that by using a `Weak` reference (to prevent cyclic references).