### PR TITLE
Bump master to 2.2.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -256,7 +256,7 @@ publish-linux-snap-armhf:
 
 publish-docker-parity-amd64: &publish_docker
   stage:                           publish
-  only:                            *publishable_branches
+  only:                            *releaseable_branches
   cache: {}
   dependencies:
     - build-linux-ubuntu-amd64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2004,7 +2004,7 @@ version = "1.12.0"
 dependencies = [
  "jni 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic_hook 0.1.0",
- "parity-ethereum 2.1.0",
+ "parity-ethereum 2.2.0",
 ]
 
 [[package]]
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "parity-ethereum"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2070,7 +2070,7 @@ dependencies = [
  "parity-rpc 1.12.0",
  "parity-rpc-client 1.4.0",
  "parity-updater 1.12.0",
- "parity-version 2.1.0",
+ "parity-version 2.2.0",
  "parity-whisper 0.1.0",
  "parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2235,7 +2235,7 @@ dependencies = [
  "parity-crypto 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-reactor 0.1.0",
  "parity-updater 1.12.0",
- "parity-version 2.1.0",
+ "parity-version 2.2.0",
  "parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "patricia-trie 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2325,7 +2325,7 @@ dependencies = [
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-hash-fetch 1.12.0",
  "parity-path 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-version 2.1.0",
+ "parity-version 2.2.0",
  "parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fs-swap"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1558,7 +1558,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "elastic-array 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fs-swap 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "interleaved-ordered 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3969,7 +3969,7 @@ dependencies = [
 "checksum fixed-hash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d5ec8112f00ea8a483e04748a85522184418fd1cf02890b626d8fc28683f7de"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum fs-swap 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67f816b2a5f8a6628764a4323d1a8d9ad5303266c4e4e4486ba680f477ba7e62"
+"checksum fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "921d332c89b3b61a826de38c61ee5b6e02c56806cade1b0e5d81bd71f57a71bb"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "884dbe32a6ae4cd7da5c6db9b78114449df9953b8d490c9d7e1b51720b922c62"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Parity Ethereum client"
 name = "parity-ethereum"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "2.1.0"
+version = "2.2.0"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 

--- a/scripts/gitlab/package-snap.sh
+++ b/scripts/gitlab/package-snap.sh
@@ -3,9 +3,9 @@
 set -e # fail on any error
 set -u # treat unset variables as error
 case ${CI_COMMIT_REF_NAME} in
-  nightly|*v2.1*) export GRADE="devel";;
-  beta|*v2.0*) export GRADE="stable";;
-  stable|*v1.11*) export GRADE="stable";;
+  nightly|*v2.2*) export GRADE="devel";;
+  beta|*v2.1*) export GRADE="stable";;
+  stable|*v2.0*) export GRADE="stable";;
   *) echo "No release" exit 0;;
 esac
 SNAP_PACKAGE="parity_"$VERSION"_"$BUILD_ARCH".snap"

--- a/scripts/gitlab/publish-docker.sh
+++ b/scripts/gitlab/publish-docker.sh
@@ -3,7 +3,7 @@
 set -e # fail on any error
 set -u # treat unset variables as error
 
-if [ "$CI_COMMIT_REF_NAME" == "beta" ];
+if [ "$CI_COMMIT_REF_NAME" == "master" ];
 then export DOCKER_BUILD_TAG="latest";
 else export DOCKER_BUILD_TAG=$CI_COMMIT_REF_NAME;
 fi

--- a/scripts/gitlab/publish-snap.sh
+++ b/scripts/gitlab/publish-snap.sh
@@ -4,9 +4,9 @@ set -e # fail on any error
 set -u # treat unset variables as error
 
 case ${CI_COMMIT_REF_NAME} in
-  nightly|*v2.1*) export CHANNEL="edge";;
-  beta|*v2.0*) export CHANNEL="beta";;
-  stable|*v1.11*) export CHANNEL="stable";;
+  nightly|*v2.2*) export CHANNEL="edge";;
+  beta|*v2.1*) export CHANNEL="beta";;
+  stable|*v2.0*) export CHANNEL="stable";;
   *) echo "No release" exit 0;;
 esac
 echo "Release channel :" $CHANNEL " Branch/tag: " $CI_COMMIT_REF_NAME

--- a/scripts/gitlab/push.sh
+++ b/scripts/gitlab/push.sh
@@ -14,9 +14,9 @@ RELEASE_TABLE="$(echo "${RELEASE_TABLE//\$VERSION/${VERSION}}")"
 #The text in the file CANGELOG.md before which the table with links is inserted. Must be present in this file necessarily
 REPLACE_TEXT="The full list of included changes:"
 case ${CI_COMMIT_REF_NAME} in
-  nightly|*v2.1*) NAME="Parity "$VERSION" nightly";;
-  beta|*v2.0*) NAME="Parity "$VERSION" beta";;
-  stable|*v1.11*) NAME="Parity "$VERSION" stable";;
+  nightly|*v2.2*) NAME="Parity "$VERSION" nightly";;
+  beta|*v2.1*) NAME="Parity "$VERSION" beta";;
+  stable|*v2.0*) NAME="Parity "$VERSION" stable";;
   *) echo "No release" exit 0;;
 esac
 cd artifacts

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for Parity Ethereum version string (via env CARGO_PKG_VERSION)
-version = "2.1.0"
+version = "2.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 


### PR DESCRIPTION
- [x] parity-version: bump master to 2.2.0
- [x] ci: update branch version references
- [x] docker: release master to latest
- [x] deps: bump fs-swap to 0.2.4 ref https://github.com/debris/fs-swap/pull/8