### PR TITLE
stable(rpc-docs): avoid recursive copy

### DIFF
--- a/scripts/gitlab-rpc-docs.sh
+++ b/scripts/gitlab-rpc-docs.sh
@@ -41,12 +41,13 @@ upload_files() {
     git push --tags
 }
 
-PROJECT_DIR=$(pwd)
+RPC_TRAITS_DIR="rpc/src/v1/traits"
 
 setup_git
 cd ..
 clone_repos
-cp -r $PROJECT_DIR jsonrpc/.parity
+mkdir -p "jsonrpc/.parity/$RPC_TRAITS_DIR"
+cp $RPC_TRAITS_DIR/*.rs "jsonrpc/.parity/$RPC_TRAITS_DIR"
 cd jsonrpc
 build_docs
 cd ..

--- a/scripts/gitlab-rpc-docs.sh
+++ b/scripts/gitlab-rpc-docs.sh
@@ -44,7 +44,6 @@ upload_files() {
 RPC_TRAITS_DIR="rpc/src/v1/traits"
 
 setup_git
-cd ..
 clone_repos
 mkdir -p "jsonrpc/.parity/$RPC_TRAITS_DIR"
 cp $RPC_TRAITS_DIR/*.rs "jsonrpc/.parity/$RPC_TRAITS_DIR"


### PR DESCRIPTION
`cp -r $PROJECT_DIR jsonrpc/.parity` tries to copy `.` into subdir, which is not nice.