### PR TITLE
Bump snap rust version to latest stable channel.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,8 +30,7 @@ parts:
   parity:
     source: .
     plugin: rust
-  # rust-channel: stable  # @TODO enable after https://bugs.launchpad.net/snapcraft/+bug/1778530
-    rust-revision: 1.26.2 # @TODO remove after https://bugs.launchpad.net/snapcraft/+bug/1778530
+    rust-channel: stable
     build-attributes: [no-system-libraries]
     build-packages: [g++, libudev-dev, make, pkg-config, cmake]
     stage-packages: [libc6, libudev1, libstdc++6]


### PR DESCRIPTION
ref https://bugs.launchpad.net/snapcraft/+bug/1778530

versus https://gitlab.parity.io/parity/parity-ethereum/-/jobs/96635

:roll_eyes: 