### PR TITLE
Remove caching for osx tests.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,6 +76,7 @@ test-linux-rust-nightly:
 
 test-darwin-rust-stable:
   stage:                           test
+  cache: {}
   variables:
     CARGO_TARGET:                  x86_64-apple-darwin
     CC:                            gcc

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -230,3 +230,4 @@ pub fn start_ws<M, S, H, T, U, V>(
 		.session_stats(stats)
 		.start(addr)
 }
+

--- a/test.sh
+++ b/test.sh
@@ -56,4 +56,4 @@ cd parity-clib-examples/cpp && \
 # Running tests
 echo "________Running Parity Full Test Suite________"
 git submodule update --init --recursive
-time cargo test  $OPTIONS --features "$FEATURES" --all $1 -- --test-threads 8
+time cargo test  $OPTIONS --features "$FEATURES" --all $1 -- --test-threads 4


### PR DESCRIPTION
Some jobs are spending longer on caching than the actual running of tests, e.g. https://gitlab.parity.io/parity/parity-ethereum/-/jobs/101206