### PR TITLE
evmbin: escape newlines in json errors

### DIFF
--- a/evmbin/src/display/json.rs
+++ b/evmbin/src/display/json.rs
@@ -95,7 +95,7 @@ impl vm::Informant for Informant {
 
 				println!(
 					"{{\"error\":\"{error}\",\"gasUsed\":\"{gas:x}\",\"time\":{time}}}",
-					error = failure.error,
+					error = display::escape_newlines(&failure.error),
 					gas = failure.gas_used,
 					time = display::as_micros(&failure.time),
 				)

--- a/evmbin/src/display/mod.rs
+++ b/evmbin/src/display/mod.rs
@@ -31,3 +31,7 @@ pub fn format_time(time: &Duration) -> String {
 pub fn as_micros(time: &Duration) -> u64 {
 	time.as_secs() * 1_000_000 + time.subsec_nanos() as u64 / 1_000
 }
+
+fn escape_newlines<D: ::std::fmt::Display>(s: D) -> String {
+	format!("{}", s).replace("\r\n", "\n").replace('\n', "\\n")
+}

--- a/evmbin/src/display/std_json.rs
+++ b/evmbin/src/display/std_json.rs
@@ -129,7 +129,7 @@ impl<Trace: Writer, Out: Writer> vm::Informant for Informant<Trace, Out> {
 				writeln!(
 					&mut out_sink,
 					"{{\"error\":\"{error}\",\"gasUsed\":\"0x{gas:x}\",\"time\":{time}}}",
-					error = failure.error,
+					error = display::escape_newlines(&failure.error),
 					gas = failure.gas_used,
 					time = display::as_micros(&failure.time),
 				).expect("The sink must be writeable.");


### PR DESCRIPTION
Fixes #9456. 