### PR TITLE
Prevent old blocks sync restart if import queue full

### DIFF
--- a/ethcore/src/error.rs
+++ b/ethcore/src/error.rs
@@ -152,6 +152,24 @@ impl error::Error for BlockError {
 
 error_chain! {
 	types {
+		QueueError, QueueErrorKind, QueueErrorResultExt, QueueErrorResult;
+	}
+
+	errors {
+		#[doc = "Queue is full"]
+		Full(limit: usize) {
+			description("Queue is full")
+			display("The queue is full ({})", limit)
+		}
+	}
+
+	foreign_links {
+		Channel(IoError) #[doc = "Io channel error"];
+	}
+}
+
+error_chain! {
+	types {
 		ImportError, ImportErrorKind, ImportErrorResultExt, ImportErrorResult;
 	}
 
@@ -183,6 +201,7 @@ error_chain! {
 
 	links {
 		Import(ImportError, ImportErrorKind) #[doc = "Import error"];
+		Queue(QueueError, QueueErrorKind) #[doc = "Io channel queue error"];
 	}
 
 	foreign_links {

--- a/ethcore/sync/src/block_sync.rs
+++ b/ethcore/sync/src/block_sync.rs
@@ -25,7 +25,7 @@ use ethereum_types::H256;
 use rlp::{self, Rlp};
 use ethcore::header::BlockNumber;
 use ethcore::client::{BlockStatus, BlockId, BlockImportError, BlockImportErrorKind};
-use ethcore::error::{ImportErrorKind, BlockError};
+use ethcore::error::{ImportErrorKind, QueueErrorKind, BlockError};
 use sync_io::SyncIo;
 use blocks::{BlockCollection, SyncBody, SyncHeader};
 
@@ -511,6 +511,10 @@ impl BlockDownloader {
 				},
 				Err(BlockImportError(BlockImportErrorKind::Block(BlockError::TemporarilyInvalid(_)), _)) => {
 					debug!(target: "sync", "Block temporarily invalid, restarting sync");
+					break;
+				},
+				Err(BlockImportError(BlockImportErrorKind::Queue(QueueErrorKind::Full(limit)), _)) => {
+					debug!(target: "sync", "Block import queue full ({}), restarting sync", limit);
 					break;
 				},
 				Err(e) => {


### PR DESCRIPTION
This PR prevents ancient blocks sync restarting when the `IoChannelQueue` becomes full. This was causing some invalid old blocks to be inserted (see #9306). This fix was suggested by @tomusdrw:

1. Handle the QueueFull error
2. Just ignore the blocks that couldn't be imported
3. Re-try importing from the same point a bit later (hoping that the blocks in the queue were imported in the meantime)

*edit* Only partially addresses #9306. It prevents the sync from restarting from the `queue full` error, but it will still eventually retract back to genesis (see #9306 for explanation). 

@andresilva has a fix for this and will submit a follow up PR.



