### PR TITLE
Backports for 2.1.1 beta

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ cache:
 .publishable_branches:             # list of git refs for publishing builds to the "production" locations
   only:                            &publishable_branches
     - nightly # Our nightly builds from schedule, on `master`
-    - "v2*" # Our version tags
+    - /^v2.*$/ # Our version tags
 
 .collect_artifacts:                &collect_artifacts
   artifacts:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,7 +2007,7 @@ version = "1.12.0"
 dependencies = [
  "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic_hook 0.1.0",
- "parity-ethereum 2.1.0",
+ "parity-ethereum 2.1.1",
 ]
 
 [[package]]
@@ -2023,7 +2023,7 @@ dependencies = [
 
 [[package]]
 name = "parity-ethereum"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2073,7 +2073,7 @@ dependencies = [
  "parity-rpc 1.12.0",
  "parity-rpc-client 1.4.0",
  "parity-updater 1.12.0",
- "parity-version 2.1.0",
+ "parity-version 2.1.1",
  "parity-whisper 0.1.0",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2238,7 +2238,7 @@ dependencies = [
  "parity-crypto 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-reactor 0.1.0",
  "parity-updater 1.12.0",
- "parity-version 2.1.0",
+ "parity-version 2.1.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "patricia-trie 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2327,7 +2327,7 @@ dependencies = [
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-hash-fetch 1.12.0",
  "parity-path 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-version 2.1.0",
+ "parity-version 2.1.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2337,7 +2337,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Parity Ethereum client"
 name = "parity-ethereum"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "2.1.0"
+version = "2.1.1"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 

--- a/scripts/gitlab/rpc-docs.sh
+++ b/scripts/gitlab/rpc-docs.sh
@@ -34,7 +34,7 @@ commit_files() {
     git checkout -b rpcdoc-update-${CI_COMMIT_REF_NAME}
     git add .
     git commit -m "Update docs to ${CI_COMMIT_REF_NAME}"
-    git tag -a "${CI_COMMIT_REF_NAME}"
+    git tag -a "${CI_COMMIT_REF_NAME}" -m "Update RPC docs to ${CI_COMMIT_REF_NAME}"
 }
 
 upload_files() {

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for Parity Ethereum version string (via env CARGO_PKG_VERSION)
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 
@@ -16,9 +16,9 @@ track = "beta"
 # Latest supported fork blocks.
 # Indicates a critical release in this track (i.e. consensus issue).
 [package.metadata.networks]
-foundation = { forkBlock = 4370000, critical = true }
-ropsten = { forkBlock = 10, critical = true }
-kovan = { forkBlock = 6600000, critical = true }
+foundation = { forkBlock = 4370000, critical = false }
+ropsten = { forkBlock = 10, critical = false }
+kovan = { forkBlock = 6600000, critical = false }
 
 [dependencies]
 parity-bytes = "0.1"


### PR DESCRIPTION
- [x] parity-version: bump beta to 2.1.1
- [ ] Keep existing blocks when restoring a Snapshot (#8643)
- [ ] Fix ancient blocks sync (#9531)
- [ ] ethcore: fix detection of major import (#9552)
- [x] ci: fix regex 🙄 (#9597)
- [x] docs(rpc): annotate tag with the provided message (#9601)