### PR TITLE
Remove initial token for WS

### DIFF
--- a/rpc/src/authcodes.rs
+++ b/rpc/src/authcodes.rs
@@ -50,8 +50,6 @@ impl TimeProvider for DefaultTimeProvider {
 const TIME_THRESHOLD: u64 = 7;
 /// minimal length of hash
 const TOKEN_LENGTH: usize = 16;
-/// special "initial" token used for authorization when there are no tokens yet.
-const INITIAL_TOKEN: &'static str = "initial";
 /// Separator between fields in serialized tokens file.
 const SEPARATOR: &'static str = ";";
 /// Number of seconds to keep unused tokens.
@@ -163,16 +161,6 @@ impl<T: TimeProvider> AuthCodes<T> {
 
 		let as_token = |code| keccak(format!("{}:{}", code, time));
 
-		// Check if it's the initial token.
-		if self.is_empty() {
-			let initial = &as_token(INITIAL_TOKEN) == hash;
-			// Initial token can be used only once.
-			if initial {
-				let _ = self.generate_new();
-			}
-			return initial;
-		}
-
 		// look for code
 		for code in &mut self.codes {
 			if &as_token(&code.code) == hash {
@@ -239,7 +227,7 @@ mod tests {
 	}
 
 	#[test]
-	fn should_return_true_if_code_is_initial_and_store_is_empty() {
+	fn should_return_false_even_if_code_is_initial_and_store_is_empty() {
 		// given
 		let code = "initial";
 		let time = 99;
@@ -250,7 +238,7 @@ mod tests {
 		let res2 = codes.is_valid(&generate_hash(code, time), time);
 
 		// then
-		assert_eq!(res1, true);
+		assert_eq!(res1, false);
 		assert_eq!(res2, false);
 	}
 

--- a/rpc/src/tests/ws.rs
+++ b/rpc/src/tests/ws.rs
@@ -136,7 +136,7 @@ mod testing {
 	}
 
 	#[test]
-	fn should_allow_initial_connection_but_only_once() {
+	fn should_not_allow_initial_connection_even_once() {
 		// given
 		let (server, port, authcodes) = serve();
 		let code = "initial";
@@ -160,26 +160,9 @@ mod testing {
 			timestamp,
 			)
 		);
-		let response2 = http_client::request(server.addr(),
-			&format!("\
-				GET / HTTP/1.1\r\n\
-				Host: 127.0.0.1:{}\r\n\
-				Connection: Close\r\n\
-				Sec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==\r\n\
-				Sec-WebSocket-Protocol:{:?}_{}\r\n\
-				Sec-WebSocket-Version: 13\r\n\
-				\r\n\
-				{{}}
-			",
-			port,
-			keccak(format!("{}:{}", code, timestamp)),
-			timestamp,
-			)
-		);
 
 		// then
-		assert_eq!(response1.status, "HTTP/1.1 101 Switching Protocols".to_owned());
-		assert_eq!(response2.status, "HTTP/1.1 403 Forbidden".to_owned());
-		http_client::assert_security_headers_present(&response2.headers, None);
+		assert_eq!(response1.status, "HTTP/1.1 403 Forbidden".to_owned());
+		http_client::assert_security_headers_present(&response1.headers, None);
 	}
 }


### PR DESCRIPTION
Since the UI has been phased out we can remove the initial token that allows one to connect to "secure" version of WebSockets RPC for the first time without actually generating any tokens.

Related #9490