### PR TITLE
Add constantinople conf to EvmTestClient.

### DIFF
--- a/ethcore/src/client/evm_test_client.rs
+++ b/ethcore/src/client/evm_test_client.rs
@@ -86,9 +86,9 @@ impl<'a> EvmTestClient<'a> {
 			ForkSpec::EIP150 => Some(ethereum::new_eip150_test()),
 			ForkSpec::EIP158 => Some(ethereum::new_eip161_test()),
 			ForkSpec::Byzantium => Some(ethereum::new_byzantium_test()),
+			ForkSpec::Constantinople => Some(ethereum::new_constantinople_test()),
 			ForkSpec::EIP158ToByzantiumAt5 => Some(ethereum::new_transition_test()),
 			ForkSpec::FrontierToHomesteadAt5 | ForkSpec::HomesteadToDaoAt5 | ForkSpec::HomesteadToEIP150At5 => None,
-			_ => None,
 		}
 	}
 


### PR DESCRIPTION
Fixes 9568.
Constantinople spec was not resolve when using EvmTestClient. This adds it.