### PR TITLE
ethcore: kovan: delay activation of strict score validation

### DIFF
--- a/ethcore/res/ethereum/kovan.json
+++ b/ethcore/res/ethereum/kovan.json
@@ -19,7 +19,7 @@
 						"0x00a0a24b9f0e5ec7aa4c7389b8302fd0123194de"
 					]
 				},
-				"validateScoreTransition": 1000000,
+				"validateScoreTransition": 4301764,
 				"validateStepTransition": 1500000,
 				"maximumUncleCountTransition": 5067000,
 				"maximumUncleCount": 0


### PR DESCRIPTION
Fix #9403.

Recently we added a stricter validation of block score for AuthorityRound chains (#9164). But in the past we had a race condition that lead to generating some blocks with invalid difficulty (#7198). Taking into account the date of that PR, it would be expected for the issue to not exist past around block #5000000 on Kovan. Still, I synced the chain, increasing the transition block every time I found an invalid block and the issue was rare enough that I think it explains why it seems to have stopped happening before the fix was released.

I'm currently syncing Kovan at around block #6000000 and haven't seen any block that fails validation past #4301764.