### PR TITLE
aura: don't report skipped primaries when empty steps are enabled

### DIFF
--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -988,8 +988,10 @@ impl Engine<EthereumMachine> for AuthorityRound {
 					self.clear_empty_steps(parent_step);
 
 					// report any skipped primaries between the parent block and
-					// the block we're sealing
-					self.report_skipped(header, step, u64::from(parent_step) as usize, &*validators, set_number);
+					// the block we're sealing, unless we have empty steps enabled
+					if header.number() < self.empty_steps_transition {
+						self.report_skipped(header, step, u64::from(parent_step) as usize, &*validators, set_number);
+					}
 
 					let mut fields = vec![
 						encode(&step).into_vec(),


### PR DESCRIPTION
Fix #9325.

When empty steps are enabled we cannot report skipped primaries since we have no meaningful way to prove that the authority didn't actually broadcast an empty step message. This is already the existing behavior when verifying blocks (https://github.com/paritytech/parity-ethereum/blob/master/ethcore/src/engines/authority_round/mod.rs#L1146-L1180).