### PR TITLE
Fix a panic on create2 new opcode

### DIFF
--- a/ethcore/evm/src/interpreter/gasometer.rs
+++ b/ethcore/evm/src/interpreter/gasometer.rs
@@ -233,11 +233,7 @@ impl<Gas: evm::CostType> Gasometer<Gas> {
 			},
 			instructions::CREATE | instructions::CREATE2 => {
 				let gas = Gas::from(schedule.create_gas);
-				let mem = match instruction {
-					instructions::CREATE => mem_needed(stack.peek(1), stack.peek(2))?,
-					instructions::CREATE2 => mem_needed(stack.peek(2), stack.peek(3))?,
-					_ => unreachable!("instruction can only be CREATE/CREATE2 checked above; qed"),
-				};
+				let mem = mem_needed(stack.peek(1), stack.peek(2))?;
 
 				Request::GasMemProvide(gas, mem, None)
 			},


### PR DESCRIPTION
Memory calculation for create2 is the same as for create because the additional parameter was popped before.

Alternate fix would be to stop poping the salt in interpreter `exec_instruction` function. This is a bit more robust (this fix only is fine if `exec_instruction` is called before the `requirement` call), but require more change to fix.

I did not add a test case because it is covered by src/GeneralStateTestsFiller/stCreate2/create2InitCodesFiller.json of ethereum/tests. 

Please note that this json test case does not currently run in our CI (constantinople test case are not yet all running).