### PR TITLE
ethcore: fix detection of major import

### DIFF
--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -700,6 +700,7 @@ impl ChainSync {
 	fn complete_sync(&mut self, io: &mut SyncIo) {
 		trace!(target: "sync", "Sync complete");
 		self.reset(io);
+		self.state = SyncState::Idle;
 	}
 
 	/// Enter waiting state

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -507,8 +507,9 @@ impl ChainSync {
 		self.peers.clear();
 	}
 
-	/// Reset sync. Clear all downloaded data but keep the queue
-	fn reset(&mut self, io: &mut SyncIo) {
+	/// Reset sync. Clear all downloaded data but keep the queue.
+	/// Set sync state to the given state or to the initial state if `None` is provided.
+	fn reset(&mut self, io: &mut SyncIo, state: Option<SyncState>) {
 		self.new_blocks.reset();
 		let chain_info = io.chain().chain_info();
 		for (_, ref mut p) in &mut self.peers {
@@ -520,7 +521,7 @@ impl ChainSync {
 				}
 			}
 		}
-		self.state = ChainSync::get_init_state(self.warp_sync, io.chain());
+		self.state = state.unwrap_or_else(|| ChainSync::get_init_state(self.warp_sync, io.chain()));
 		// Reactivate peers only if some progress has been made
 		// since the last sync round of if starting fresh.
 		self.active_peers = self.peers.keys().cloned().collect();
@@ -534,7 +535,7 @@ impl ChainSync {
 			io.snapshot_service().abort_restore();
 		}
 		self.snapshot.clear();
-		self.reset(io);
+		self.reset(io, None);
 		self.continue_sync(io);
 	}
 
@@ -699,8 +700,7 @@ impl ChainSync {
 	/// Called after all blocks have been downloaded
 	fn complete_sync(&mut self, io: &mut SyncIo) {
 		trace!(target: "sync", "Sync complete");
-		self.reset(io);
-		self.state = SyncState::Idle;
+		self.reset(io, Some(SyncState::Idle));
 	}
 
 	/// Enter waiting state


### PR DESCRIPTION
After a sync round completes successfully we call `Chainsync::reset`, which in turn will set the sync state to the initial state by calling `ChainSync::get_init_state`. If warp sync is enabled the initial state will be set to `WaitingPeers`, which would be incorrect since it would make the client try to start a warp restore and also leads to incorrect detection of major import state. The fix is to force the state to `Idle` after the sync is complete. Also reverted changes introduced in #9112. I tested this by hammering the `eth_syncing` RPC and comparing the results to current master. On current master whenever a new block is imported `eth_syncing` would temporarily return that the node is syncing.

Fixes #9428.