### PR TITLE
Fix evm's evm-debug informant compile

### DIFF
--- a/ethcore/evm/src/instructions.rs
+++ b/ethcore/evm/src/instructions.rs
@@ -45,7 +45,7 @@ macro_rules! enum_with_from_u8 {
 enum_with_from_u8! {
 	#[doc = "Virtual machine bytecode instruction."]
 	#[repr(u8)]
-	#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Debug)]
+	#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Debug, Hash)]
 	pub enum Instruction {
 		#[doc = "halts execution"]
 		STOP = 0x00,

--- a/ethcore/evm/src/interpreter/informant.rs
+++ b/ethcore/evm/src/interpreter/informant.rs
@@ -42,7 +42,7 @@ mod inner {
 	use ethereum_types::U256;
 
 	use interpreter::stack::Stack;
-	use instructions::{Instruction, InstructionInfo, INSTRUCTIONS};
+	use instructions::{Instruction, InstructionInfo};
 	use CostType;
 
 	macro_rules! evm_debug {
@@ -97,7 +97,7 @@ mod inner {
 				&self.spacing,
 				pc,
 				Self::color(instruction, info.name),
-				instruction,
+				instruction as u8,
 				current_gas,
 				Self::as_micro(&time),
 			));
@@ -117,18 +117,16 @@ mod inner {
 
 		pub fn done(&mut self) {
 			// Print out stats
-			let infos = &*INSTRUCTIONS;
-
 			let mut stats: Vec<(_,_)> = self.stats.drain().collect();
 			stats.sort_by(|ref a, ref b| b.1.avg().cmp(&a.1.avg()));
 
 			print(format!("\n{}-------OPCODE STATS:", self.spacing));
 			for (instruction, stats) in stats.into_iter() {
-				let info = infos[instruction as usize];
+				let info = instruction.info();
 				print(format!("{}-------{:>19}(0x{:<2x}) count: {:4}, avg: {:10}μs",
 					self.spacing,
 					Self::color(instruction, info.name),
-					instruction,
+					instruction as u8,
 					stats.count,
 					stats.avg(),
 				));

--- a/ethcore/evm/src/interpreter/mod.rs
+++ b/ethcore/evm/src/interpreter/mod.rs
@@ -274,7 +274,7 @@ impl<Cost: CostType> Interpreter<Cost> {
 		self.gasometer.as_mut().expect(GASOMETER_PROOF).current_mem_gas = requirements.memory_total_gas;
 		self.gasometer.as_mut().expect(GASOMETER_PROOF).current_gas = self.gasometer.as_mut().expect(GASOMETER_PROOF).current_gas - requirements.gas_cost;
 
-		evm_debug!({ informant.before_instruction(reader.position, instruction, info, &self.gasometer.as_mut().expect(GASOMETER_PROOF).current_gas, &stack) });
+		evm_debug!({ self.informant.before_instruction(self.reader.position, instruction, info, &self.gasometer.as_mut().expect(GASOMETER_PROOF).current_gas, &self.stack) });
 
 		let (mem_written, store_written) = match self.do_trace {
 			true => (Self::mem_written(instruction, &self.stack), Self::store_written(instruction, &self.stack)),
@@ -287,7 +287,7 @@ impl<Cost: CostType> Interpreter<Cost> {
 			current_gas, ext, instruction, requirements.provide_gas
 		)?;
 
-		evm_debug!({ informant.after_instruction(instruction) });
+		evm_debug!({ self.informant.after_instruction(instruction) });
 
 		if let InstructionResult::UnusedGas(ref gas) = result {
 			self.gasometer.as_mut().expect(GASOMETER_PROOF).current_gas = self.gasometer.as_mut().expect(GASOMETER_PROOF).current_gas + *gas;


### PR DESCRIPTION
Fixes `evm-debug` feature flags so that Constantinople testing debugs can be easier.

Those fixes was also presented in #9360.