### PR TITLE
network-devp2p `Fix some clippy errors/warnings`

### DIFF
--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -569,11 +569,11 @@ pub trait ManageNetwork : Send + Sync {
 
 impl ManageNetwork for EthSync {
 	fn accept_unreserved_peers(&self) {
-		self.network.set_non_reserved_mode(NonReservedPeerMode::Accept);
+		self.network.set_non_reserved_mode(&NonReservedPeerMode::Accept);
 	}
 
 	fn deny_unreserved_peers(&self) {
-		self.network.set_non_reserved_mode(NonReservedPeerMode::Deny);
+		self.network.set_non_reserved_mode(&NonReservedPeerMode::Deny);
 	}
 
 	fn remove_reserved_peer(&self, peer: String) -> Result<(), String> {
@@ -839,11 +839,11 @@ impl ::std::ops::Deref for LightSync {
 
 impl ManageNetwork for LightSync {
 	fn accept_unreserved_peers(&self) {
-		self.network.set_non_reserved_mode(NonReservedPeerMode::Accept);
+		self.network.set_non_reserved_mode(&NonReservedPeerMode::Accept);
 	}
 
 	fn deny_unreserved_peers(&self) {
-		self.network.set_non_reserved_mode(NonReservedPeerMode::Deny);
+		self.network.set_non_reserved_mode(&NonReservedPeerMode::Deny);
 	}
 
 	fn remove_reserved_peer(&self, peer: String) -> Result<(), String> {

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -569,11 +569,11 @@ pub trait ManageNetwork : Send + Sync {
 
 impl ManageNetwork for EthSync {
 	fn accept_unreserved_peers(&self) {
-		self.network.set_non_reserved_mode(&NonReservedPeerMode::Accept);
+		self.network.set_non_reserved_mode(NonReservedPeerMode::Accept);
 	}
 
 	fn deny_unreserved_peers(&self) {
-		self.network.set_non_reserved_mode(&NonReservedPeerMode::Deny);
+		self.network.set_non_reserved_mode(NonReservedPeerMode::Deny);
 	}
 
 	fn remove_reserved_peer(&self, peer: String) -> Result<(), String> {
@@ -839,11 +839,11 @@ impl ::std::ops::Deref for LightSync {
 
 impl ManageNetwork for LightSync {
 	fn accept_unreserved_peers(&self) {
-		self.network.set_non_reserved_mode(&NonReservedPeerMode::Accept);
+		self.network.set_non_reserved_mode(NonReservedPeerMode::Accept);
 	}
 
 	fn deny_unreserved_peers(&self) {
-		self.network.set_non_reserved_mode(&NonReservedPeerMode::Deny);
+		self.network.set_non_reserved_mode(NonReservedPeerMode::Deny);
 	}
 
 	fn remove_reserved_peer(&self, peer: String) -> Result<(), String> {

--- a/util/network-devp2p/src/connection.rs
+++ b/util/network-devp2p/src/connection.rs
@@ -167,8 +167,8 @@ impl Connection {
 	/// Create a new connection with given id and socket.
 	pub fn new(token: StreamToken, socket: TcpStream) -> Connection {
 		Connection {
-			token: token,
-			socket: socket,
+			token,
+			socket,
 			send_queue: VecDeque::new(),
 			rec_buf: Bytes::new(),
 			rec_size: 0,
@@ -318,24 +318,24 @@ impl EncryptedConnection {
 		let mac_encoder = EcbEncryptor::new(AesSafe256Encryptor::new(&key_material[32..64]), NoPadding);
 
 		let mut egress_mac = Keccak::new_keccak256();
-		let mut mac_material = &H256::from_slice(&key_material[32..64]) ^ &handshake.remote_nonce;
+		let mut mac_material = H256::from_slice(&key_material[32..64]) ^ handshake.remote_nonce;
 		egress_mac.update(&mac_material);
 		egress_mac.update(if handshake.originated { &handshake.auth_cipher } else { &handshake.ack_cipher });
 
 		let mut ingress_mac = Keccak::new_keccak256();
-		mac_material = &H256::from_slice(&key_material[32..64]) ^ &handshake.nonce;
+		mac_material = H256::from_slice(&key_material[32..64]) ^ handshake.nonce;
 		ingress_mac.update(&mac_material);
 		ingress_mac.update(if handshake.originated { &handshake.ack_cipher } else { &handshake.auth_cipher });
 
 		let old_connection = handshake.connection.try_clone()?;
 		let connection = ::std::mem::replace(&mut handshake.connection, old_connection);
 		let mut enc = EncryptedConnection {
-			connection: connection,
-			encoder: encoder,
-			decoder: decoder,
-			mac_encoder: mac_encoder,
-			egress_mac: egress_mac,
-			ingress_mac: ingress_mac,
+			connection,
+			encoder,
+			decoder,
+			mac_encoder,
+			egress_mac,
+			ingress_mac,
 			read_state: EncryptedConnectionState::Header,
 			protocol_id: 0,
 			payload_len: 0,
@@ -534,7 +534,7 @@ mod tests {
 				read_buffer: vec![],
 				write_buffer: vec![],
 				cursor: 0,
-				buf_size: buf_size,
+				buf_size,
 			}
 		}
 	}

--- a/util/network-devp2p/src/handshake.rs
+++ b/util/network-devp2p/src/handshake.rs
@@ -271,7 +271,7 @@ impl Handshake {
 
 			// E(remote-pubk, S(ecdhe-random, ecdh-shared-secret^nonce) || H(ecdhe-random-pubk) || pubk || nonce || 0x0)
 			let shared = *ecdh::agree(secret, &self.id)?;
-			sig.copy_from_slice(&*sign(self.ecdhe.secret(), &(&shared ^ &self.nonce))?);
+			sig.copy_from_slice(&*sign(self.ecdhe.secret(), &(shared ^ self.nonce))?);
 			write_keccak(self.ecdhe.public(), hepubk);
 			pubk.copy_from_slice(public);
 			nonce.copy_from_slice(&self.nonce);

--- a/util/network-devp2p/src/host.rs
+++ b/util/network-devp2p/src/host.rs
@@ -280,7 +280,7 @@ impl Host {
 		listen_address = SocketAddr::new(listen_address.ip(), tcp_listener.local_addr()?.port());
 		debug!(target: "network", "Listening at {:?}", listen_address);
 		let udp_port = config.udp_port.unwrap_or_else(|| listen_address.port());
-		let local_endpoint = NodeEndpoint { address: listen_address, udp_port: udp_port };
+		let local_endpoint = NodeEndpoint { address: listen_address, udp_port };
 
 		let boot_nodes = config.boot_nodes.clone();
 		let reserved_nodes = config.reserved_nodes.clone();
@@ -288,13 +288,13 @@ impl Host {
 
 		let mut host = Host {
 			info: RwLock::new(HostInfo {
-				keys: keys,
-				config: config,
+				keys,
+				config,
 				nonce: H256::random(),
 				protocol_version: PROTOCOL_VERSION,
 				capabilities: Vec::new(),
 				public_endpoint: None,
-				local_endpoint: local_endpoint,
+				local_endpoint,
 			}),
 			discovery: Mutex::new(None),
 			udp_socket: Mutex::new(None),
@@ -306,7 +306,7 @@ impl Host {
 			timer_counter: RwLock::new(USER_TIMER),
 			reserved_nodes: RwLock::new(HashSet::new()),
 			stopping: AtomicBool::new(false),
-			filter: filter,
+			filter,
 		};
 
 		for n in boot_nodes {
@@ -430,7 +430,7 @@ impl Host {
 			return Ok(());
 		}
 		let local_endpoint = self.info.read().local_endpoint.clone();
-		let public_address = self.info.read().config.public_address.clone();
+		let public_address = self.info.read().config.public_address;
 		let allow_ips = self.info.read().config.ip_filter.clone();
 		let public_endpoint = match public_address {
 			None => {
@@ -489,7 +489,7 @@ impl Host {
 	}
 
 	fn have_session(&self, id: &NodeId) -> bool {
-		self.sessions.read().iter().any(|e| e.lock().info.id == Some(id.clone()))
+		self.sessions.read().iter().any(|e| e.lock().info.id == Some(*id))
 	}
 
 	// returns (handshakes, egress, ingress)
@@ -534,7 +534,7 @@ impl Host {
 			}
 			let config = &info.config;
 
-			(config.min_peers, config.non_reserved_mode == NonReservedPeerMode::Deny, config.max_handshakes as usize, config.ip_filter.clone(), info.id().clone())
+			(config.min_peers, config.non_reserved_mode == NonReservedPeerMode::Deny, config.max_handshakes as usize, config.ip_filter.clone(), *info.id())
 		};
 
 		let (handshake_count, egress_count, ingress_count) = self.session_count();
@@ -710,18 +710,18 @@ impl Host {
 							let (min_peers, mut max_peers, reserved_only, self_id) = {
 								let info = self.info.read();
 								let mut max_peers = info.config.max_peers;
-								for cap in s.info.capabilities.iter() {
+								for cap in &s.info.capabilities {
 									if let Some(num) = info.config.reserved_protocols.get(&cap.protocol) {
 										max_peers += *num;
 										break;
 									}
 								}
-								(info.config.min_peers as usize, max_peers as usize, info.config.non_reserved_mode == NonReservedPeerMode::Deny, info.id().clone())
+								(info.config.min_peers as usize, max_peers as usize, info.config.non_reserved_mode == NonReservedPeerMode::Deny, *info.id())
 							};
 
 							max_peers = max(max_peers, min_peers);
 
-							let id = s.id().expect("Ready session always has id").clone();
+							let id = *s.id().expect("Ready session always has id");
 
 							// Check for the session limit.
 							// Outgoing connections are allowed as long as their count is <= min_peers
@@ -729,13 +729,11 @@ impl Host {
 							let max_ingress = max(max_peers - min_peers, min_peers / 2);
 							if reserved_only ||
 								(s.info.originated && egress_count > min_peers) ||
-								(!s.info.originated && ingress_count > max_ingress) {
+								(!s.info.originated && ingress_count > max_ingress) && !self.reserved_nodes.read().contains(&id) {
 								// only proceed if the connecting peer is reserved.
-								if !self.reserved_nodes.read().contains(&id) {
-									s.disconnect(io, DisconnectReason::TooManyPeers);
-									kill = true;
-									break;
-								}
+								s.disconnect(io, DisconnectReason::TooManyPeers);
+								kill = true;
+								break;
 							}
 
 							if !self.filter.as_ref().map_or(true, |f| f.connection_allowed(&self_id, &id, ConnectionDirection::Inbound)) {
@@ -752,7 +750,7 @@ impl Host {
 								if let Ok(address) = s.remote_addr() {
 									// We can't know remote listening ports, so just assume defaults and hope for the best.
 									let endpoint = NodeEndpoint { address: SocketAddr::new(address.ip(), DEFAULT_PORT), udp_port: DEFAULT_PORT };
-									let entry = NodeEntry { id: id, endpoint: endpoint };
+									let entry = NodeEntry { id, endpoint };
 									let mut nodes = self.nodes.write();
 									if !nodes.contains(&entry.id) {
 										nodes.add_node(Node::new(entry.id, entry.endpoint.clone()));
@@ -807,7 +805,7 @@ impl Host {
 				}
 				for p in ready_data {
 					let reserved = self.reserved_nodes.read();
-					if let Some(h) = handlers.get(&p).clone() {
+					if let Some(h) = handlers.get(&p) {
 						h.connected(&NetworkContext::new(io, p, Some(session.clone()), self.sessions.clone(), &reserved), &token);
 						// accumulate pending packets.
 						let mut session = session.lock();
@@ -818,7 +816,7 @@ impl Host {
 
 			for (p, packet_id, data) in packet_data {
 				let reserved = self.reserved_nodes.read();
-				if let Some(h) = handlers.get(&p).clone() {
+				if let Some(h) = handlers.get(&p) {
 					h.read(&NetworkContext::new(io, p, Some(session.clone()), self.sessions.clone(), &reserved), &token, packet_id, &data);
 				}
 			}
@@ -858,31 +856,28 @@ impl Host {
 	}
 
 	fn discovery_writable(&self, io: &IoContext<NetworkIoMessage>) {
-		match (self.udp_socket.lock().as_ref(), self.discovery.lock().as_mut()) {
-			(Some(udp_socket), Some(discovery)) => {
-				while let Some(data) = discovery.dequeue_send() {
-					match udp_socket.send_to(&data.payload, &data.address) {
-						Ok(Some(size)) if size == data.payload.len() => {
-						},
-						Ok(Some(_)) => {
-							warn!(target: "network", "UDP sent incomplete datagram");
-						},
-						Ok(None) => {
-							discovery.requeue_send(data);
-							return;
-						}
-						Err(e) => {
-							debug!(target: "network", "UDP send error: {:?}, address: {:?}", e, &data.address);
-							return;
-						}
+		if let (Some(udp_socket), Some(discovery)) = (self.udp_socket.lock().as_ref(), self.discovery.lock().as_mut()) {
+			while let Some(data) = discovery.dequeue_send() {
+				match udp_socket.send_to(&data.payload, &data.address) {
+					Ok(Some(size)) if size == data.payload.len() => {
+					},
+					Ok(Some(_)) => {
+						warn!(target: "network", "UDP sent incomplete datagram");
+					},
+					Ok(None) => {
+						discovery.requeue_send(data);
+						return;
+					}
+					Err(e) => {
+						debug!(target: "network", "UDP send error: {:?}, address: {:?}", e, &data.address);
+						return;
 					}
 				}
-				io.update_registration(DISCOVERY)
-					.unwrap_or_else(|e| {
-						debug!(target: "network", "Error updating discovery registration: {:?}", e)
-					});
-			},
-			_ => (),
+			}
+			io.update_registration(DISCOVERY)
+				.unwrap_or_else(|e| {
+					debug!(target: "network", "Error updating discovery registration: {:?}", e)
+				});
 		}
 	}
 
@@ -922,7 +917,7 @@ impl Host {
 		}
 		for p in to_disconnect {
 			let reserved = self.reserved_nodes.read();
-			if let Some(h) = self.handlers.read().get(&p).clone() {
+			if let Some(h) = self.handlers.read().get(&p) {
 				h.disconnected(&NetworkContext::new(io, p, expired_session.clone(), self.sessions.clone(), &reserved), &token);
 			}
 		}
@@ -1012,11 +1007,13 @@ impl IoHandler<NetworkIoMessage> for Host {
 			IDLE => self.maintain_network(io),
 			FIRST_SESSION ... LAST_SESSION => self.connection_timeout(token, io),
 			DISCOVERY_REFRESH => {
-				self.discovery.lock().as_mut().map(|d| d.refresh());
+				if let Some(d) = self.discovery.lock().as_mut() {
+					d.refresh();
+                                }
 				io.update_registration(DISCOVERY).unwrap_or_else(|e| debug!("Error updating discovery registration: {:?}", e));
 			},
 			DISCOVERY_ROUND => {
-				let node_changes = { self.discovery.lock().as_mut().map_or(None, |d| d.round()) };
+				let node_changes = { self.discovery.lock().as_mut().and_then(|d| d.round()) };
 				if let Some(node_changes) = node_changes {
 					self.update_nodes(io, node_changes);
 				}

--- a/util/network-devp2p/src/host.rs
+++ b/util/network-devp2p/src/host.rs
@@ -349,11 +349,11 @@ impl Host {
 		Ok(())
 	}
 
-	pub fn set_non_reserved_mode(&self, mode: &NonReservedPeerMode, io: &IoContext<NetworkIoMessage>) {
+	pub fn set_non_reserved_mode(&self, mode: NonReservedPeerMode, io: &IoContext<NetworkIoMessage>) {
 		let mut info = self.info.write();
 
-		if &info.config.non_reserved_mode != mode {
-			info.config.non_reserved_mode = mode.clone();
+		if info.config.non_reserved_mode != mode {
+			info.config.non_reserved_mode = mode;
 			drop(info);
 			if let NonReservedPeerMode::Deny = mode {
 				// disconnect all non-reserved peers here.

--- a/util/network-devp2p/src/node_table.rs
+++ b/util/network-devp2p/src/node_table.rs
@@ -393,7 +393,6 @@ impl NodeTable {
 		let nodes = node_ids.into_iter()
 			.map(|id| self.nodes.get(&id).expect("self.nodes() only returns node IDs from self.nodes"))
 			.take(MAX_NODES)
-			.map(|node| node.clone())
 			.map(Into::into)
 			.collect();
 		let table = json::NodeTable { nodes };

--- a/util/network-devp2p/src/service.rs
+++ b/util/network-devp2p/src/service.rs
@@ -173,11 +173,11 @@ impl NetworkService {
 	}
 
 	/// Set the non-reserved peer mode.
-	pub fn set_non_reserved_mode(&self, mode: &NonReservedPeerMode) {
+	pub fn set_non_reserved_mode(&self, mode: NonReservedPeerMode) {
 		let host = self.host.read();
 		if let Some(ref host) = *host {
 			let io_ctxt = IoContext::new(self.io_service.channel(), 0);
-			host.set_non_reserved_mode(&mode, &io_ctxt);
+			host.set_non_reserved_mode(mode, &io_ctxt);
 		}
 	}
 

--- a/util/network/src/lib.rs
+++ b/util/network/src/lib.rs
@@ -350,7 +350,7 @@ pub trait NetworkProtocolHandler: Sync + Send {
 }
 
 /// Non-reserved peer modes.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum NonReservedPeerMode {
 	/// Accept them. This is the default.
 	Accept,


### PR DESCRIPTION
These errors/warnings are not fixed:

```bash
warning: the function has a cyclomatic complexity of 28
   --> util/network-devp2p/src/host.rs:678:2
    |
678 |       fn session_readable(&self, token: StreamToken, io: &IoContext<NetworkIoMessage>) {
    |  _____^
679 | |         let mut ready_data: Vec<ProtocolId> = Vec::new();
680 | |         let mut packet_data: Vec<(ProtocolId, PacketId, Vec<u8>)> = Vec::new();
681 | |         let mut kill = false;
...   |
823 | |         }
824 | |     }
    | |_____^
    |
    = note: #[warn(cyclomatic_complexity)] on by default
    = help: you could split it up into multiple smaller functions
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#cyclomatic_complexity

warning: casting u8 to u32 may become silently lossy if types change
   --> util/network-devp2p/src/connection.rs:393:19
    |
393 |         let length = ((((hdec[0] as u32) << 8) + (hdec[1] as u32)) << 8) + (hdec[2] as u32);
    |                         ^^^^^^^^^^^^^^^^ help: try: `u32::from(hdec[0])`
    |
    = note: #[warn(cast_lossless)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#cast_lossless

warning: casting u8 to u32 may become silently lossy if types change
   --> util/network-devp2p/src/connection.rs:393:44
    |
393 |         let length = ((((hdec[0] as u32) << 8) + (hdec[1] as u32)) << 8) + (hdec[2] as u32);
    |                                                  ^^^^^^^^^^^^^^^^ help: try: `u32::from(hdec[1])`
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#cast_lossless

warning: casting u8 to u32 may become silently lossy if types change
   --> util/network-devp2p/src/connection.rs:393:70
    |
393 |         let length = ((((hdec[0] as u32) << 8) + (hdec[1] as u32)) << 8) + (hdec[2] as u32);
    |                                                                            ^^^^^^^^^^^^^^^^ help: try: `u32::from(hdec[2])`
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#cast_lossless

warning: large size difference between variants
  --> util/network-devp2p/src/session.rs:70:2
   |
70 |     Session(EncryptedConnection),
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(large_enum_variant)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#large_enum_variant
help: consider boxing the large fields to reduce the total size of the enum
   |
70 |     Session(Box<EncryptedConnection>),
   |             ^^^^^^^^^^^^^^^^^^^^^^^^

error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`)
  --> util/network-devp2p/src/node_table.rs:78:25
   |
78 |                 let o: *const u16 = addr_bytes.as_ptr() as *const u16;
   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[deny(cast_ptr_alignment)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#cast_ptr_alignment

warning: you seem to be using .map() to clone the contents of an iterator, consider using `.cloned()`
   --> util/network-devp2p/src/node_table.rs:393:15
    |
393 |           let nodes = node_ids.into_iter()
    |  _____________________^
394 | |             .map(|id| self.nodes.get(&id).expect("self.nodes() only returns node IDs from self.nodes"))
395 | |             .take(MAX_NODES)
396 | |             .map(|node| node.clone())
    | |_____________________________________^
    |
    = note: #[warn(map_clone)] on by default
    = help: try
            node_ids.into_iter()
                        .map(|id| self.nodes.get(&id).expect("self.nodes() only returns node IDs from self.nodes"))
                        .take(MAX_NODES).cloned()
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#map_clone

error: using `clone` on a double-reference; this will copy the reference instead of cloning the inner type
   --> util/network-devp2p/src/node_table.rs:396:16
    |
396 |             .map(|node| node.clone())
    |                         ^^^^^^^^^^^^
    |
    = note: #[deny(clone_double_ref)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#clone_double_ref
help: try dereferencing it
    |
396 |             .map(|node| &(*node).clone())
    |                         ^^^^^^^^^^^^^^^^
help: or try being explicit about what type to clone
    |
396 |             .map(|node| &node_table::Node::clone(node))
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: casting from `*mut libc::sockaddr` to a more-strictly-aligned pointer (`*const libc::sockaddr_in`)
   --> util/network-devp2p/src/ip_utils.rs:225:34
    |
225 |                 let sa: *const sockaddr_in = sa as *const sockaddr_in;
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#cast_ptr_alignment

error: casting from `*mut libc::sockaddr` to a more-strictly-aligned pointer (`*const libc::sockaddr_in6`)
   --> util/network-devp2p/src/ip_utils.rs:233:35
    |
233 |                 let sa: *const sockaddr_in6 = sa as *const sockaddr_in6;
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#cast_ptr_alignment

error: aborting due to 4 previous errors

error: Could not compile `ethcore-network-devp2p`.

```

Remarks:
- ```Node``` is not a clone type so I guess ```shallow copying makes sense```