### PR TITLE
fix (light/provider) : Make `read_only executions` read-only

### DIFF
--- a/ethcore/light/src/on_demand/request.rs
+++ b/ethcore/light/src/on_demand/request.rs
@@ -61,7 +61,7 @@ pub enum Request {
 	/// A request for a contract's code.
 	Code(Code),
 	/// A request for proof of execution.
-	Execution(TransactionProof),
+	Execution(ReadOnlyTransactionProof),
 	/// A request for epoch change signal.
 	Signal(Signal),
 }
@@ -145,7 +145,7 @@ impl_single!(Receipts, BlockReceipts, Vec<Receipt>);
 impl_single!(Body, Body, encoded::Block);
 impl_single!(Account, Account, Option<BasicAccount>);
 impl_single!(Code, Code, Bytes);
-impl_single!(Execution, TransactionProof, super::ExecutionResult);
+impl_single!(Execution, ReadOnlyTransactionProof, super::ExecutionResult);
 impl_single!(Signal, Signal, Vec<u8>);
 
 macro_rules! impl_args {
@@ -256,7 +256,7 @@ pub enum CheckedRequest {
 	Body(Body, net_request::IncompleteBodyRequest),
 	Account(Account, net_request::IncompleteAccountRequest),
 	Code(Code, net_request::IncompleteCodeRequest),
-	Execution(TransactionProof, net_request::IncompleteExecutionRequest),
+	Execution(ReadOnlyTransactionProof, net_request::IncompleteExecutionRequest),
 	Signal(Signal, net_request::IncompleteSignalRequest)
 }
 
@@ -1030,7 +1030,7 @@ impl Code {
 
 /// Request for transaction execution, along with the parts necessary to verify the proof.
 #[derive(Clone)]
-pub struct TransactionProof {
+pub struct ReadOnlyTransactionProof {
 	/// The transaction to request proof of.
 	pub tx: SignedTransaction,
 	/// Block header.
@@ -1042,7 +1042,7 @@ pub struct TransactionProof {
 	pub engine: Arc<EthEngine>,
 }
 
-impl TransactionProof {
+impl ReadOnlyTransactionProof {
 	/// Check the proof, returning the proved execution or indicate that the proof was bad.
 	pub fn check_response(&self, _: &Mutex<::cache::Cache>, state_items: &[DBValue]) -> Result<super::ExecutionResult, Error> {
 		let root = self.header.as_ref()?.state_root();

--- a/ethcore/light/src/on_demand/request.rs
+++ b/ethcore/light/src/on_demand/request.rs
@@ -61,7 +61,7 @@ pub enum Request {
 	/// A request for a contract's code.
 	Code(Code),
 	/// A request for proof of execution.
-	Execution(ReadOnlyTransactionProof),
+	Execution(TransactionProof),
 	/// A request for epoch change signal.
 	Signal(Signal),
 }
@@ -145,7 +145,7 @@ impl_single!(Receipts, BlockReceipts, Vec<Receipt>);
 impl_single!(Body, Body, encoded::Block);
 impl_single!(Account, Account, Option<BasicAccount>);
 impl_single!(Code, Code, Bytes);
-impl_single!(Execution, ReadOnlyTransactionProof, super::ExecutionResult);
+impl_single!(Execution, TransactionProof, super::ExecutionResult);
 impl_single!(Signal, Signal, Vec<u8>);
 
 macro_rules! impl_args {
@@ -256,7 +256,7 @@ pub enum CheckedRequest {
 	Body(Body, net_request::IncompleteBodyRequest),
 	Account(Account, net_request::IncompleteAccountRequest),
 	Code(Code, net_request::IncompleteCodeRequest),
-	Execution(ReadOnlyTransactionProof, net_request::IncompleteExecutionRequest),
+	Execution(TransactionProof, net_request::IncompleteExecutionRequest),
 	Signal(Signal, net_request::IncompleteSignalRequest)
 }
 
@@ -1030,7 +1030,7 @@ impl Code {
 
 /// Request for transaction execution, along with the parts necessary to verify the proof.
 #[derive(Clone)]
-pub struct ReadOnlyTransactionProof {
+pub struct TransactionProof {
 	/// The transaction to request proof of.
 	pub tx: SignedTransaction,
 	/// Block header.
@@ -1042,7 +1042,7 @@ pub struct ReadOnlyTransactionProof {
 	pub engine: Arc<EthEngine>,
 }
 
-impl ReadOnlyTransactionProof {
+impl TransactionProof {
 	/// Check the proof, returning the proved execution or indicate that the proof was bad.
 	pub fn check_response(&self, _: &Mutex<::cache::Cache>, state_items: &[DBValue]) -> Result<super::ExecutionResult, Error> {
 		let root = self.header.as_ref()?.state_root();

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2374,6 +2374,7 @@ impl ProvingBlockChainClient for Client {
 	}
 
 	fn prove_transaction(&self, transaction: SignedTransaction, id: BlockId) -> Option<(Bytes, Vec<DBValue>)> {
+		trace!(target: "pip_provider", "prove_transaction: {:?}", transaction);
 		let (header, mut env_info) = match (self.block_header(id), self.env_info(id)) {
 			(Some(s), Some(e)) => (s, e),
 			_ => return None,
@@ -2389,7 +2390,7 @@ impl ProvingBlockChainClient for Client {
 			self.engine.machine(),
 			&env_info,
 			self.factories.clone(),
-			false,
+			true,
 		)
 	}
 

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2374,7 +2374,6 @@ impl ProvingBlockChainClient for Client {
 	}
 
 	fn prove_transaction(&self, transaction: SignedTransaction, id: BlockId) -> Option<(Bytes, Vec<DBValue>)> {
-		trace!(target: "pip_provider", "prove_transaction: {:?}", transaction);
 		let (header, mut env_info) = match (self.block_header(id), self.env_info(id)) {
 			(Some(s), Some(e)) => (s, e),
 			_ => return None,

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2382,14 +2382,13 @@ impl ProvingBlockChainClient for Client {
 		env_info.gas_limit = transaction.gas.clone();
 		let mut jdb = self.state_db.read().journal_db().boxed_clone();
 
-		state::prove_transaction(
+		state::prove_transaction_virtual(
 			jdb.as_hashdb_mut(),
 			header.state_root().clone(),
 			&transaction,
 			self.engine.machine(),
 			&env_info,
 			self.factories.clone(),
-			true,
 		)
 	}
 

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -873,14 +873,13 @@ impl Spec {
 				data: d,
 			}.fake_sign(from);
 
-			let res = ::state::prove_transaction(
+			let res = ::state::prove_transaction_virtual(
 				db.as_hashdb_mut(),
 				*genesis.state_root(),
 				&tx,
 				self.engine.machine(),
 				&env_info,
 				factories.clone(),
-				true,
 			);
 
 			res.map(|(out, proof)| {

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -224,17 +224,16 @@ pub fn check_proof(
 	}
 }
 
-/// Prove a transaction on the given state.
+/// Prove a `virtual` transaction on the given state.
 /// Returns `None` when the transacion could not be proved,
 /// and a proof otherwise.
-pub fn prove_transaction<H: AsHashDB<KeccakHasher> + Send + Sync>(
+pub fn prove_transaction_virtual<H: AsHashDB<KeccakHasher> + Send + Sync>(
 	db: H,
 	root: H256,
 	transaction: &SignedTransaction,
 	machine: &Machine,
 	env_info: &EnvInfo,
 	factories: Factories,
-	virt: bool,
 ) -> Option<(Bytes, Vec<DBValue>)> {
 	use self::backend::Proving;
 
@@ -252,7 +251,7 @@ pub fn prove_transaction<H: AsHashDB<KeccakHasher> + Send + Sync>(
 	};
 
 	let options = TransactOptions::with_no_tracing().dont_check_nonce().save_output_from_contract();
-	match state.execute(env_info, machine, transaction, options, virt) {
+	match state.execute(env_info, machine, transaction, options, true) {
 		Err(ExecutionError::Internal(_)) => None,
 		Err(e) => {
 			trace!(target: "state", "Proved call failed: {}", e);

--- a/rpc/src/v1/helpers/light_fetch.rs
+++ b/rpc/src/v1/helpers/light_fetch.rs
@@ -636,7 +636,7 @@ fn execute_read_only_tx(gas_known: bool, params: ExecuteParams) -> impl Future<I
 		trace!(target: "light_fetch", "Placing execution request for {} gas in on_demand",
 			params.tx.gas);
 
-		let request = request::ReadOnlyTransactionProof {
+		let request = request::TransactionProof {
 			tx: params.tx.fake_sign(params.from),
 			header: params.hdr.into(),
 			env_info: params.env_info,

--- a/rpc/src/v1/helpers/light_fetch.rs
+++ b/rpc/src/v1/helpers/light_fetch.rs
@@ -191,7 +191,7 @@ impl LightFetch {
 	}
 
 	/// Helper for getting proved execution.
-	pub fn proved_execution(&self, req: CallRequest, num: Trailing<BlockNumber>) -> impl Future<Item = ExecutionResult, Error = Error> + Send {
+	pub fn proved_read_only_execution(&self, req: CallRequest, num: Trailing<BlockNumber>) -> impl Future<Item = ExecutionResult, Error = Error> + Send {
 		const DEFAULT_GAS_PRICE: u64 = 21_000;
 		// starting gas when gas not provided.
 		const START_GAS: u64 = 50_000;
@@ -256,14 +256,14 @@ impl LightFetch {
 				_ => return Either::A(future::err(errors::unknown_block())),
 			};
 
-			Either::B(execute_tx(gas_known, ExecuteParams {
-				from: from,
-				tx: tx,
-				hdr: hdr,
-				env_info: env_info,
+			Either::B(execute_read_only_tx(gas_known, ExecuteParams {
+				from,
+				tx,
+				hdr,
+				env_info,
 				engine: client.engine().clone(),
-				on_demand: on_demand,
-				sync: sync,
+				on_demand,
+				sync,
 			}))
 		}))
 	}
@@ -608,10 +608,10 @@ struct ExecuteParams {
 
 // has a peer execute the transaction with given params. If `gas_known` is false,
 // this will double the gas on each `OutOfGas` error.
-fn execute_tx(gas_known: bool, params: ExecuteParams) -> impl Future<Item = ExecutionResult, Error = Error> + Send {
+fn execute_read_only_tx(gas_known: bool, params: ExecuteParams) -> impl Future<Item = ExecutionResult, Error = Error> + Send {
 	if !gas_known {
 		Box::new(future::loop_fn(params, |mut params| {
-			execute_tx(true, params.clone()).and_then(move |res| {
+			execute_read_only_tx(true, params.clone()).and_then(move |res| {
 				match res {
 					Ok(executed) => {
 						// TODO: how to distinguish between actual OOG and
@@ -636,7 +636,7 @@ fn execute_tx(gas_known: bool, params: ExecuteParams) -> impl Future<Item = Exec
 		trace!(target: "light_fetch", "Placing execution request for {} gas in on_demand",
 			params.tx.gas);
 
-		let request = request::TransactionProof {
+		let request = request::ReadOnlyTransactionProof {
 			tx: params.tx.fake_sign(params.from),
 			header: params.hdr.into(),
 			env_info: params.env_info,

--- a/rpc/src/v1/impls/light/eth.rs
+++ b/rpc/src/v1/impls/light/eth.rs
@@ -381,7 +381,7 @@ impl<T: LightChainClient + 'static> Eth for EthClient<T> {
 	}
 
 	fn call(&self, req: CallRequest, num: Trailing<BlockNumber>) -> BoxFuture<Bytes> {
-		Box::new(self.fetcher().proved_execution(req, num).and_then(|res| {
+		Box::new(self.fetcher().proved_read_only_execution(req, num).and_then(|res| {
 			match res {
 				Ok(exec) => Ok(exec.output.into()),
 				Err(e) => Err(errors::execution(e)),
@@ -391,7 +391,7 @@ impl<T: LightChainClient + 'static> Eth for EthClient<T> {
 
 	fn estimate_gas(&self, req: CallRequest, num: Trailing<BlockNumber>) -> BoxFuture<RpcU256> {
 		// TODO: binary chop for more accurate estimates.
-		Box::new(self.fetcher().proved_execution(req, num).and_then(|res| {
+		Box::new(self.fetcher().proved_read_only_execution(req, num).and_then(|res| {
 			match res {
 				Ok(exec) => Ok((exec.refunded + exec.gas_used).into()),
 				Err(e) => Err(errors::execution(e)),


### PR DESCRIPTION
Attempt to close #9551 and fix #9535 

/cc @Tbaut can you try this with `fether`? 

This changes so all `ExecutionRequests` from light-clients are executed
as read-only which the `virtual flag` == true ensures. 

This boost up the current transaction to always succeed such as account balance and similar!

Note, this only affects `eth_estimateGas` and `eth_call` AFAIK.

## Manual tests on (kovan)

1. Started a `provider` (full node)  
2. Request from light client with unknown account ```0x0066Dc48bb833d2B59f730F33952B3c29fE926ff```

```bash
curl --data '{"method":"eth_estimateGas","params":[{"from":"0x0066Dc48bb833d2B59f730F33952B3c29fE926ff", "gas":"0xffff" }, "latest"],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST localhost:8555
{"jsonrpc":"2.0","result":"0xcf08","id":1}
```