### PR TITLE
net_version caches network_id to avoid redundant aquire of sync read lock

### DIFF
--- a/rpc/src/v1/impls/net.rs
+++ b/rpc/src/v1/impls/net.rs
@@ -22,7 +22,12 @@ use v1::traits::Net;
 
 /// Net rpc implementation.
 pub struct NetClient<S: ?Sized> {
-	sync: Arc<S>
+	sync: Arc<S>,
+	/// Cached `network_id`.
+	///
+	/// We cache it to avoid redundant aquire of sync read lock.
+	/// https://github.com/paritytech/parity-ethereum/issues/8746
+	network_id: u64,
 }
 
 impl<S: ?Sized> NetClient<S> where S: SyncProvider {
@@ -30,17 +35,18 @@ impl<S: ?Sized> NetClient<S> where S: SyncProvider {
 	pub fn new(sync: &Arc<S>) -> Self {
 		NetClient {
 			sync: sync.clone(),
+			network_id: sync.status().network_id,
 		}
 	}
 }
 
 impl<S: ?Sized> Net for NetClient<S> where S: SyncProvider + 'static {
 	fn version(&self) -> Result<String> {
-		Ok(format!("{}", self.sync.status().network_id).to_owned())
+		Ok(format!("{}", self.network_id))
 	}
 
 	fn peer_count(&self) -> Result<String> {
-		Ok(format!("0x{:x}", self.sync.status().num_peers as u64).to_owned())
+		Ok(format!("0x{:x}", self.sync.status().num_peers as u64))
 	}
 
 	fn is_listening(&self) -> Result<bool> {

--- a/rpc/src/v1/impls/net.rs
+++ b/rpc/src/v1/impls/net.rs
@@ -46,7 +46,7 @@ impl<S: ?Sized> Net for NetClient<S> where S: SyncProvider + 'static {
 	}
 
 	fn peer_count(&self) -> Result<String> {
-		Ok(format!("0x{:x}", self.sync.status().num_peers as u64))
+		Ok(format!("{:#x}", self.sync.status().num_peers as u64))
 	}
 
 	fn is_listening(&self) -> Result<bool> {


### PR DESCRIPTION
issue #8746

This pull request does not resolve the underlying issue with `net_version` rpc method, but it is simply trying to workaround the problem. We should backport it and see if the issue with `net_version` still exists. 

If it does, it is caused by rpc library and we should fix the problem over there.

If it does not, we should fix `sync.status()` locking and/or all other rpc methods that do not respond immediately