### PR TITLE
disable mac ci cache

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,6 +76,7 @@ test-linux-rust-nightly:
 
 test-darwin-rust-stable:
   stage:                           test
+  cache: {}
   variables:
     CARGO_TARGET:                  x86_64-apple-darwin
     CC:                            gcc

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,7 @@ test-android-rust-stable:
 test-windows-rust-stable:
   stage:                           test
   cache:
-    key:                           "%CI_JOB_NAME%"
+    key:                           "{CI_JOB_NAME}"
     paths:
       - "%CI_PROJECT_DIR%/target/"
       - "%CI_PROJECT_DIR%/cargo/"
@@ -208,7 +208,7 @@ build-windows-msvc-x86_64:
   stage:                           build
   only:                            *releaseable_branches
   cache:
-    key:                           "%CI_JOB_NAME%"
+    key:                           "{CI_JOB_NAME}"
     paths:
       - "%CI_PROJECT_DIR%/target/"
       - "%CI_PROJECT_DIR%/cargo/"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,7 @@ test-android-rust-stable:
 test-windows-rust-stable:
   stage:                           test
   cache:
-    key:                           "{CI_JOB_NAME}"
+    key:                           "${CI_JOB_NAME}"
     paths:
       - "%CI_PROJECT_DIR%/target/"
       - "%CI_PROJECT_DIR%/cargo/"
@@ -208,7 +208,7 @@ build-windows-msvc-x86_64:
   stage:                           build
   only:                            *releaseable_branches
   cache:
-    key:                           "{CI_JOB_NAME}"
+    key:                           "${CI_JOB_NAME}"
     paths:
       - "%CI_PROJECT_DIR%/target/"
       - "%CI_PROJECT_DIR%/cargo/"


### PR DESCRIPTION
Some jobs are spending longer on caching than the actual running of tests, e.g. https://gitlab.parity.io/parity/parity-ethereum/-/jobs/101206
