### PR TITLE
Backports for 2.1.0 beta

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -256,7 +256,7 @@ publish-linux-snap-armhf:
 
 publish-docker-parity-amd64: &publish_docker
   stage:                           publish
-  only:                            *publishable_branches
+  only:                            *releaseable_branches
   cache: {}
   dependencies:
     - build-linux-ubuntu-amd64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/scripts/gitlab/package-snap.sh
+++ b/scripts/gitlab/package-snap.sh
@@ -3,9 +3,9 @@
 set -e # fail on any error
 set -u # treat unset variables as error
 case ${CI_COMMIT_REF_NAME} in
-  nightly|*v2.1*) export GRADE="devel";;
-  beta|*v2.0*) export GRADE="stable";;
-  stable|*v1.11*) export GRADE="stable";;
+  nightly|*v2.2*) export GRADE="devel";;
+  beta|*v2.1*) export GRADE="stable";;
+  stable|*v2.0*) export GRADE="stable";;
   *) echo "No release" exit 0;;
 esac
 SNAP_PACKAGE="parity_"$VERSION"_"$BUILD_ARCH".snap"

--- a/scripts/gitlab/publish-docker.sh
+++ b/scripts/gitlab/publish-docker.sh
@@ -3,7 +3,7 @@
 set -e # fail on any error
 set -u # treat unset variables as error
 
-if [ "$CI_COMMIT_REF_NAME" == "beta" ];
+if [ "$CI_COMMIT_REF_NAME" == "master" ];
 then export DOCKER_BUILD_TAG="latest";
 else export DOCKER_BUILD_TAG=$CI_COMMIT_REF_NAME;
 fi

--- a/scripts/gitlab/publish-snap.sh
+++ b/scripts/gitlab/publish-snap.sh
@@ -4,9 +4,9 @@ set -e # fail on any error
 set -u # treat unset variables as error
 
 case ${CI_COMMIT_REF_NAME} in
-  nightly|*v2.1*) export CHANNEL="edge";;
-  beta|*v2.0*) export CHANNEL="beta";;
-  stable|*v1.11*) export CHANNEL="stable";;
+  nightly|*v2.2*) export CHANNEL="edge";;
+  beta|*v2.1*) export CHANNEL="beta";;
+  stable|*v2.0*) export CHANNEL="stable";;
   *) echo "No release" exit 0;;
 esac
 echo "Release channel :" $CHANNEL " Branch/tag: " $CI_COMMIT_REF_NAME

--- a/scripts/gitlab/push.sh
+++ b/scripts/gitlab/push.sh
@@ -14,9 +14,9 @@ RELEASE_TABLE="$(echo "${RELEASE_TABLE//\$VERSION/${VERSION}}")"
 #The text in the file CANGELOG.md before which the table with links is inserted. Must be present in this file necessarily
 REPLACE_TEXT="The full list of included changes:"
 case ${CI_COMMIT_REF_NAME} in
-  nightly|*v2.1*) NAME="Parity "$VERSION" nightly";;
-  beta|*v2.0*) NAME="Parity "$VERSION" beta";;
-  stable|*v1.11*) NAME="Parity "$VERSION" stable";;
+  nightly|*v2.2*) NAME="Parity "$VERSION" nightly";;
+  beta|*v2.1*) NAME="Parity "$VERSION" beta";;
+  stable|*v2.0*) NAME="Parity "$VERSION" stable";;
   *) echo "No release" exit 0;;
 esac
 cd artifacts

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -10,7 +10,7 @@ build = "build.rs"
 [package.metadata]
 # This versions track. Should be changed to `stable` or `beta` when on respective branches.
 # Used by auto-updater and for Parity version string.
-track = "nightly"
+track = "beta"
 
 # Network specific settings, used ONLY by auto-updater.
 # Latest supported fork blocks.


### PR DESCRIPTION
- [x] parity-version: mark 2.1.0 track beta
- [x] ci: update branch version references
- [x] docker: release master to latest
- [ ] Keep existing blocks when restoring a Snapshot (#8643)
- [ ] AuthorityRound: finalize blocks (#9113)
- [ ] ethcore: fix ancient block sync (#9407)
- [ ] Enable all Constantinople hard fork changes in constantinople_test.json (#9505)
- [ ] Fix checkpointing when creating contract failed (#9514)
- [ ] ci: fix rpc docs generation (#9515)
- [ ] fix typo in version string (#9516)
