### PR TITLE
evmbin: Fix gas_used issue in state root mismatch and handle output better

### DIFF
--- a/evmbin/src/display/std_json.rs
+++ b/evmbin/src/display/std_json.rs
@@ -52,7 +52,7 @@ impl Writer for io::Stderr {
 }
 
 /// JSON formatting informant.
-pub struct Informant<Trace: Writer = io::Stderr, Out: Writer = io::Stdout> {
+pub struct Informant<Trace = io::Stderr, Out = io::Stdout> {
 	code: Vec<u8>,
 	instruction: u8,
 	depth: usize,

--- a/evmbin/src/display/std_json.rs
+++ b/evmbin/src/display/std_json.rs
@@ -28,44 +28,60 @@ use info as vm;
 
 pub trait Writer: io::Write + Send + Sized {
 	fn clone(&self) -> Self;
+	fn default() -> Self;
 }
 
 impl Writer for io::Stdout {
 	fn clone(&self) -> Self {
 		io::stdout()
 	}
+
+	fn default() -> Self {
+		io::stdout()
+	}
+}
+
+impl Writer for io::Stderr {
+	fn clone(&self) -> Self {
+		io::stderr()
+	}
+
+	fn default() -> Self {
+		io::stderr()
+	}
 }
 
 /// JSON formatting informant.
-pub struct Informant<T: Writer = io::Stdout> {
+pub struct Informant<Trace: Writer = io::Stderr, Out: Writer = io::Stdout> {
 	code: Vec<u8>,
 	instruction: u8,
 	depth: usize,
 	stack: Vec<U256>,
 	storage: HashMap<H256, H256>,
-	sink: T,
+	trace_sink: Trace,
+	out_sink: Out,
 }
 
 impl Default for Informant {
 	fn default() -> Self {
-		Self::new(io::stdout())
+		Self::new(io::stderr(), io::stdout())
 	}
 }
 
-impl<T: Writer> Informant<T> {
-	pub fn new(sink: T) -> Self {
+impl<Trace: Writer, Out: Writer> Informant<Trace, Out> {
+	pub fn new(trace_sink: Trace, out_sink: Out) -> Self {
 		Informant {
 			code: Default::default(),
 			instruction: Default::default(),
 			depth: Default::default(),
 			stack: Default::default(),
 			storage: Default::default(),
-			sink,
+			trace_sink, out_sink
 		}
 	}
 }
 
-impl<T: Writer> Informant<T> {
+impl<Trace: Writer, Out: Writer> Informant<Trace, Out> {
 	fn stack(&self) -> String {
 		let items = self.stack.iter().map(|i| format!("\"0x{:x}\"", i)).collect::<Vec<_>>();
 		format!("[{}]", items.join(","))
@@ -79,10 +95,10 @@ impl<T: Writer> Informant<T> {
 	}
 }
 
-impl<T: Writer> vm::Informant for Informant<T> {
+impl<Trace: Writer, Out: Writer> vm::Informant for Informant<Trace, Out> {
 	fn before_test(&mut self, name: &str, action: &str) {
 		writeln!(
-			&mut self.sink,
+			&mut self.out_sink,
 			"{{\"test\":\"{name}\",\"action\":\"{action}\"}}",
 			name = name,
 			action = action,
@@ -91,30 +107,38 @@ impl<T: Writer> vm::Informant for Informant<T> {
 
 	fn set_gas(&mut self, _gas: U256) {}
 
-	fn finish(result: vm::RunResult<Self::Output>) {
+	fn finish(result: vm::RunResult<<Self as trace::VMTracer>::Output>) {
+		let mut trace_sink = Trace::default();
+		let mut out_sink = Out::default();
+
 		match result {
 			Ok(success) => {
-				println!("{{\"stateRoot\":\"{:?}\"}}", success.state_root);
-				println!(
+				writeln!(
+					&mut trace_sink,
+					"{{\"stateRoot\":\"{:?}\"}}", success.state_root
+				).expect("The sink must be writeable.");
+				writeln!(
+					&mut out_sink,
 					"{{\"output\":\"0x{output}\",\"gasUsed\":\"0x{gas:x}\",\"time\":{time}}}",
 					output = success.output.to_hex(),
 					gas = success.gas_used,
 					time = display::as_micros(&success.time),
-				);
+				).expect("The sink must be writeable.");
 			},
 			Err(failure) => {
-				println!(
+				writeln!(
+					&mut out_sink,
 					"{{\"error\":\"{error}\",\"gasUsed\":\"0x{gas:x}\",\"time\":{time}}}",
 					error = failure.error,
 					gas = failure.gas_used,
 					time = display::as_micros(&failure.time),
-				)
+				).expect("The sink must be writeable.");
 			},
 		}
 	}
 }
 
-impl<T: Writer> trace::VMTracer for Informant<T> {
+impl<Trace: Writer, Out: Writer> trace::VMTracer for Informant<Trace, Out> {
 	type Output = ();
 
 	fn trace_next_instruction(&mut self, pc: usize, instruction: u8, current_gas: U256) -> bool {
@@ -124,7 +148,7 @@ impl<T: Writer> trace::VMTracer for Informant<T> {
 		let stack = self.stack();
 
 		writeln!(
-			&mut self.sink,
+			&mut self.trace_sink,
 			"{{\"pc\":{pc},\"op\":{op},\"opName\":\"{name}\",\"gas\":\"0x{gas:x}\",\"stack\":{stack},\"storage\":{storage},\"depth\":{depth}}}",
 			pc = pc,
 			op = instruction,
@@ -155,7 +179,7 @@ impl<T: Writer> trace::VMTracer for Informant<T> {
 	}
 
 	fn prepare_subtrace(&self, code: &[u8]) -> Self where Self: Sized {
-		let mut vm = Informant::new(self.sink.clone());
+		let mut vm = Informant::new(self.trace_sink.clone(), self.out_sink.clone());
 		vm.depth = self.depth + 1;
 		vm.code = code.to_vec();
 		vm

--- a/evmbin/src/display/std_json.rs
+++ b/evmbin/src/display/std_json.rs
@@ -96,7 +96,7 @@ impl<T: Writer> vm::Informant for Informant<T> {
 			Ok(success) => {
 				println!("{{\"stateRoot\":\"{:?}\"}}", success.state_root);
 				println!(
-					"{{\"output\":\"0x{output}\",\"gasUsed\":\"{gas:x}\",\"time\":{time}}}",
+					"{{\"output\":\"0x{output}\",\"gasUsed\":\"0x{gas:x}\",\"time\":{time}}}",
 					output = success.output.to_hex(),
 					gas = success.gas_used,
 					time = display::as_micros(&success.time),
@@ -104,7 +104,7 @@ impl<T: Writer> vm::Informant for Informant<T> {
 			},
 			Err(failure) => {
 				println!(
-					"{{\"error\":\"{error}\",\"gasUsed\":\"{gas:x}\",\"time\":{time}}}",
+					"{{\"error\":\"{error}\",\"gasUsed\":\"0x{gas:x}\",\"time\":{time}}}",
 					error = failure.error,
 					gas = failure.gas_used,
 					time = display::as_micros(&failure.time),

--- a/evmbin/src/display/std_json.rs
+++ b/evmbin/src/display/std_json.rs
@@ -201,6 +201,7 @@ pub mod tests {
 
 	impl Writer for TestWriter {
 		fn clone(&self) -> Self { Clone::clone(self) }
+		fn default() -> Self { Default::default() }
 	}
 
 	impl io::Write for TestWriter {
@@ -213,10 +214,11 @@ pub mod tests {
 		}
 	}
 
-	pub fn informant() -> (Informant<TestWriter>, Arc<Mutex<Vec<u8>>>) {
-		let writer = TestWriter::default();
-		let res = writer.0.clone();
-		(Informant::new(writer), res)
+	pub fn informant() -> (Informant<TestWriter, TestWriter>, Arc<Mutex<Vec<u8>>>) {
+		let trace_writer: TestWriter = Default::default();
+		let out_writer: TestWriter = Default::default();
+		let res = trace_writer.0.clone();
+		(Informant::new(trace_writer, out_writer), res)
 	}
 
 	#[test]


### PR DESCRIPTION
Fixes #9408

* When state root mismatch, prints the actual gas used instead of total gas.
* Output full hash of state root hashes in error message.
* Change `std_json` informant to have two sinks, one for traces (which default to stderr), and another for test results (which defaults to stdout).