### PR TITLE
test.sh: use cargo --target for platforms other than linux, win or mac

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,8 @@ cache:
 
 test-linux-rust-stable:            &test
   stage:                           test
+  variables:
+    RUN_TESTS:                     true
   script:
     - scripts/gitlab/test.sh stable
   tags:
@@ -60,6 +62,8 @@ test-linux-rust-stable:            &test
 
 test-linux-rust-beta:
   stage:                           test
+  variables:
+    RUN_TESTS:                     true
   script:
     - scripts/gitlab/test.sh beta
   tags:
@@ -68,6 +72,8 @@ test-linux-rust-beta:
 
 test-linux-rust-nightly:
   stage:                           test
+  variables:
+    RUN_TESTS:                     true
   script:
     - scripts/gitlab/test.sh nightly
   tags:
@@ -80,6 +86,7 @@ test-darwin-rust-stable:
     CARGO_TARGET:                  x86_64-apple-darwin
     CC:                            gcc
     CXX:                           g++
+    RUN_TESTS:                     true
   script:
     - scripts/gitlab/test.sh stable
   tags:
@@ -107,6 +114,7 @@ test-windows-rust-stable:
       # No cargo caching, since fetch-locking on Windows gets stuck
   variables:
     CARGO_TARGET:                  x86_64-pc-windows-msvc
+    RUN_TESTS:                     true
   script:
     - sh scripts/gitlab/test.sh stable
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ cache:
 test-linux-rust-stable:            &test
   stage:                           test
   variables:
-    RUN_TESTS:                     true
+    RUN_TESTS:                     "true"
   script:
     - scripts/gitlab/test.sh stable
   tags:
@@ -63,7 +63,7 @@ test-linux-rust-stable:            &test
 test-linux-rust-beta:
   stage:                           test
   variables:
-    RUN_TESTS:                     true
+    RUN_TESTS:                     "true"
   script:
     - scripts/gitlab/test.sh beta
   tags:
@@ -73,7 +73,7 @@ test-linux-rust-beta:
 test-linux-rust-nightly:
   stage:                           test
   variables:
-    RUN_TESTS:                     true
+    RUN_TESTS:                     "true"
   script:
     - scripts/gitlab/test.sh nightly
   tags:
@@ -86,7 +86,7 @@ test-darwin-rust-stable:
     CARGO_TARGET:                  x86_64-apple-darwin
     CC:                            gcc
     CXX:                           g++
-    RUN_TESTS:                     true
+    RUN_TESTS:                     "true"
   script:
     - scripts/gitlab/test.sh stable
   tags:
@@ -114,7 +114,7 @@ test-windows-rust-stable:
       # No cargo caching, since fetch-locking on Windows gets stuck
   variables:
     CARGO_TARGET:                  x86_64-pc-windows-msvc
-    RUN_TESTS:                     true
+    RUN_TESTS:                     "true"
   script:
     - sh scripts/gitlab/test.sh stable
   tags:

--- a/test.sh
+++ b/test.sh
@@ -4,6 +4,7 @@
 FEATURES="json-tests,ci-skip-issue"
 OPTIONS="--release"
 VALIDATE=1
+THREADS=8
 
 case $1 in
   --no-json)
@@ -29,31 +30,58 @@ esac
 
 set -e
 
-if [ "$VALIDATE" -eq "1" ]; then
-# Validate --no-default-features build
-echo "________Validate build________"
-time cargo check --no-default-features
-time cargo check --manifest-path util/io/Cargo.toml --no-default-features
-time cargo check --manifest-path util/io/Cargo.toml --features "mio"
 
-# Validate chainspecs
-echo "________Validate chainspecs________"
-time ./scripts/validate_chainspecs.sh
-fi
 
-# Running the C++ example
-echo "________Running the C++ example________"
-cd parity-clib-examples/cpp && \
-  mkdir -p build && \
-  cd build && \
-  cmake .. && \
-  make -j 8 && \
-  ./parity-example && \
-  cd .. && \
-  rm -rf build && \
-  cd ../..
+case $CARGO_TARGET in
+  (x86_64-unknown-linux-gnu|x86_64-apple-darwin|x86_64-pc-windows-msvc|'')
+    # native builds
+    if [ "$VALIDATE" -eq "1" ]
+    then
+      echo "________Validate build________"
+      time cargo check --no-default-features
+      time cargo check --manifest-path util/io/Cargo.toml --no-default-features
+      time cargo check --manifest-path util/io/Cargo.toml --features "mio"
+    
+      # Validate chainspecs
+      echo "________Validate chainspecs________"
+      time ./scripts/validate_chainspecs.sh
+    fi
 
-# Running tests
-echo "________Running Parity Full Test Suite________"
-git submodule update --init --recursive
-time cargo test  $OPTIONS --features "$FEATURES" --all $1 -- --test-threads 8
+
+    # Running the C++ example
+    echo "________Running the C++ example________"
+    cd parity-clib-examples/cpp && \
+      mkdir -p build && \
+      cd build && \
+      cmake .. && \
+      make -j $THREADS && \
+      ./parity-example && \
+      cd .. && \
+      rm -rf build && \
+      cd ../..
+
+    # Running tests
+    echo "________Running Parity Full Test Suite________"
+    git submodule update --init --recursive
+    time cargo test  $OPTIONS --features "$FEATURES" --all $@ -- --test-threads $THREADS
+    ;;
+  (*)
+    if [ "$VALIDATE" -eq "1" ]
+    then
+      echo "________Validate build________"
+      time cargo check --target $CARGO_TARGET --no-default-features
+      time cargo check --target $CARGO_TARGET --manifest-path util/io/Cargo.toml --no-default-features
+      time cargo check --target $CARGO_TARGET --manifest-path util/io/Cargo.toml --features "mio"
+    
+      # Validate chainspecs
+      echo "________Validate chainspecs________"
+      time ./scripts/validate_chainspecs.sh
+    fi
+
+    # Per default only build but not run the tests
+    echo "________Building Parity Full Test Suite________"
+    git submodule update --init --recursive
+    time cargo test  --no-run --target $CARGO_TARGET $OPTIONS --features "$FEATURES" --all $@ -- --test-threads $THREADS
+    ;;
+esac
+


### PR DESCRIPTION
test runs need cargo --target option for cross-compilation and should then build only but not run the tests.