### PR TITLE
Beta backports to 2.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,7 +1930,7 @@ source = "git+https://github.com/paritytech/parity-common#0045887fecd2fec39e56c9
 name = "parity-clib"
 version = "1.12.0"
 dependencies = [
- "parity-ethereum 2.0.3",
+ "parity-ethereum 2.0.4",
 ]
 
 [[package]]
@@ -1947,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "parity-ethereum"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1996,7 +1996,7 @@ dependencies = [
  "parity-rpc 1.12.0",
  "parity-rpc-client 1.4.0",
  "parity-updater 1.12.0",
- "parity-version 2.0.3",
+ "parity-version 2.0.4",
  "parity-whisper 0.1.0",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "path 0.1.1 (git+https://github.com/paritytech/parity-common)",
@@ -2135,7 +2135,7 @@ dependencies = [
  "parity-crypto 0.1.0 (git+https://github.com/paritytech/parity-common)",
  "parity-reactor 0.1.0",
  "parity-updater 1.12.0",
- "parity-version 2.0.3",
+ "parity-version 2.0.4",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "patricia-trie 0.2.1 (git+https://github.com/paritytech/parity-common)",
  "plain_hasher 0.1.0 (git+https://github.com/paritytech/parity-common)",
@@ -2206,7 +2206,7 @@ dependencies = [
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (git+https://github.com/paritytech/parity-common)",
  "parity-hash-fetch 1.12.0",
- "parity-version 2.0.3",
+ "parity-version 2.0.4",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "path 0.1.1 (git+https://github.com/paritytech/parity-common)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "parity-bytes 0.1.0 (git+https://github.com/paritytech/parity-common)",
  "rlp 0.2.1 (git+https://github.com/paritytech/parity-common)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Parity Ethereum client"
 name = "parity-ethereum"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "2.0.3"
+version = "2.0.4"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1296,9 +1296,7 @@ impl snapshot::DatabaseRestore for Client {
 		let mut tracedb = self.tracedb.write();
 		self.importer.miner.clear();
 		let db = self.db.write();
-		db.key_value().restore(new_db)?;
-		db.blooms().reopen()?;
-		db.trace_blooms().reopen()?;
+		db.restore(new_db)?;
 
 		let cache_size = state_db.cache_size();
 		*state_db = StateDB::new(journaldb::new(db.key_value().clone(), self.pruning, ::db::COL_STATE), cache_size);

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -984,8 +984,10 @@ impl Engine<EthereumMachine> for AuthorityRound {
 					self.clear_empty_steps(parent_step);
 
 					// report any skipped primaries between the parent block and
-					// the block we're sealing
-					self.report_skipped(header, step, u64::from(parent_step) as usize, &*validators, set_number);
+					// the block we're sealing, unless we have empty steps enabled
+					if header.number() < self.empty_steps_transition {
+						self.report_skipped(header, step, u64::from(parent_step) as usize, &*validators, set_number);
+					}
 
 					let mut fields = vec![
 						encode(&step).into_vec(),

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -185,7 +185,7 @@ fn execute_light_impl(cmd: RunCmd, logger: Arc<RotatingLogger>) -> Result<Runnin
 	cmd.dirs.create_dirs(cmd.acc_conf.unlocked_accounts.len() == 0, cmd.secretstore_conf.enabled)?;
 
 	//print out running parity environment
-	print_running_environment(&spec.name, &cmd.dirs, &db_dirs);
+	print_running_environment(&spec.data_dir, &cmd.dirs, &db_dirs);
 
 	info!("Running in experimental {} mode.", Colour::Blue.bold().paint("Light Client"));
 
@@ -402,7 +402,7 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 	}
 
 	//print out running parity environment
-	print_running_environment(&spec.name, &cmd.dirs, &db_dirs);
+	print_running_environment(&spec.data_dir, &cmd.dirs, &db_dirs);
 
 	// display info about used pruning algorithm
 	info!("State DB configuration: {}{}{}",
@@ -926,9 +926,9 @@ fn daemonize(_pid_file: String) -> Result<(), String> {
 	Err("daemon is no supported on windows".into())
 }
 
-fn print_running_environment(spec_name: &String, dirs: &Directories, db_dirs: &DatabaseDirectories) {
+fn print_running_environment(data_dir: &str, dirs: &Directories, db_dirs: &DatabaseDirectories) {
 	info!("Starting {}", Colour::White.bold().paint(version()));
-	info!("Keys path {}", Colour::White.bold().paint(dirs.keys_path(spec_name).to_string_lossy().into_owned()));
+	info!("Keys path {}", Colour::White.bold().paint(dirs.keys_path(data_dir).to_string_lossy().into_owned()));
 	info!("DB path {}", Colour::White.bold().paint(db_dirs.db_root_path().to_string_lossy().into_owned()));
 }
 

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -741,7 +741,7 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 			let queue_info = self.client.queue_info();
 			let total_queue_size = queue_info.total_queue_size();
 
-			if is_major_importing(Some(sync_status.state), queue_info) || total_queue_size > MAX_QUEUE_SIZE_TO_MINE_ON {
+			if sync_status.is_snapshot_syncing() || total_queue_size > MAX_QUEUE_SIZE_TO_MINE_ON {
 				trace!(target: "miner", "Syncing. Cannot give any work.");
 				return Err(errors::no_work());
 			}

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -33,7 +33,7 @@ use ethcore::log_entry::LogEntry;
 use ethcore::miner::{self, MinerService};
 use ethcore::snapshot::SnapshotService;
 use ethcore::encoded;
-use sync::{SyncProvider};
+use sync::SyncProvider;
 use miner::external::ExternalMinerService;
 use transaction::{SignedTransaction, LocalizedTransaction};
 
@@ -52,7 +52,7 @@ use v1::types::{
 };
 use v1::metadata::Metadata;
 
-const EXTRA_INFO_PROOF: &'static str = "Object exists in blockchain (fetched earlier), extra_info is always available if object exists; qed";
+const EXTRA_INFO_PROOF: &str = "Object exists in blockchain (fetched earlier), extra_info is always available if object exists; qed";
 
 /// Eth RPC options
 pub struct EthClientOptions {
@@ -502,12 +502,16 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 	}
 
 	fn author(&self) -> Result<RpcH160> {
-		let mut miner = self.miner.authoring_params().author;
+		let miner = self.miner.authoring_params().author;
 		if miner == 0.into() {
-			miner = self.accounts.accounts().ok().and_then(|a| a.get(0).cloned()).unwrap_or_default();
+			self.accounts.accounts()
+				.ok()
+				.and_then(|a| a.first().cloned())
+				.map(From::from)
+				.ok_or_else(|| errors::account("No accounts were found", ""))
+		} else {
+			Ok(RpcH160::from(miner))
 		}
-
-		Ok(RpcH160::from(miner))
 	}
 
 	fn is_mining(&self) -> Result<bool> {

--- a/rpc/src/v1/impls/light/eth.rs
+++ b/rpc/src/v1/impls/light/eth.rs
@@ -253,7 +253,11 @@ impl<T: LightChainClient + 'static> Eth for EthClient<T> {
 	}
 
 	fn author(&self) -> Result<RpcH160> {
-		Ok(Default::default())
+		self.accounts.accounts()
+			.ok()
+			.and_then(|a| a.first().cloned())
+			.map(From::from)
+			.ok_or_else(|| errors::account("No accounts were found", ""))
 	}
 
 	fn is_mining(&self) -> Result<bool> {

--- a/rpc/src/v1/tests/mocked/eth.rs
+++ b/rpc/src/v1/tests/mocked/eth.rs
@@ -350,25 +350,27 @@ fn rpc_eth_author() {
 	let make_res = |addr| r#"{"jsonrpc":"2.0","result":""#.to_owned() + &format!("0x{:x}", addr) + r#"","id":1}"#;
 	let tester = EthTester::default();
 
-	let req = r#"{
+	let request = r#"{
 		"jsonrpc": "2.0",
 		"method": "eth_coinbase",
 		"params": [],
 		"id": 1
 	}"#;
 
-	// No accounts - returns zero
-	assert_eq!(tester.io.handle_request_sync(req), Some(make_res(Address::zero())));
+	let response = r#"{"jsonrpc":"2.0","error":{"code":-32023,"message":"No accounts were found","data":"\"\""},"id":1}"#;
+
+	// No accounts - returns an error indicating that no accounts were found
+	assert_eq!(tester.io.handle_request_sync(request), Some(response.to_string()));
 
 	// Account set - return first account
 	let addr = tester.accounts_provider.new_account(&"123".into()).unwrap();
-	assert_eq!(tester.io.handle_request_sync(req), Some(make_res(addr)));
+	assert_eq!(tester.io.handle_request_sync(request), Some(make_res(addr)));
 
 	for i in 0..20 {
 		let addr = tester.accounts_provider.new_account(&format!("{}", i).into()).unwrap();
 		tester.miner.set_author(addr.clone(), None).unwrap();
 
-		assert_eq!(tester.io.handle_request_sync(req), Some(make_res(addr)));
+		assert_eq!(tester.io.handle_request_sync(request), Some(make_res(addr)));
 	}
 }
 

--- a/util/blooms-db/src/lib.rs
+++ b/util/blooms-db/src/lib.rs
@@ -54,6 +54,11 @@ impl Database {
 		Ok(result)
 	}
 
+	/// Closes the inner database
+	pub fn close(&self) -> io::Result<()> {
+		self.database.lock().close()
+	}
+
 	/// Reopens database at the same location.
 	pub fn reopen(&self) -> io::Result<()> {
 		self.database.lock().reopen()

--- a/util/dir/src/lib.rs
+++ b/util/dir/src/lib.rs
@@ -128,9 +128,9 @@ impl Directories {
 	}
 
 	/// Get the keys path
-	pub fn keys_path(&self, spec_name: &str) -> PathBuf {
+	pub fn keys_path(&self, data_dir: &str) -> PathBuf {
 		let mut dir = PathBuf::from(&self.keys);
-		dir.push(spec_name);
+		dir.push(data_dir);
 		dir
 	}
 }

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for Parity version string (via env CARGO_PKG_VERSION)
-version = "2.0.3"
+version = "2.0.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 


### PR DESCRIPTION
- [x] parity-version: bump beta to 2.0.4
- [ ] ~~calculate gas_used of the transaction trace correctly, (#9194)~~
- [x] [light/jsonrpc] Provide the actual account for `eth_coinbase` RPC (#9383)
- [ ] ethcore: fix ancient block sync (#9407)
- [x] aura: don't report skipped primaries when empty steps are enabled (#9435)
- [x] Only check warp syncing for eth_getWorks (#9484)
- [x] Fix Snapshot restoration failure on Windows (#9491)
- [x] parity: print correct keys path on startup (#9501)