### PR TITLE
Replace hardcoded JSON with serde json! macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,7 @@ dependencies = [
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]

--- a/evmbin/Cargo.toml
+++ b/evmbin/Cargo.toml
@@ -21,6 +21,7 @@ panic_hook = { path = "../util/panic_hook" }
 rustc-hex = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
+serde_json = "1.0"
 vm = { path = "../ethcore/vm" }
 
 [dev-dependencies]

--- a/evmbin/src/display/json.rs
+++ b/evmbin/src/display/json.rs
@@ -45,7 +45,7 @@ pub struct Informant {
 
 impl vm::Informant for Informant {
 	fn before_test(&mut self, name: &str, action: &str) {
-		println!("{}", json!({"action": action, "test": name}).to_string());
+		println!("{}", json!({"action": action, "test": name}));
 	}
 
 	fn set_gas(&mut self, gas: U256) {
@@ -65,7 +65,7 @@ impl vm::Informant for Informant {
 					"time": display::as_micros(&success.time),
 				});
 
-				println!("{}", success_msg.to_string())
+				println!("{}", success_msg)
 			},
 			Err(failure) => {
 				for trace in failure.traces.unwrap_or_else(Vec::new) {
@@ -78,7 +78,7 @@ impl vm::Informant for Informant {
 					"time": display::as_micros(&failure.time),
 				});
 
-				println!("{}", failure_msg.to_string())
+				println!("{}", failure_msg)
 			},
 		}
 	}

--- a/evmbin/src/display/json.rs
+++ b/evmbin/src/display/json.rs
@@ -61,7 +61,7 @@ impl vm::Informant for Informant {
 
 				let success_msg = json!({
 					"output": format!("0x{}", success.output.to_hex()),
-					"gasUsed": format!("0x{:x}", success.gas_used),
+					"gasUsed": format!("{:#x}", success.gas_used),
 					"time": display::as_micros(&success.time),
 				});
 
@@ -74,7 +74,7 @@ impl vm::Informant for Informant {
 
 				let failure_msg = json!({
 					"error": display::escape_newlines(&failure.error),
-					"gasUsed": format!("0x{:x}", failure.gas_used),
+					"gasUsed": format!("{:#x}", failure.gas_used),
 					"time": display::as_micros(&failure.time),
 				});
 
@@ -107,8 +107,8 @@ impl trace::VMTracer for Informant {
 			"pc": self.pc,
 			"op": self.instruction,
 			"opName": info.map(|i| i.name).unwrap_or(""),
-			"gas": format!("0x{:x}", gas_used.saturating_add(self.gas_cost)),
-			"gasCost": format!("0x{:x}", self.gas_cost),
+			"gas": format!("{:#x}", gas_used.saturating_add(self.gas_cost)),
+			"gasCost": format!("{:#x}", self.gas_cost),
 			"memory": format!("0x{}", self.memory.to_hex()),
 			"stack": self.stack,
 			"storage": self.storage,

--- a/evmbin/src/display/json.rs
+++ b/evmbin/src/display/json.rs
@@ -280,7 +280,20 @@ mod tests {
 {"pc":5,"op":88,"opName":"PC","gas":"0x2102","gasCost":"0x2","memory":"0x","stack":["0x0","0x0","0x0","0x0","0x0"],"storage":{},"depth":2}
 {"pc":6,"op":48,"opName":"ADDRESS","gas":"0x2100","gasCost":"0x2","memory":"0x","stack":["0x0","0x0","0x0","0x0","0x0","0x5"],"storage":{},"depth":2}
 {"pc":7,"op":241,"opName":"CALL","gas":"0x20fe","gasCost":"0x0","memory":"0x","stack":["0x0","0x0","0x0","0x0","0x0","0x5","0xbd770416a3345f91e4b34576cb804a576fa48eb1"],"storage":{},"depth":2}
-			"#,
+"#,
+		);
+
+		run_test(
+			Informant::default(),
+			&compare_json,
+			"3260D85554",
+			0xffff,
+			r#"
+{"pc":0,"op":50,"opName":"ORIGIN","gas":"0xffff","gasCost":"0x2","memory":"0x","stack":[],"storage":{},"depth":1}
+{"pc":1,"op":96,"opName":"PUSH1","gas":"0xfffd","gasCost":"0x3","memory":"0x","stack":["0x0"],"storage":{},"depth":1}
+{"pc":3,"op":85,"opName":"SSTORE","gas":"0xfffa","gasCost":"0x1388","memory":"0x","stack":["0x0","0xd8"],"storage":{},"depth":1}
+{"pc":4,"op":84,"opName":"SLOAD","gas":"0xec72","gasCost":"0x0","memory":"0x","stack":[],"storage":{"0x00000000000000000000000000000000000000000000000000000000000000d8":"0x0000000000000000000000000000000000000000000000000000000000000000"},"depth":1}
+"#,
 		)
 	}
 }

--- a/evmbin/src/display/json.rs
+++ b/evmbin/src/display/json.rs
@@ -73,7 +73,7 @@ impl vm::Informant for Informant {
 				}
 
 				let failure_msg = json!({
-					"error": display::escape_newlines(&failure.error),
+					"error": &failure.error.to_string(),
 					"gasUsed": format!("{:#x}", failure.gas_used),
 					"time": display::as_micros(&failure.time),
 				});

--- a/evmbin/src/display/json.rs
+++ b/evmbin/src/display/json.rs
@@ -43,31 +43,9 @@ pub struct Informant {
 	unmatched: bool,
 }
 
-impl Informant {
-	fn memory(&self) -> String {
-		format!("\"0x{}\"", self.memory.to_hex())
-	}
-
-	fn stack(&self) -> String {
-		let items = self.stack.iter().map(|i| format!("\"0x{:x}\"", i)).collect::<Vec<_>>();
-		format!("[{}]", items.join(","))
-	}
-
-	fn storage(&self) -> String {
-		let vals = self.storage.iter()
-			.map(|(k, v)| format!("\"0x{:?}\": \"0x{:?}\"", k, v))
-			.collect::<Vec<_>>();
-		format!("{{{}}}", vals.join(","))
-	}
-}
-
 impl vm::Informant for Informant {
 	fn before_test(&mut self, name: &str, action: &str) {
-		println!(
-			"{{\"test\":\"{name}\",\"action\":\"{action}\"}}",
-			name = name,
-			action = action,
-		);
+		println!("{}", json!({"action": action, "test": name}).to_string());
 	}
 
 	fn set_gas(&mut self, gas: U256) {
@@ -81,24 +59,26 @@ impl vm::Informant for Informant {
 					println!("{}", trace);
 				}
 
-				println!(
-					"{{\"output\":\"0x{output}\",\"gasUsed\":\"{gas:x}\",\"time\":{time}}}",
-					output = success.output.to_hex(),
-					gas = success.gas_used,
-					time = display::as_micros(&success.time),
-				)
+				let success_msg = json!({
+					"output": format!("0x{}", success.output.to_hex()),
+					"gasUsed": format!("0x{:x}", success.gas_used),
+					"time": display::as_micros(&success.time),
+				});
+
+				println!("{}", success_msg.to_string())
 			},
 			Err(failure) => {
 				for trace in failure.traces.unwrap_or_else(Vec::new) {
 					println!("{}", trace);
 				}
 
-				println!(
-					"{{\"error\":\"{error}\",\"gasUsed\":\"{gas:x}\",\"time\":{time}}}",
-					error = display::escape_newlines(&failure.error),
-					gas = failure.gas_used,
-					time = display::as_micros(&failure.time),
-				)
+				let failure_msg = json!({
+					"error": display::escape_newlines(&failure.error),
+					"gasUsed": format!("0x{:x}", failure.gas_used),
+					"time": display::as_micros(&failure.time),
+				});
+
+				println!("{}", failure_msg.to_string())
 			},
 		}
 	}
@@ -123,19 +103,19 @@ impl trace::VMTracer for Informant {
 	fn trace_executed(&mut self, gas_used: U256, stack_push: &[U256], mem_diff: Option<(usize, &[u8])>, store_diff: Option<(U256, U256)>) {
 		let info = ::evm::Instruction::from_u8(self.instruction).map(|i| i.info());
 
-		let trace = format!(
-			"{{\"pc\":{pc},\"op\":{op},\"opName\":\"{name}\",\"gas\":\"0x{gas:x}\",\"gasCost\":\"0x{gas_cost:x}\",\"memory\":{memory},\"stack\":{stack},\"storage\":{storage},\"depth\":{depth}}}",
-			pc = self.pc,
-			op = self.instruction,
-			name = info.map(|i| i.name).unwrap_or(""),
-			gas = gas_used.saturating_add(self.gas_cost),
-			gas_cost = self.gas_cost,
-			memory = self.memory(),
-			stack = self.stack(),
-			storage = self.storage(),
-			depth = self.depth,
-		);
-		self.traces.push(trace);
+		let trace = json!({
+			"pc": self.pc,
+			"op": self.instruction,
+			"opName": info.map(|i| i.name).unwrap_or(""),
+			"gas": format!("0x{:x}", gas_used.saturating_add(self.gas_cost)),
+			"gasCost": format!("0x{:x}", self.gas_cost),
+			"memory": format!("0x{}", self.memory.to_hex()),
+			"stack": self.stack,
+			"storage": self.storage,
+			"depth": self.depth,
+		});
+
+		self.traces.push(trace.to_string());
 
 		self.unmatched = false;
 		self.gas_used = gas_used;
@@ -193,6 +173,23 @@ impl trace::VMTracer for Informant {
 mod tests {
 	use super::*;
 	use info::tests::run_test;
+	use serde_json;
+
+	#[derive(Serialize, Deserialize, Debug, PartialEq)]
+	#[serde(rename_all = "camelCase")]
+	struct TestTrace {
+		pc: usize,
+		#[serde(rename = "op")]
+		instruction: u8,
+		op_name: String,
+		#[serde(rename = "gas")]
+		gas_used: U256,
+		gas_cost: U256,
+		memory: String,
+		stack: Vec<U256>,
+		storage: HashMap<H256, H256>,
+		depth: usize,
+	}
 
 	fn assert_traces_eq(
 		a: &[String],
@@ -204,7 +201,10 @@ mod tests {
 		loop {
 			match (ita.next(), itb.next()) {
 				(Some(a), Some(b)) => {
-					assert_eq!(a, b);
+					// Compare both without worrying about the order of the fields
+					let actual: TestTrace = serde_json::from_str(a).unwrap();
+					let expected: TestTrace = serde_json::from_str(b).unwrap();
+					assert_eq!(actual, expected);
 					println!("{}", a);
 				},
 				(None, None) => return,

--- a/evmbin/src/display/mod.rs
+++ b/evmbin/src/display/mod.rs
@@ -31,7 +31,3 @@ pub fn format_time(time: &Duration) -> String {
 pub fn as_micros(time: &Duration) -> u64 {
 	time.as_secs() * 1_000_000 + time.subsec_nanos() as u64 / 1_000
 }
-
-fn escape_newlines<D: ::std::fmt::Display>(s: D) -> String {
-	format!("{}", s).replace("\r\n", "\n").replace('\n', "\\n")
-}

--- a/evmbin/src/display/std_json.rs
+++ b/evmbin/src/display/std_json.rs
@@ -106,7 +106,7 @@ impl<Trace: Writer, Out: Writer> vm::Informant for Informant<Trace, Out> {
 
 				let out_data = json!({
 					"output": format!("0x{}", success.output.to_hex()),
-					"gasUsed": format!("0x{:x}", success.gas_used),
+					"gasUsed": format!("{:#x}", success.gas_used),
 					"time": display::as_micros(&success.time),
 				});
 
@@ -116,7 +116,7 @@ impl<Trace: Writer, Out: Writer> vm::Informant for Informant<Trace, Out> {
 			Err(failure) => {
 				let out_data = json!({
 					"error": display::escape_newlines(&failure.error),
-					"gasUsed": format!("0x{:x}", failure.gas_used),
+					"gasUsed": format!("{:#x}", failure.gas_used),
 					"time": display::as_micros(&failure.time),
 				});
 
@@ -137,7 +137,7 @@ impl<Trace: Writer, Out: Writer> trace::VMTracer for Informant<Trace, Out> {
 			"pc": pc,
 			"op": instruction,
 			"opName": info.map(|i| i.name).unwrap_or(""),
-			"gas": format!("0x{:x}", current_gas),
+			"gas": format!("{:#x}", current_gas),
 			"stack": self.stack,
 			"storage": self.storage,
 			"depth": self.depth,

--- a/evmbin/src/display/std_json.rs
+++ b/evmbin/src/display/std_json.rs
@@ -115,7 +115,7 @@ impl<Trace: Writer, Out: Writer> vm::Informant for Informant<Trace, Out> {
 			},
 			Err(failure) => {
 				let out_data = json!({
-					"error": display::escape_newlines(&failure.error),
+					"error": &failure.error.to_string(),
 					"gasUsed": format!("{:#x}", failure.gas_used),
 					"time": display::as_micros(&failure.time),
 				});

--- a/evmbin/src/display/std_json.rs
+++ b/evmbin/src/display/std_json.rs
@@ -219,8 +219,8 @@ pub mod tests {
 			},
 			"60F8d6",
 			0xffff,
-			r#"{"pc":0,"op":96,"opName":"PUSH1","gas":"0xffff","stack":[],"storage":{},"depth":1}
-{"pc":2,"op":214,"opName":"","gas":"0xfffc","stack":["0xf8"],"storage":{},"depth":1}
+			r#"{"depth":1,"gas":"0xffff","op":96,"opName":"PUSH1","pc":0,"stack":[],"storage":{}}
+{"depth":1,"gas":"0xfffc","op":214,"opName":"","pc":2,"stack":["0xf8"],"storage":{}}
 "#,
 		);
 
@@ -233,7 +233,7 @@ pub mod tests {
 			},
 			"F8d6",
 			0xffff,
-			r#"{"pc":0,"op":248,"opName":"","gas":"0xffff","stack":[],"storage":{},"depth":1}
+			r#"{"depth":1,"gas":"0xffff","op":248,"opName":"","pc":0,"stack":[],"storage":{}}
 "#,
 		);
 	}
@@ -249,30 +249,30 @@ pub mod tests {
 			},
 			"32343434345830f138343438323439f0",
 			0xffff,
-			r#"{"pc":0,"op":50,"opName":"ORIGIN","gas":"0xffff","stack":[],"storage":{},"depth":1}
-{"pc":1,"op":52,"opName":"CALLVALUE","gas":"0xfffd","stack":["0x0"],"storage":{},"depth":1}
-{"pc":2,"op":52,"opName":"CALLVALUE","gas":"0xfffb","stack":["0x0","0x0"],"storage":{},"depth":1}
-{"pc":3,"op":52,"opName":"CALLVALUE","gas":"0xfff9","stack":["0x0","0x0","0x0"],"storage":{},"depth":1}
-{"pc":4,"op":52,"opName":"CALLVALUE","gas":"0xfff7","stack":["0x0","0x0","0x0","0x0"],"storage":{},"depth":1}
-{"pc":5,"op":88,"opName":"PC","gas":"0xfff5","stack":["0x0","0x0","0x0","0x0","0x0"],"storage":{},"depth":1}
-{"pc":6,"op":48,"opName":"ADDRESS","gas":"0xfff3","stack":["0x0","0x0","0x0","0x0","0x0","0x5"],"storage":{},"depth":1}
-{"pc":7,"op":241,"opName":"CALL","gas":"0xfff1","stack":["0x0","0x0","0x0","0x0","0x0","0x5","0x0"],"storage":{},"depth":1}
-{"pc":8,"op":56,"opName":"CODESIZE","gas":"0x9e21","stack":["0x1"],"storage":{},"depth":1}
-{"pc":9,"op":52,"opName":"CALLVALUE","gas":"0x9e1f","stack":["0x1","0x10"],"storage":{},"depth":1}
-{"pc":10,"op":52,"opName":"CALLVALUE","gas":"0x9e1d","stack":["0x1","0x10","0x0"],"storage":{},"depth":1}
-{"pc":11,"op":56,"opName":"CODESIZE","gas":"0x9e1b","stack":["0x1","0x10","0x0","0x0"],"storage":{},"depth":1}
-{"pc":12,"op":50,"opName":"ORIGIN","gas":"0x9e19","stack":["0x1","0x10","0x0","0x0","0x10"],"storage":{},"depth":1}
-{"pc":13,"op":52,"opName":"CALLVALUE","gas":"0x9e17","stack":["0x1","0x10","0x0","0x0","0x10","0x0"],"storage":{},"depth":1}
-{"pc":14,"op":57,"opName":"CODECOPY","gas":"0x9e15","stack":["0x1","0x10","0x0","0x0","0x10","0x0","0x0"],"storage":{},"depth":1}
-{"pc":15,"op":240,"opName":"CREATE","gas":"0x9e0c","stack":["0x1","0x10","0x0","0x0"],"storage":{},"depth":1}
-{"pc":0,"op":50,"opName":"ORIGIN","gas":"0x210c","stack":[],"storage":{},"depth":2}
-{"pc":1,"op":52,"opName":"CALLVALUE","gas":"0x210a","stack":["0x0"],"storage":{},"depth":2}
-{"pc":2,"op":52,"opName":"CALLVALUE","gas":"0x2108","stack":["0x0","0x0"],"storage":{},"depth":2}
-{"pc":3,"op":52,"opName":"CALLVALUE","gas":"0x2106","stack":["0x0","0x0","0x0"],"storage":{},"depth":2}
-{"pc":4,"op":52,"opName":"CALLVALUE","gas":"0x2104","stack":["0x0","0x0","0x0","0x0"],"storage":{},"depth":2}
-{"pc":5,"op":88,"opName":"PC","gas":"0x2102","stack":["0x0","0x0","0x0","0x0","0x0"],"storage":{},"depth":2}
-{"pc":6,"op":48,"opName":"ADDRESS","gas":"0x2100","stack":["0x0","0x0","0x0","0x0","0x0","0x5"],"storage":{},"depth":2}
-{"pc":7,"op":241,"opName":"CALL","gas":"0x20fe","stack":["0x0","0x0","0x0","0x0","0x0","0x5","0xbd770416a3345f91e4b34576cb804a576fa48eb1"],"storage":{},"depth":2}
+			r#"{"depth":1,"gas":"0xffff","op":50,"opName":"ORIGIN","pc":0,"stack":[],"storage":{}}
+{"depth":1,"gas":"0xfffd","op":52,"opName":"CALLVALUE","pc":1,"stack":["0x0"],"storage":{}}
+{"depth":1,"gas":"0xfffb","op":52,"opName":"CALLVALUE","pc":2,"stack":["0x0","0x0"],"storage":{}}
+{"depth":1,"gas":"0xfff9","op":52,"opName":"CALLVALUE","pc":3,"stack":["0x0","0x0","0x0"],"storage":{}}
+{"depth":1,"gas":"0xfff7","op":52,"opName":"CALLVALUE","pc":4,"stack":["0x0","0x0","0x0","0x0"],"storage":{}}
+{"depth":1,"gas":"0xfff5","op":88,"opName":"PC","pc":5,"stack":["0x0","0x0","0x0","0x0","0x0"],"storage":{}}
+{"depth":1,"gas":"0xfff3","op":48,"opName":"ADDRESS","pc":6,"stack":["0x0","0x0","0x0","0x0","0x0","0x5"],"storage":{}}
+{"depth":1,"gas":"0xfff1","op":241,"opName":"CALL","pc":7,"stack":["0x0","0x0","0x0","0x0","0x0","0x5","0x0"],"storage":{}}
+{"depth":1,"gas":"0x9e21","op":56,"opName":"CODESIZE","pc":8,"stack":["0x1"],"storage":{}}
+{"depth":1,"gas":"0x9e1f","op":52,"opName":"CALLVALUE","pc":9,"stack":["0x1","0x10"],"storage":{}}
+{"depth":1,"gas":"0x9e1d","op":52,"opName":"CALLVALUE","pc":10,"stack":["0x1","0x10","0x0"],"storage":{}}
+{"depth":1,"gas":"0x9e1b","op":56,"opName":"CODESIZE","pc":11,"stack":["0x1","0x10","0x0","0x0"],"storage":{}}
+{"depth":1,"gas":"0x9e19","op":50,"opName":"ORIGIN","pc":12,"stack":["0x1","0x10","0x0","0x0","0x10"],"storage":{}}
+{"depth":1,"gas":"0x9e17","op":52,"opName":"CALLVALUE","pc":13,"stack":["0x1","0x10","0x0","0x0","0x10","0x0"],"storage":{}}
+{"depth":1,"gas":"0x9e15","op":57,"opName":"CODECOPY","pc":14,"stack":["0x1","0x10","0x0","0x0","0x10","0x0","0x0"],"storage":{}}
+{"depth":1,"gas":"0x9e0c","op":240,"opName":"CREATE","pc":15,"stack":["0x1","0x10","0x0","0x0"],"storage":{}}
+{"depth":2,"gas":"0x210c","op":50,"opName":"ORIGIN","pc":0,"stack":[],"storage":{}}
+{"depth":2,"gas":"0x210a","op":52,"opName":"CALLVALUE","pc":1,"stack":["0x0"],"storage":{}}
+{"depth":2,"gas":"0x2108","op":52,"opName":"CALLVALUE","pc":2,"stack":["0x0","0x0"],"storage":{}}
+{"depth":2,"gas":"0x2106","op":52,"opName":"CALLVALUE","pc":3,"stack":["0x0","0x0","0x0"],"storage":{}}
+{"depth":2,"gas":"0x2104","op":52,"opName":"CALLVALUE","pc":4,"stack":["0x0","0x0","0x0","0x0"],"storage":{}}
+{"depth":2,"gas":"0x2102","op":88,"opName":"PC","pc":5,"stack":["0x0","0x0","0x0","0x0","0x0"],"storage":{}}
+{"depth":2,"gas":"0x2100","op":48,"opName":"ADDRESS","pc":6,"stack":["0x0","0x0","0x0","0x0","0x0","0x5"],"storage":{}}
+{"depth":2,"gas":"0x20fe","op":241,"opName":"CALL","pc":7,"stack":["0x0","0x0","0x0","0x0","0x0","0x5","0xbd770416a3345f91e4b34576cb804a576fa48eb1"],"storage":{}}
 "#,
 		)
 	}

--- a/evmbin/src/display/std_json.rs
+++ b/evmbin/src/display/std_json.rs
@@ -88,8 +88,7 @@ impl<Trace: Writer, Out: Writer> vm::Informant for Informant<Trace, Out> {
 			"test": name,
 		});
 
-		writeln!(&mut self.out_sink, "{}", out_data.to_string())
-			.expect("The sink must be writeable.");
+		writeln!(&mut self.out_sink, "{}", out_data).expect("The sink must be writeable.");
 	}
 
 	fn set_gas(&mut self, _gas: U256) {}
@@ -101,7 +100,7 @@ impl<Trace: Writer, Out: Writer> vm::Informant for Informant<Trace, Out> {
 		match result {
 			Ok(success) => {
 				let trace_data = json!({"stateRoot": success.state_root});
-				writeln!(&mut trace_sink, "{}", trace_data.to_string())
+				writeln!(&mut trace_sink, "{}", trace_data)
 					.expect("The sink must be writeable.");
 
 				let out_data = json!({
@@ -110,8 +109,7 @@ impl<Trace: Writer, Out: Writer> vm::Informant for Informant<Trace, Out> {
 					"time": display::as_micros(&success.time),
 				});
 
-				writeln!(&mut out_sink, "{}", out_data.to_string())
-					.expect("The sink must be writeable.");
+				writeln!(&mut out_sink, "{}", out_data).expect("The sink must be writeable.");
 			},
 			Err(failure) => {
 				let out_data = json!({
@@ -120,8 +118,7 @@ impl<Trace: Writer, Out: Writer> vm::Informant for Informant<Trace, Out> {
 					"time": display::as_micros(&failure.time),
 				});
 
-				writeln!(&mut out_sink, "{}", out_data.to_string())
-					.expect("The sink must be writeable.");
+				writeln!(&mut out_sink, "{}", out_data).expect("The sink must be writeable.");
 			},
 		}
 	}
@@ -143,8 +140,7 @@ impl<Trace: Writer, Out: Writer> trace::VMTracer for Informant<Trace, Out> {
 			"depth": self.depth,
 		});
 
-		writeln!(&mut self.trace_sink, "{}", trace_data.to_string())
-			.expect("The sink must be writeable.");
+		writeln!(&mut self.trace_sink, "{}", trace_data).expect("The sink must be writeable.");
 
 		true
 	}

--- a/evmbin/src/info.rs
+++ b/evmbin/src/info.rs
@@ -225,16 +225,16 @@ pub mod tests {
 
 		assert_eq!(
 			&String::from_utf8_lossy(&**res.lock().unwrap()),
-r#"{"pc":0,"op":98,"opName":"PUSH3","gas":"0xffff","stack":[],"storage":{},"depth":1}
-{"pc":4,"op":96,"opName":"PUSH1","gas":"0xfffc","stack":["0xaaaaaa"],"storage":{},"depth":1}
-{"pc":6,"op":96,"opName":"PUSH1","gas":"0xfff9","stack":["0xaaaaaa","0xaa"],"storage":{},"depth":1}
-{"pc":8,"op":80,"opName":"POP","gas":"0xfff6","stack":["0xaaaaaa","0xaa","0xaa"],"storage":{},"depth":1}
-{"pc":9,"op":96,"opName":"PUSH1","gas":"0xfff4","stack":["0xaaaaaa","0xaa"],"storage":{},"depth":1}
-{"pc":11,"op":96,"opName":"PUSH1","gas":"0xfff1","stack":["0xaaaaaa","0xaa","0xaa"],"storage":{},"depth":1}
-{"pc":13,"op":96,"opName":"PUSH1","gas":"0xffee","stack":["0xaaaaaa","0xaa","0xaa","0xaa"],"storage":{},"depth":1}
-{"pc":15,"op":96,"opName":"PUSH1","gas":"0xffeb","stack":["0xaaaaaa","0xaa","0xaa","0xaa","0xaa"],"storage":{},"depth":1}
-{"pc":17,"op":96,"opName":"PUSH1","gas":"0xffe8","stack":["0xaaaaaa","0xaa","0xaa","0xaa","0xaa","0xaa"],"storage":{},"depth":1}
-{"pc":19,"op":96,"opName":"PUSH1","gas":"0xffe5","stack":["0xaaaaaa","0xaa","0xaa","0xaa","0xaa","0xaa","0xaa"],"storage":{},"depth":1}
+r#"{"depth":1,"gas":"0xffff","op":98,"opName":"PUSH3","pc":0,"stack":[],"storage":{}}
+{"depth":1,"gas":"0xfffc","op":96,"opName":"PUSH1","pc":4,"stack":["0xaaaaaa"],"storage":{}}
+{"depth":1,"gas":"0xfff9","op":96,"opName":"PUSH1","pc":6,"stack":["0xaaaaaa","0xaa"],"storage":{}}
+{"depth":1,"gas":"0xfff6","op":80,"opName":"POP","pc":8,"stack":["0xaaaaaa","0xaa","0xaa"],"storage":{}}
+{"depth":1,"gas":"0xfff4","op":96,"opName":"PUSH1","pc":9,"stack":["0xaaaaaa","0xaa"],"storage":{}}
+{"depth":1,"gas":"0xfff1","op":96,"opName":"PUSH1","pc":11,"stack":["0xaaaaaa","0xaa","0xaa"],"storage":{}}
+{"depth":1,"gas":"0xffee","op":96,"opName":"PUSH1","pc":13,"stack":["0xaaaaaa","0xaa","0xaa","0xaa"],"storage":{}}
+{"depth":1,"gas":"0xffeb","op":96,"opName":"PUSH1","pc":15,"stack":["0xaaaaaa","0xaa","0xaa","0xaa","0xaa"],"storage":{}}
+{"depth":1,"gas":"0xffe8","op":96,"opName":"PUSH1","pc":17,"stack":["0xaaaaaa","0xaa","0xaa","0xaa","0xaa","0xaa"],"storage":{}}
+{"depth":1,"gas":"0xffe5","op":96,"opName":"PUSH1","pc":19,"stack":["0xaaaaaa","0xaa","0xaa","0xaa","0xaa","0xaa","0xaa"],"storage":{}}
 "#);
 	}
 }

--- a/evmbin/src/main.rs
+++ b/evmbin/src/main.rs
@@ -24,6 +24,8 @@ extern crate rustc_hex;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate serde_json;
 extern crate docopt;
 extern crate ethcore_transaction as transaction;
 extern crate parity_bytes as bytes;


### PR DESCRIPTION
Looks to address #9459.

I'm having a problem getting the tests to pass though, and could use some suggestions. The json! macro creates JSON with all the fields in alphabetical order. This is causing three of the evmbin tests to fail since the expected tests strings are not in the same order. 

This is from one of the failed tests (`should_trace_failure`). You can see all the fields are correctly serialized, just in the "wrong" order.

```
"{\"pc\":0,\"op\":96,\"opName\":\"PUSH1\",\"gas\":\"0xffff\",\"stack\":[],\"storage\":{},\"depth\":1}\n
{\"pc\":2,\"op\":214,\"opName\":\"\",\"gas\":\"0xfffc\",\"stack\":[\"0xf8\"],\"storage\":{},\"depth\":1}\n"

"{\"depth\":1,\"gas\":\"0xffff\",\"op\":96,\"opName\":\"PUSH1\",\"pc\":0,\"stack\":[],\"storage\":{}\n
{\"depth\":1,\"gas\":\"0xfffc\",\"op\":214,\"opName\":\"\",\"pc\":2,\"stack\":[\"0xf8\"],\"storage\":{}}\n"
```

I can change the fields of the raw test strings to be in alphabetical order and get the tests to pass, but that seems like a hack since the order of JSON fields shouldn't matter. 