### PR TITLE
ci: always run build pipelines for win, mac, linux, and android

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,19 +141,23 @@ build-linux-ubuntu-armhf:
     - rust-arm
 
 build-linux-android-armhf:
-  <<:                              *build
+  stage:                           build
   image:                           parity/rust-android:gitlab-ci
   variables:
     CARGO_TARGET:                  armv7-linux-androideabi
+  script:
+    - scripts/gitlab/build-unix.sh
   tags:
     - rust-arm
 
 build-darwin-macos-x86_64:
-  <<:                              *build
+  stage:                           build
   variables:
     CARGO_TARGET:                  x86_64-apple-darwin
     CC:                            gcc
     CXX:                           g++
+  script:
+    - scripts/gitlab/build-unix.sh
   tags:
     - osx
   <<:                              *collect_artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,7 +142,6 @@ build-linux-ubuntu-armhf:
 
 build-linux-android-armhf:
   <<:                              *build
-  only:                            *releaseable_branches
   image:                           parity/rust-android:gitlab-ci
   variables:
     CARGO_TARGET:                  armv7-linux-androideabi
@@ -161,7 +160,6 @@ build-darwin-macos-x86_64:
 
 build-windows-msvc-x86_64:
   stage:                           build
-  only:                            *releaseable_branches
   cache:
     key:                           "%CI_JOB_NAME%"
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,7 +111,6 @@ build-linux-ubuntu-amd64:          &build
   <<:                              *collect_artifacts
   tags:
     - rust-stable
-  allow_failure: true
 
 build-linux-ubuntu-i386:
   <<:                              *build
@@ -263,7 +262,6 @@ publish-docker-parity-amd64: &publish_docker
     - build-linux-ubuntu-amd64
   tags:
     - shell
-  allow_failure:                   true
   script:
     - scripts/gitlab/publish-docker.sh parity
 
@@ -288,7 +286,6 @@ publish-github-and-s3:
     - scripts/gitlab/push.sh
   tags:
     - shell
-  allow_failure:                   true
 
 
 ####stage:                          docs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,7 +104,6 @@ test-coverage-kcov:
 
 build-linux-ubuntu-amd64:          &build
   stage:                           build
-  only:                            *releaseable_branches
   variables:
     CARGO_TARGET:                  x86_64-unknown-linux-gnu
   script:
@@ -116,6 +115,7 @@ build-linux-ubuntu-amd64:          &build
 
 build-linux-ubuntu-i386:
   <<:                              *build
+  only:                            *releaseable_branches
   image:                           parity/rust-i686:gitlab-ci
   variables:
     CARGO_TARGET:                  i686-unknown-linux-gnu
@@ -124,6 +124,7 @@ build-linux-ubuntu-i386:
 
 build-linux-ubuntu-arm64:
   <<:                              *build
+  only:                            *releaseable_branches
   image:                           parity/rust-arm64:gitlab-ci
   variables:
     CARGO_TARGET:                  aarch64-unknown-linux-gnu
@@ -132,6 +133,7 @@ build-linux-ubuntu-arm64:
 
 build-linux-ubuntu-armhf:
   <<:                              *build
+  only:                            *releaseable_branches
   image:                           parity/rust-armv7:gitlab-ci
   variables:
     CARGO_TARGET:                  armv7-unknown-linux-gnueabihf
@@ -140,6 +142,7 @@ build-linux-ubuntu-armhf:
 
 build-linux-android-armhf:
   <<:                              *build
+  only:                            *releaseable_branches
   image:                           parity/rust-android:gitlab-ci
   variables:
     CARGO_TARGET:                  armv7-linux-androideabi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,6 +104,7 @@ test-coverage-kcov:
 
 build-linux-ubuntu-amd64:          &build
   stage:                           build
+  only:                            *releaseable_branches
   variables:
     CARGO_TARGET:                  x86_64-unknown-linux-gnu
   script:

--- a/scripts/gitlab/test.sh
+++ b/scripts/gitlab/test.sh
@@ -6,7 +6,7 @@ set -u # treat unset variables as error
 
 rustup default $1
 
-if [[ "$CI_COMMIT_REF_NAME" = "beta" || "$CI_COMMIT_REF_NAME" = "stable" ]]; then
+if [[ "$CI_COMMIT_REF_NAME" = "master" || "$CI_COMMIT_REF_NAME" = "beta" || "$CI_COMMIT_REF_NAME" = "stable" ]]; then
   export GIT_COMPARE=$CI_COMMIT_REF_NAME~;
 else
   export GIT_COMPARE=master;

--- a/scripts/gitlab/test.sh
+++ b/scripts/gitlab/test.sh
@@ -19,7 +19,7 @@ git submodule update --init --recursive
 rustup show
 if [[ "${RUST_FILES_MODIFIED}" == "0" ]];
 then echo "__________Skipping Rust tests since no Rust files modified__________";
-else ./test.sh --no-release || exit $?;
+else ./test.sh || exit $?;
 fi
 
 # if [[ "$CI_COMMIT_REF_NAME" == "nightly" ]];

--- a/scripts/gitlab/test.sh
+++ b/scripts/gitlab/test.sh
@@ -19,7 +19,7 @@ git submodule update --init --recursive
 rustup show
 if [[ "${RUST_FILES_MODIFIED}" == "0" ]];
 then echo "__________Skipping Rust tests since no Rust files modified__________";
-else ./test.sh || exit $?;
+else ./test.sh --no-release || exit $?;
 fi
 
 # if [[ "$CI_COMMIT_REF_NAME" == "nightly" ]];


### PR DESCRIPTION
- Runs build pipelines for windows, macos, and android on every PR in addition to the test suite on linux.
- ~~Runs test pipelines in debug mode to speed up things.~~
- Enable tests on master :roll_eyes: 
