### PR TITLE
Fix a bug in evmbin initial_gas display

### DIFF
--- a/evmbin/src/info.rs
+++ b/evmbin/src/info.rs
@@ -114,7 +114,7 @@ pub fn run_transaction<T: Informant>(
 
 	informant.set_gas(env_info.gas_limit);
 
-	let result = run(&spec, env_info.gas_limit, pre_state, |mut client| {
+	let result = run(&spec, transaction.gas, pre_state, |mut client| {
 		let result = client.transact(env_info, transaction, trace::NoopTracer, informant);
 		match result {
 			TransactResult::Ok { state_root, gas_left, .. } if state_root != post_root => {


### PR DESCRIPTION
`initial_gas` should be transaction gas limit, not block gas limit.