### PR TITLE
Fix typos in `network-devp2p`

### DIFF
--- a/util/network-devp2p/src/connection.rs
+++ b/util/network-devp2p/src/connection.rs
@@ -353,7 +353,7 @@ impl EncryptedConnection {
 		}
 		header.append_raw(&[(len >> 16) as u8, (len >> 8) as u8, len as u8], 1);
 		header.append_raw(&[0xc2u8, 0x80u8, 0x80u8], 1);
-		//TODO: ger rid of vectors here
+		//TODO: get rid of vectors here
 		let mut header = header.out();
 		let padding = (16 - (payload.len() % 16)) % 16;
 		header.resize(16, 0u8);
@@ -442,7 +442,7 @@ impl EncryptedConnection {
 		mac.update(&enc);
 	}
 
-	/// Readable IO handler. Tracker receive status and returns decoded packet if avaialable.
+	/// Readable IO handler. Tracker receive status and returns decoded packet if available.
 	pub fn readable<Message>(&mut self, io: &IoContext<Message>) -> Result<Option<Packet>, Error> where Message: Send + Clone + Sync + 'static {
 		io.clear_timer(self.connection.token)?;
 		if let EncryptedConnectionState::Header = self.read_state {
@@ -465,7 +465,7 @@ impl EncryptedConnection {
 		}
 	}
 
-	/// Writable IO handler. Processes send queeue.
+	/// Writable IO handler. Processes send queue.
 	pub fn writable<Message>(&mut self, io: &IoContext<Message>) -> Result<(), Error> where Message: Send + Clone + Sync + 'static {
 		self.connection.writable(io)?;
 		Ok(())

--- a/util/network-devp2p/src/handshake.rs
+++ b/util/network-devp2p/src/handshake.rs
@@ -21,7 +21,7 @@ use mio::tcp::*;
 use ethereum_types::{H256, H520};
 use parity_bytes::Bytes;
 use rlp::{Rlp, RlpStream};
-use connection::{Connection};
+use connection::Connection;
 use node_table::NodeId;
 use io::{IoContext, StreamToken};
 use ethkey::{KeyPair, Public, Secret, recover, sign, Generator, Random};
@@ -45,7 +45,7 @@ enum HandshakeState {
 	StartSession,
 }
 
-/// `RLPx` protocol handhake. See https://github.com/ethereum/devp2p/blob/master/rlpx.md#encrypted-handshake
+/// `RLPx` protocol handshake. See https://github.com/ethereum/devp2p/blob/master/rlpx.md#encrypted-handshake
 pub struct Handshake {
 	/// Remote node public key
 	pub id: NodeId,
@@ -65,11 +65,11 @@ pub struct Handshake {
 	pub remote_nonce: H256,
 	/// Remote `RLPx` protocol version.
 	pub remote_version: u64,
-	/// A copy of received encryped auth packet
+	/// A copy of received encrypted auth packet
 	pub auth_cipher: Bytes,
-	/// A copy of received encryped ack packet
+	/// A copy of received encrypted ack packet
 	pub ack_cipher: Bytes,
-	/// This Handshake is marked for deleteion flag
+	/// This Handshake is marked for deletion flag
 	pub expired: bool,
 }
 
@@ -104,7 +104,7 @@ impl Handshake {
 		self.expired
 	}
 
-	/// Start a handhsake
+	/// Start a handshake
 	pub fn start<Message>(&mut self, io: &IoContext<Message>, host: &HostInfo, originated: bool) -> Result<(), Error> where Message: Send + Clone+ Sync + 'static {
 		self.originated = originated;
 		io.register_timer(self.connection.token, HANDSHAKE_TIMEOUT).ok();
@@ -152,7 +152,7 @@ impl Handshake {
 		Ok(())
 	}
 
-	/// Writabe IO handler.
+	/// Writable IO handler.
 	pub fn writable<Message>(&mut self, io: &IoContext<Message>) -> Result<(), Error> where Message: Send + Clone + Sync + 'static {
 		if !self.expired() {
 			self.connection.writable(io)?;

--- a/util/network-devp2p/src/node_table.rs
+++ b/util/network-devp2p/src/node_table.rs
@@ -38,7 +38,7 @@ pub type NodeId = H512;
 pub struct NodeEndpoint {
 	/// IP(V4 or V6) address
 	pub address: SocketAddr,
-	/// Conneciton port.
+	/// Connection port.
 	pub udp_port: u16
 }
 
@@ -373,7 +373,7 @@ impl NodeTable {
 		self.useless_nodes.insert(id.clone());
 	}
 
-	/// Atempt to connect to useless nodes again.
+	/// Attempt to connect to useless nodes again.
 	pub fn clear_useless(&mut self) {
 		self.useless_nodes.clear();
 	}

--- a/util/network-devp2p/src/service.rs
+++ b/util/network-devp2p/src/service.rs
@@ -68,7 +68,7 @@ impl NetworkService {
 		})
 	}
 
-	/// Regiter a new protocol handler with the event loop.
+	/// Register a new protocol handler with the event loop.
 	pub fn register_protocol(
 		&self,
 		handler: Arc<NetworkProtocolHandler + Send + Sync>,

--- a/util/network-devp2p/src/session.rs
+++ b/util/network-devp2p/src/session.rs
@@ -49,11 +49,11 @@ enum ProtocolState {
 
 /// Peer session over encrypted connection.
 /// When created waits for Hello packet exchange and signals ready state.
-/// Sends and receives protocol packets and handles basic packes such as ping/pong and disconnect.
+/// Sends and receives protocol packets and handles basic packets such as ping/pong and disconnect.
 pub struct Session {
 	/// Shared session information
 	pub info: SessionInfo,
-	/// Session ready flag. Set after successfull Hello packet exchange
+	/// Session ready flag. Set after successful Hello packet exchange
 	had_hello: bool,
 	/// Session is no longer active flag.
 	expired: bool,
@@ -98,8 +98,8 @@ const PACKET_USER: u8 = 0x10;
 const PACKET_LAST: u8 = 0x7f;
 
 impl Session {
-	/// Create a new session out of comepleted handshake. This clones the handshake connection object
-	/// and leaves the handhsake in limbo to be deregistered from the event loop.
+	/// Create a new session out of completed handshake. This clones the handshake connection object
+	/// and leaves the handshake in limbo to be de-registered from the event loop.
 	pub fn new<Message>(io: &IoContext<Message>, socket: TcpStream, token: StreamToken, id: Option<&NodeId>,
 		nonce: &H256, host: &HostInfo) -> Result<Session, Error>
 		where Message: Send + Clone + Sync + 'static {
@@ -450,7 +450,7 @@ impl Session {
 			}
 		}
 
-		// Sort capabilities alphabeticaly.
+		// Sort capabilities alphabetically.
 		caps.sort();
 
 		i = 0;


### PR DESCRIPTION
Fixes a couple of typos that I discovered when I skimmed the networking code!