### PR TITLE
fix(light_fetch): avoid race with BlockNumber::Latest

### DIFF
--- a/rpc/src/v1/helpers/light_fetch.rs
+++ b/rpc/src/v1/helpers/light_fetch.rs
@@ -250,7 +250,8 @@ impl LightFetch {
 		}).join(header_fut).and_then(move |((gas_known, tx), hdr)| {
 			// then request proved execution.
 			// TODO: get last-hashes from network.
-			let env_info = match client.env_info(id) {
+			let hash = hdr.hash();
+			let env_info = match client.env_info(BlockId::Hash(hash)) {
 				Some(env_info) => env_info,
 				_ => return Either::A(future::err(errors::unknown_block())),
 			};


### PR DESCRIPTION
Fixes the issue mentioned by @cheme in https://github.com/paritytech/parity-ethereum/issues/9551#issuecomment-421399699. Instead of using `BlockNumber::Latest`, which can correspond to different blocks in two points in time, we can use hash of the header we just received.
part of #9535, related to #9551.