### PR TITLE
while working on the platform tests make them non-breaking

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,6 +70,7 @@ test-darwin-macos-x86_64:
     - scripts/gitlab/test.sh stable
   tags:
     - osx
+  allow_failure:                   true
 
 test-linux-android-armhf:
   stage:                           test
@@ -80,6 +81,7 @@ test-linux-android-armhf:
     - scripts/gitlab/test.sh stable
   tags:
     - rust-arm
+  allow_failure:                   true
 
 test-windows-msvc-x86_64:
   stage:                           test
@@ -95,6 +97,7 @@ test-windows-msvc-x86_64:
     - sh scripts/gitlab/test.sh stable
   tags:
    - rust-windows
+  allow_failure:                   true
 
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,18 +49,30 @@ cache:
   - export VERSION
   - echo "Version = ${VERSION}"
 
-
-
 #### stage:                        test
 
-test-rust-stable:                  &test
+test-linux-rust-stable:            &test
   stage:                           test
   script:
     - scripts/gitlab/test.sh stable
   tags:
     - rust-stable
 
-test-darwin-macos-x86_64:
+test-linux-rust-beta:
+  stage:                           test
+  script:
+    - scripts/gitlab/test.sh beta
+  tags:
+    - rust-stable
+
+test-linux-rust-nightly:
+  stage:                           test
+  script:
+    - scripts/gitlab/test.sh nightly
+  tags:
+    - rust-stable
+
+test-darwin-rust-stable:
   stage:                           test
   variables:
     CARGO_TARGET:                  x86_64-apple-darwin
@@ -72,7 +84,7 @@ test-darwin-macos-x86_64:
     - osx
   allow_failure:                   true
 
-test-linux-android-armhf:
+test-android-rust-stable:
   stage:                           test
   image:                           parity/rust-android:gitlab-ci
   variables:
@@ -83,7 +95,7 @@ test-linux-android-armhf:
     - rust-arm
   allow_failure:                   true
 
-test-windows-msvc-x86_64:
+test-windows-rust-stable:
   stage:                           test
   cache:
     key:                           "%CI_JOB_NAME%"
@@ -99,25 +111,11 @@ test-windows-msvc-x86_64:
    - rust-windows
   allow_failure:                   true
 
-
-
-
-
 .optional_test:                    &optional_test
   <<:                              *test
   allow_failure:                   true
   only:
     - master
-
-test-rust-beta:
-  <<:                              *optional_test
-  script:
-    - scripts/gitlab/test.sh beta
-
-test-rust-nightly:
-  <<:                              *optional_test
-  script:
-    - scripts/gitlab/test.sh nightly
 
 test-lint-rustfmt:
   <<:                             *optional_test
@@ -130,15 +128,10 @@ test-lint-clippy:
     - scripts/gitlab/clippy.sh
 
 test-coverage-kcov:
-  stage:                           test
-  only:
-    - master
-  script:
+  <<:                             *optional_test
     - scripts/gitlab/coverage.sh
   tags:
     - shell
-  allow_failure:                   true
-
 
 #### stage:                        build
 
@@ -161,6 +154,7 @@ build-linux-ubuntu-i386:
     CARGO_TARGET:                  i686-unknown-linux-gnu
   tags:
     - rust-i686
+  allow_failure:                   true
 
 build-linux-ubuntu-arm64:
   <<:                              *build
@@ -170,6 +164,7 @@ build-linux-ubuntu-arm64:
     CARGO_TARGET:                  aarch64-unknown-linux-gnu
   tags:
     - rust-arm
+  allow_failure:                   true
 
 build-linux-ubuntu-armhf:
   <<:                              *build
@@ -179,6 +174,7 @@ build-linux-ubuntu-armhf:
     CARGO_TARGET:                  armv7-unknown-linux-gnueabihf
   tags:
     - rust-arm
+  allow_failure:                   true
 
 build-linux-android-armhf:
   stage:                           build
@@ -190,6 +186,7 @@ build-linux-android-armhf:
     - scripts/gitlab/build-unix.sh
   tags:
     - rust-arm
+  allow_failure:                   true
 
 build-darwin-macos-x86_64:
   stage:                           build
@@ -220,7 +217,6 @@ build-windows-msvc-x86_64:
   tags:
    - rust-windows
   <<:                              *collect_artifacts
-
 
 #### stage:                        package
 
@@ -262,7 +258,6 @@ package-linux-snap-armhf:
     CARGO_TARGET:                  armv7-unknown-linux-gnueabihf
   dependencies:
     - build-linux-ubuntu-armhf
-
 
 #### stage:                        publish
 
@@ -334,7 +329,6 @@ publish-github-and-s3:
     - scripts/gitlab/push.sh
   tags:
     - shell
-
 
 ####stage:                          docs
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -129,6 +129,7 @@ test-lint-clippy:
 
 test-coverage-kcov:
   <<:                             *optional_test
+  script:
     - scripts/gitlab/coverage.sh
   tags:
     - shell

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,7 @@ test-linux-rust-beta:
     - scripts/gitlab/test.sh beta
   tags:
     - rust-stable
+  allow_failure:                   true
 
 test-linux-rust-nightly:
   stage:                           test
@@ -71,6 +72,7 @@ test-linux-rust-nightly:
     - scripts/gitlab/test.sh nightly
   tags:
     - rust-stable
+  allow_failure:                   true
 
 test-darwin-rust-stable:
   stage:                           test


### PR DESCRIPTION
This is just a proposal.

During debugging and potentially upgrading macos hardware pr checks might not be verified at all. So if you get bored by that simply merge it and you can have the previous behaviour (except for the long build times).