### PR TITLE
ci: fix rpc docs generation

### DIFF
--- a/scripts/gitlab/rpc-docs.sh
+++ b/scripts/gitlab/rpc-docs.sh
@@ -42,9 +42,12 @@ upload_files() {
     git push --tags
 }
 
+RPC_TRAITS_DIR="rpc/src/v1/traits/"
+
 setup_git
 clone_repos
-cp -r parity/ jsonrpc/.parity/
+mkdir -p "jsonrpc/.parity/$RPC_TRAITS_DIR"
+cp -r "$RPC_TRAITS_DIR" "jsonrpc/.parity/$RPC_TRAITS_DIR"
 cd jsonrpc
 build_docs
 cd ..


### PR DESCRIPTION
Looks like #8765 was out of sync with #9219 causing https://gitlab.parity.io/parity/parity-ethereum/-/jobs/97484. This fix copies only needed dir instead of the whole repo.
