### PR TITLE
Ancient sync improvements

### DIFF
--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -1459,7 +1459,7 @@ impl BlockChain {
 		let first_block_number = self.first_block_number().into();
 		let genesis_hash = self.genesis_hash();
 
-		// ensure data consistencly by locking everything first
+		// ensure data consistency by locking everything first
 		let best_block = self.best_block.read();
 		let best_ancient_block = self.best_ancient_block.read();
 		BlockChainInfo {

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -235,7 +235,7 @@ pub struct BlockChain {
 	cache_man: Mutex<CacheManager<CacheId>>,
 
 	pending_best_block: RwLock<Option<BestBlock>>,
-	pending_block_hashes: RwLock<HashMap<BlockNumber, H256>>,
+	pending_block_hashes: RwLock<HashMap<BlockNumber, Option<H256>>>,
 	pending_block_details: RwLock<HashMap<H256, BlockDetails>>,
 	pending_transaction_addresses: RwLock<HashMap<H256, Option<TransactionAddress>>>,
 }
@@ -1110,7 +1110,7 @@ impl BlockChain {
 			let mut write_txs = self.pending_transaction_addresses.write();
 
 			batch.extend_with_cache(db::COL_EXTRA, &mut *write_details, update.block_details, CacheUpdatePolicy::Overwrite);
-			batch.extend_with_cache(db::COL_EXTRA, &mut *write_hashes, update.block_hashes, CacheUpdatePolicy::Overwrite);
+			batch.extend_with_option_cache(db::COL_EXTRA, &mut *write_hashes, update.block_hashes, CacheUpdatePolicy::Overwrite);
 			batch.extend_with_option_cache(db::COL_EXTRA, &mut *write_txs, update.transactions_addresses, CacheUpdatePolicy::Overwrite);
 		}
 	}
@@ -1132,22 +1132,30 @@ impl BlockChain {
 		}
 
 		let pending_txs = mem::replace(&mut *pending_write_txs, HashMap::new());
-		let (retracted_txs, enacted_txs) = pending_txs.into_iter().partition::<HashMap<_, _>, _>(|&(_, ref value)| value.is_none());
+		let (retracted_txs, enacted_txs) = pending_txs.into_iter()
+			.partition::<HashMap<_, _>, _>(|&(_, ref value)| value.is_none());
 
-		let pending_hashes_keys: Vec<_> = pending_write_hashes.keys().cloned().collect();
+		let pending_hashes = mem::replace(&mut *pending_write_hashes, HashMap::new());
+		let (retracted_hashes, enacted_hashes) = pending_hashes.into_iter()
+			.partition::<HashMap<_, _>, _>(|&(_, ref value)| value.is_none());
+
+		let enacted_hashes_keys: Vec<_> = enacted_hashes.keys().cloned().collect();
 		let enacted_txs_keys: Vec<_> = enacted_txs.keys().cloned().collect();
 		let pending_block_hashes: Vec<_> = pending_block_details.keys().cloned().collect();
 
-		write_hashes.extend(mem::replace(&mut *pending_write_hashes, HashMap::new()));
+		write_hashes.extend(enacted_hashes.into_iter().map(|(k, v)| (k, v.expect("Hashes were partitioned; qed"))));
 		write_txs.extend(enacted_txs.into_iter().map(|(k, v)| (k, v.expect("Transactions were partitioned; qed"))));
 		write_block_details.extend(mem::replace(&mut *pending_block_details, HashMap::new()));
 
 		for hash in retracted_txs.keys() {
 			write_txs.remove(hash);
 		}
+		for number in retracted_hashes.keys() {
+			write_hashes.remove(number);
+		}
 
 		let mut cache_man = self.cache_man.lock();
-		for n in pending_hashes_keys {
+		for n in enacted_hashes_keys {
 			cache_man.note_used(CacheId::BlockHashes(n));
 		}
 
@@ -1221,23 +1229,26 @@ impl BlockChain {
 	}
 
 	/// This function returns modified block hashes.
-	fn prepare_block_hashes_update(&self, info: &BlockInfo) -> HashMap<BlockNumber, H256> {
+	fn prepare_block_hashes_update(&self, info: &BlockInfo) -> HashMap<BlockNumber, Option<H256>> {
 		let mut block_hashes = HashMap::new();
 
 		match info.location {
 			BlockLocation::Branch => (),
 			BlockLocation::CanonChain => {
-				block_hashes.insert(info.number, info.hash);
+				block_hashes.insert(info.number, Some(info.hash));
 			},
 			BlockLocation::BranchBecomingCanonChain(ref data) => {
 				let ancestor_number = self.block_number(&data.ancestor).expect("Block number of ancestor is always in DB");
 				let start_number = ancestor_number + 1;
 
-				for (index, hash) in data.enacted.iter().cloned().enumerate() {
-					block_hashes.insert(start_number + index as BlockNumber, hash);
+				for (index, hash) in data.enacted.iter().enumerate() {
+					block_hashes.insert(start_number + index as BlockNumber, Some(*hash));
 				}
+				block_hashes.insert(info.number, Some(info.hash));
 
-				block_hashes.insert(info.number, info.hash);
+				for index in (data.enacted.len() + 1)..data.retracted.len() {
+					block_hashes.insert(start_number + index as BlockNumber, None);
+				}
 			}
 		}
 

--- a/ethcore/src/blockchain/update.rs
+++ b/ethcore/src/blockchain/update.rs
@@ -28,7 +28,7 @@ pub struct ExtrasUpdate {
 	/// Current block uncompressed rlp bytes
 	pub block: Block,
 	/// Modified block hashes.
-	pub block_hashes: HashMap<BlockNumber, H256>,
+	pub block_hashes: HashMap<BlockNumber, Option<H256>>,
 	/// Modified block details.
 	pub block_details: HashMap<H256, BlockDetails>,
 	/// Modified block receipts.

--- a/ethcore/sync/src/block_sync.rs
+++ b/ethcore/sync/src/block_sync.rs
@@ -220,7 +220,7 @@ impl BlockDownloader {
 	}
 
 	/// Add new block headers.
-	pub fn import_headers(&mut self, io: &mut SyncIo, r: &Rlp, expected_hash: Option<H256>) -> Result<DownloadAction, BlockDownloaderImportError> {
+	pub fn import_headers(&mut self, io: &mut SyncIo, r: &Rlp, expected_hash: H256) -> Result<DownloadAction, BlockDownloaderImportError> {
 		let item_count = r.item_count().unwrap_or(0);
 		match self.state {
 			State::Idle => {
@@ -233,28 +233,48 @@ impl BlockDownloader {
 			_ => {}
 		};
 
+		// The request is generated in ::request_blocks.
+		let (max_count, skip) = if self.state == State::ChainHead {
+			(SUBCHAIN_SIZE as usize, (MAX_HEADERS_TO_REQUEST - 2) as u64)
+		} else {
+			(MAX_HEADERS_TO_REQUEST, 0)
+		};
+
+		if item_count > max_count {
+			debug!(target: "sync", "Headers response is larger than expected");
+			return Err(BlockDownloaderImportError::Invalid);
+		}
+
 		let mut headers = Vec::new();
 		let mut hashes = Vec::new();
-		let mut valid_response = item_count == 0; //empty response is valid
-		let mut any_known = false;
+		let mut last_header = None;
 		for i in 0..item_count {
 			let info = SyncHeader::from_rlp(r.at(i)?.as_raw().to_vec())?;
 			let number = BlockNumber::from(info.header.number());
 			let hash = info.header.hash();
-			// Check if any of the headers matches the hash we requested
-			if !valid_response {
-				if let Some(expected) = expected_hash {
-					valid_response = expected == hash;
+
+			let valid_response = match last_header {
+				// First header must match expected hash.
+				None => expected_hash == hash,
+				Some((last_number, last_hash)) => {
+					// Subsequent headers must be spaced by skip interval.
+					let skip_valid = number == last_number + skip + 1;
+					// Consecutive headers must be linked by parent hash.
+					let parent_valid = (number != last_number + 1) || *info.header.parent_hash() == last_hash;
+					skip_valid && parent_valid
 				}
+			};
+
+			// Disable the peer for this syncing round if it gives invalid chain
+			if !valid_response {
+				debug!(target: "sync", "Invalid headers response");
+				return Err(BlockDownloaderImportError::Invalid);
 			}
-			any_known = any_known || self.blocks.contains_head(&hash);
+
+			last_header = Some((number, hash));
 			if self.blocks.contains(&hash) {
 				trace!(target: "sync", "Skipping existing block header {} ({:?})", number, hash);
 				continue;
-			}
-
-			if self.highest_block.as_ref().map_or(true, |n| number > *n) {
-				self.highest_block = Some(number);
 			}
 
 			match io.chain().block_status(BlockId::Hash(hash.clone())) {
@@ -276,16 +296,15 @@ impl BlockDownloader {
 			}
 		}
 
-		// Disable the peer for this syncing round if it gives invalid chain
-		if !valid_response {
-			trace!(target: "sync", "Invalid headers response");
-			return Err(BlockDownloaderImportError::Invalid);
+		if let Some((number, _)) = last_header {
+			if self.highest_block.as_ref().map_or(true, |n| number > *n) {
+				self.highest_block = Some(number);
+			}
 		}
 
 		match self.state {
 			State::ChainHead => {
 				if !headers.is_empty() {
-					// TODO: validate heads better. E.g. check that there is enough distance between blocks.
 					trace!(target: "sync", "Received {} subchain heads, proceeding to download", headers.len());
 					self.blocks.reset_to(hashes);
 					self.state = State::Blocks;
@@ -306,8 +325,7 @@ impl BlockDownloader {
 			},
 			State::Blocks => {
 				let count = headers.len();
-				// At least one of the heads must advance the subchain. Otherwise they are all useless.
-				if count == 0 || !any_known {
+				if count == 0 {
 					trace!(target: "sync", "No useful headers");
 					return Err(BlockDownloaderImportError::Useless);
 				}

--- a/ethcore/sync/src/blocks.rs
+++ b/ethcore/sync/src/blocks.rs
@@ -215,32 +215,28 @@ impl BlockCollection {
 	}
 
 	/// Insert a collection of block bodies for previously downloaded headers.
-	pub fn insert_bodies(&mut self, bodies: Vec<SyncBody>) -> usize {
-		let mut inserted = 0;
-		for b in bodies {
-			if let Err(e) =  self.insert_body(b) {
-				trace!(target: "sync", "Ignored invalid body: {:?}", e);
-			} else {
-				inserted += 1;
-			}
-		}
-		inserted
+	pub fn insert_bodies(&mut self, bodies: Vec<SyncBody>) -> Vec<H256> {
+		bodies.into_iter()
+			.filter_map(|b| {
+				self.insert_body(b)
+					.map_err(|e| trace!(target: "sync", "Ignored invalid body: {:?}", e))
+					.ok()
+			})
+			.collect()
 	}
 
 	/// Insert a collection of block receipts for previously downloaded headers.
-	pub fn insert_receipts(&mut self, receipts: Vec<Bytes>) -> usize {
+	pub fn insert_receipts(&mut self, receipts: Vec<Bytes>) -> Vec<SmallHashVec> {
 		if !self.need_receipts {
-			return 0;
+			return Vec::new();
 		}
-		let mut inserted = 0;
-		for r in receipts {
-			if let Err(e) =  self.insert_receipt(r) {
-				trace!(target: "sync", "Ignored invalid receipt: {:?}", e);
-			} else {
-				inserted += 1;
-			}
-		}
-		inserted
+		receipts.into_iter()
+			.filter_map(|r| {
+				self.insert_receipt(r)
+					.map_err(|e| trace!(target: "sync", "Ignored invalid receipt: {:?}", e))
+					.ok()
+			})
+			.collect()
 	}
 
 	/// Returns a set of block hashes that require a body download. The returned set is marked as being downloaded.
@@ -421,7 +417,7 @@ impl BlockCollection {
 		self.downloading_headers.contains(hash) || self.downloading_bodies.contains(hash)
 	}
 
-	fn insert_body(&mut self, body: SyncBody) -> Result<(), network::Error> {
+	fn insert_body(&mut self, body: SyncBody) -> Result<H256, network::Error> {
 		let header_id = {
 			let tx_root = ordered_trie_root(Rlp::new(&body.transactions_bytes).iter().map(|r| r.as_raw()));
 			let uncles = keccak(&body.uncles_bytes);
@@ -438,7 +434,7 @@ impl BlockCollection {
 					Some(ref mut block) => {
 						trace!(target: "sync", "Got body {}", h);
 						block.body = Some(body);
-						Ok(())
+						Ok(h)
 					},
 					None => {
 						warn!("Got body with no header {}", h);
@@ -453,7 +449,7 @@ impl BlockCollection {
 		}
 	}
 
-	fn insert_receipt(&mut self, r: Bytes) -> Result<(), network::Error> {
+	fn insert_receipt(&mut self, r: Bytes) -> Result<SmallHashVec, network::Error> {
 		let receipt_root = {
 			let receipts = Rlp::new(&r);
 			ordered_trie_root(receipts.iter().map(|r| r.as_raw()))
@@ -461,7 +457,8 @@ impl BlockCollection {
 		self.downloading_receipts.remove(&receipt_root);
 		match self.receipt_ids.entry(receipt_root) {
 			hash_map::Entry::Occupied(entry) => {
-				for h in entry.remove() {
+				let block_hashes = entry.remove();
+				for h in block_hashes.iter() {
 					match self.blocks.get_mut(&h) {
 						Some(ref mut block) => {
 							trace!(target: "sync", "Got receipt {}", h);
@@ -473,7 +470,7 @@ impl BlockCollection {
 						}
 					}
 				}
-				Ok(())
+				Ok(block_hashes)
 			},
 			hash_map::Entry::Vacant(_) => {
 				trace!(target: "sync", "Ignored unknown/stale block receipt {:?}", receipt_root);

--- a/ethcore/sync/src/blocks.rs
+++ b/ethcore/sync/src/blocks.rs
@@ -481,14 +481,15 @@ impl BlockCollection {
 
 	fn insert_header(&mut self, info: SyncHeader) -> Result<H256, DecoderError> {
 		let hash = info.header.hash();
-		if self.blocks.contains_key(&hash) {
+		if self.contains(&hash) {
 			return Ok(hash);
 		}
 
+		let parent_hash = *info.header.parent_hash();
 		match self.head {
 			None if hash == self.heads[0] => {
-				trace!(target: "sync", "New head {}", hash);
-				self.head = Some(info.header.parent_hash().clone());
+				trace!(target: "sync", "New head {}", parent_hash);
+				self.head = Some(parent_hash);
 			},
 			_ => ()
 		}
@@ -526,7 +527,7 @@ impl BlockCollection {
 			(None, H256::new())
 		};
 
-		self.parents.insert(*info.header.parent_hash(), hash);
+		self.parents.insert(parent_hash, hash);
 
 		let block = SyncBlock {
 			header: info,

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -644,9 +644,9 @@ impl ChainSync {
 
 				trace!(target: "sync", "Downloading old blocks from {:?} (#{}) till {:?} (#{:?})", ancient_block_hash, ancient_block_number, chain.first_block_hash, chain.first_block_number);
 				let mut downloader = BlockDownloader::with_unlimited_reorg(true, &ancient_block_hash, ancient_block_number);
-				if let Some(hash) = chain.first_block_hash {
-					trace!(target: "sync", "Downloader target set to {:?}", hash);
-					downloader.set_target(&hash);
+				if let (Some(hash), Some(number)) = (chain.first_block_hash, chain.first_block_number) {
+					trace!(target: "sync", "Downloader target set to {:?} (#{})", hash, number);
+					downloader.set_target(&hash, number);
 				}
 				self.old_blocks = Some(downloader);
 			}


### PR DESCRIPTION
These changes improve reliability of the ancient block sync on mainnet by:

### Validating Block{Headers,Bodies,Receipts} packets against the requests sent to the peer

This uses the `asking_hash` and `asking_blocks` fields set on the peer before making a request to ensure their responses are expected and valid. One major issue I noticed is clients with corrupted chains returning a sequence of block headers that do not connect with one another. This will detect and deactivate such peers

### Skip over subchain heads already in chain

If the peers queried in the ChainHead state are not up-to-date with the chain and return no results, the downloader retracts and queries again starting from an earlier point in the chain. When it does finally query a peer with the blocks, it may be that the blocks are already stored in the BlockChain. The code currently will download all of those blocks and receipts only to later notice that it was unnecessary. Instead, it will now stay in the ChainHead state and query for more subchain heads starting at the last known block.

**TODO**: I'm working on writing tests, but wanted to post this because it's related to #9531.