### PR TITLE
ethcore: don't validate difficulty when ignoring seal check

### DIFF
--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -297,9 +297,11 @@ pub trait Engine<M: Machine>: Sync + Send {
 	fn verify_local_seal(&self, header: &M::Header) -> Result<(), M::Error>;
 
 	/// Phase 1 quick block verification. Only does checks that are cheap. Returns either a null `Ok` or a general error detailing the problem with import.
+	/// The verification module can optionally avoid checking the seal (`check_seal`), if seal verification is disabled this method won't be called.
 	fn verify_block_basic(&self, _header: &M::Header) -> Result<(), M::Error> { Ok(()) }
 
 	/// Phase 2 verification. Perform costly checks such as transaction signatures. Returns either a null `Ok` or a general error detailing the problem with import.
+	/// The verification module can optionally avoid checking the seal (`check_seal`), if seal verification is disabled this method won't be called.
 	fn verify_block_unordered(&self, _header: &M::Header) -> Result<(), M::Error> { Ok(()) }
 
 	/// Phase 3 verification. Check block information against parent. Returns either a null `Ok` or a general error detailing the problem with import.

--- a/ethcore/src/verification/queue/kind.rs
+++ b/ethcore/src/verification/queue/kind.rs
@@ -58,7 +58,7 @@ pub trait Kind: 'static + Sized + Send + Sync {
 	type Verified: Sized + Send + BlockLike + HeapSizeOf;
 
 	/// Attempt to create the `Unverified` item from the input.
-	fn create(input: Self::Input, engine: &EthEngine) -> Result<Self::Unverified, Error>;
+	fn create(input: Self::Input, engine: &EthEngine, check_seal: bool) -> Result<Self::Unverified, Error>;
 
 	/// Attempt to verify the `Unverified` item using the given engine.
 	fn verify(unverified: Self::Unverified, engine: &EthEngine, check_seal: bool) -> Result<Self::Verified, Error>;
@@ -86,8 +86,8 @@ pub mod blocks {
 		type Unverified = Unverified;
 		type Verified = PreverifiedBlock;
 
-		fn create(input: Self::Input, engine: &EthEngine) -> Result<Self::Unverified, Error> {
-			match verify_block_basic(&input, engine) {
+		fn create(input: Self::Input, engine: &EthEngine, check_seal: bool) -> Result<Self::Unverified, Error> {
+			match verify_block_basic(&input, engine, check_seal) {
 				Ok(()) => Ok(input),
 				Err(Error(ErrorKind::Block(BlockError::TemporarilyInvalid(oob)), _)) => {
 					debug!(target: "client", "Block received too early {}: {:?}", input.hash(), oob);
@@ -209,7 +209,7 @@ pub mod headers {
 		type Unverified = Header;
 		type Verified = Header;
 
-		fn create(input: Self::Input, engine: &EthEngine) -> Result<Self::Unverified, Error> {
+		fn create(input: Self::Input, engine: &EthEngine, _check_seal: bool) -> Result<Self::Unverified, Error> {
 			verify_header_params(&input, engine, true).map(|_| input)
 		}
 

--- a/ethcore/src/verification/queue/mod.rs
+++ b/ethcore/src/verification/queue/mod.rs
@@ -482,7 +482,7 @@ impl<K: Kind> VerificationQueue<K> {
 			}
 		}
 
-		match K::create(input, &*self.engine) {
+		match K::create(input, &*self.engine, self.verification.check_seal) {
 			Ok(item) => {
 				self.verification.sizes.unverified.fetch_add(item.heap_size_of_children(), AtomicOrdering::SeqCst);
 

--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -60,14 +60,19 @@ impl HeapSizeOf for PreverifiedBlock {
 }
 
 /// Phase 1 quick block verification. Only does checks that are cheap. Operates on a single block
-pub fn verify_block_basic(block: &Unverified, engine: &EthEngine) -> Result<(), Error> {
+pub fn verify_block_basic(block: &Unverified, engine: &EthEngine, check_seal: bool) -> Result<(), Error> {
 	verify_header_params(&block.header, engine, true)?;
 	verify_block_integrity(block)?;
-	engine.verify_block_basic(&block.header)?;
+
+	if check_seal {
+		engine.verify_block_basic(&block.header)?;
+	}
 
 	for uncle in &block.uncles {
 		verify_header_params(uncle, engine, false)?;
-		engine.verify_block_basic(uncle)?;
+		if check_seal {
+			engine.verify_block_basic(uncle)?;
+		}
 	}
 
 	for t in &block.transactions {

--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -501,7 +501,7 @@ mod tests {
 
 	fn basic_test(bytes: &[u8], engine: &EthEngine) -> Result<(), Error> {
 		let unverified = Unverified::from_rlp(bytes.to_vec())?;
-		verify_block_basic(&unverified, engine)
+		verify_block_basic(&unverified, engine, true)
 	}
 
 	fn family_test<BC>(bytes: &[u8], engine: &EthEngine, bc: &BC) -> Result<(), Error> where BC: BlockProvider {


### PR DESCRIPTION
Should fix #9461. We weren't validating the PoW itself but were immediately rejecting the block based on its difficulty.