### PR TITLE
Backports to 2.0.6 stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,7 +1930,7 @@ source = "git+https://github.com/paritytech/parity-common#0045887fecd2fec39e56c9
 name = "parity-clib"
 version = "1.12.0"
 dependencies = [
- "parity-ethereum 2.0.5",
+ "parity-ethereum 2.0.6",
 ]
 
 [[package]]
@@ -1947,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "parity-ethereum"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1996,7 +1996,7 @@ dependencies = [
  "parity-rpc 1.12.0",
  "parity-rpc-client 1.4.0",
  "parity-updater 1.12.0",
- "parity-version 2.0.5",
+ "parity-version 2.0.6",
  "parity-whisper 0.1.0",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "path 0.1.1 (git+https://github.com/paritytech/parity-common)",
@@ -2135,7 +2135,7 @@ dependencies = [
  "parity-crypto 0.1.0 (git+https://github.com/paritytech/parity-common)",
  "parity-reactor 0.1.0",
  "parity-updater 1.12.0",
- "parity-version 2.0.5",
+ "parity-version 2.0.6",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "patricia-trie 0.2.1 (git+https://github.com/paritytech/parity-common)",
  "plain_hasher 0.1.0 (git+https://github.com/paritytech/parity-common)",
@@ -2206,7 +2206,7 @@ dependencies = [
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (git+https://github.com/paritytech/parity-common)",
  "parity-hash-fetch 1.12.0",
- "parity-version 2.0.5",
+ "parity-version 2.0.6",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "path 0.1.1 (git+https://github.com/paritytech/parity-common)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "parity-bytes 0.1.0 (git+https://github.com/paritytech/parity-common)",
  "rlp 0.2.1 (git+https://github.com/paritytech/parity-common)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Parity Ethereum client"
 name = "parity-ethereum"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "2.0.5"
+version = "2.0.6"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for Parity version string (via env CARGO_PKG_VERSION)
-version = "2.0.5"
+version = "2.0.6"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 
@@ -16,9 +16,9 @@ track = "stable"
 # Latest supported fork blocks.
 # Indicates a critical release in this track (i.e. consensus issue).
 [package.metadata.networks]
-foundation = { forkBlock = 4370000, critical = true }
-ropsten = { forkBlock = 10, critical = true }
-kovan = { forkBlock = 6600000, critical = true }
+foundation = { forkBlock = 4370000, critical = false }
+ropsten = { forkBlock = 10, critical = false }
+kovan = { forkBlock = 6600000, critical = false }
 
 [dependencies]
 parity-bytes = { git = "https://github.com/paritytech/parity-common" }


### PR DESCRIPTION
- [x] parity-version: bump stable to 2.0.6
- [ ] ethcore: fix ancient block sync (#9407)
