### PR TITLE
Verify block syncing responses against requests

### DIFF
--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -242,6 +242,7 @@ impl TestBlockChainClient {
 		*self.error_on_logs.write() = val;
 	}
 
+	/// Add a block to test client.
 	pub fn add_block<F>(&self, with: EachBlockWith, hook: F)
 		where F: Fn(BlockHeader) -> BlockHeader
 	{
@@ -298,7 +299,7 @@ impl TestBlockChainClient {
 		self.import_block(unverified).unwrap();
 	}
 
-	/// Add blocks to test client.
+	/// Add a sequence of blocks to test client.
 	pub fn add_blocks(&self, count: usize, with: EachBlockWith) {
 		for _ in 0..count {
 			self.add_block(with, |header| header);

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -118,7 +118,7 @@ pub struct TestBlockChainClient {
 }
 
 /// Used for generating test client blocks.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub enum EachBlockWith {
 	/// Plain block.
 	Nothing,
@@ -242,69 +242,67 @@ impl TestBlockChainClient {
 		*self.error_on_logs.write() = val;
 	}
 
-	/// Add blocks to test client.
-	pub fn add_blocks(&self, count: usize, with: EachBlockWith) {
-		let len = self.numbers.read().len();
-		for n in len..(len + count) {
-			let mut header = BlockHeader::new();
-			header.set_difficulty(From::from(n));
-			header.set_parent_hash(self.last_hash.read().clone());
-			header.set_number(n as BlockNumber);
-			header.set_gas_limit(U256::from(1_000_000));
-			header.set_extra_data(self.extra_data.clone());
-			let uncles = match with {
-				EachBlockWith::Uncle | EachBlockWith::UncleAndTransaction => {
-					let mut uncles = RlpStream::new_list(1);
-					let mut uncle_header = BlockHeader::new();
-					uncle_header.set_difficulty(From::from(n));
-					uncle_header.set_parent_hash(self.last_hash.read().clone());
-					uncle_header.set_number(n as BlockNumber);
-					uncles.append(&uncle_header);
-					header.set_uncles_hash(keccak(uncles.as_raw()));
-					uncles
-				},
-				_ => RlpStream::new_list(0)
-			};
-			let txs = match with {
-				EachBlockWith::Transaction | EachBlockWith::UncleAndTransaction => {
-					let mut txs = RlpStream::new_list(1);
-					let keypair = Random.generate().unwrap();
-					// Update nonces value
-					self.nonces.write().insert(keypair.address(), U256::one());
-					let tx = Transaction {
-						action: Action::Create,
-						value: U256::from(100),
-						data: "3331600055".from_hex().unwrap(),
-						gas: U256::from(100_000),
-						gas_price: U256::from(200_000_000_000u64),
-						nonce: U256::zero()
-					};
-					let signed_tx = tx.sign(keypair.secret(), None);
-					txs.append(&signed_tx);
-					txs.out()
-				},
-				_ => ::rlp::EMPTY_LIST_RLP.to_vec()
-			};
+	pub fn add_block<F>(&self, with: EachBlockWith, hook: F)
+		where F: Fn(BlockHeader) -> BlockHeader
+	{
+		let n = self.numbers.read().len();
 
-			let mut rlp = RlpStream::new_list(3);
-			rlp.append(&header);
-			rlp.append_raw(&txs, 1);
-			rlp.append_raw(uncles.as_raw(), 1);
-			let unverified = Unverified::from_rlp(rlp.out()).unwrap();
-			self.import_block(unverified).unwrap();
-		}
-	}
+		let mut header = BlockHeader::new();
+		header.set_difficulty(From::from(n));
+		header.set_parent_hash(self.last_hash.read().clone());
+		header.set_number(n as BlockNumber);
+		header.set_gas_limit(U256::from(1_000_000));
+		header.set_extra_data(self.extra_data.clone());
 
-	/// Make a bad block by setting invalid extra data.
-	pub fn corrupt_block(&self, n: BlockNumber) {
-		let hash = self.block_hash(BlockId::Number(n)).unwrap();
-		let mut header: BlockHeader = self.block_header(BlockId::Number(n)).unwrap().decode().expect("decoding failed");
-		header.set_extra_data(b"This extra data is way too long to be considered valid".to_vec());
+		header = hook(header);
+
+		let uncles = match with {
+			EachBlockWith::Uncle | EachBlockWith::UncleAndTransaction => {
+				let mut uncles = RlpStream::new_list(1);
+				let mut uncle_header = BlockHeader::new();
+				uncle_header.set_difficulty(From::from(n));
+				uncle_header.set_parent_hash(self.last_hash.read().clone());
+				uncle_header.set_number(n as BlockNumber);
+				uncles.append(&uncle_header);
+				header.set_uncles_hash(keccak(uncles.as_raw()));
+				uncles
+			},
+			_ => RlpStream::new_list(0)
+		};
+		let txs = match with {
+			EachBlockWith::Transaction | EachBlockWith::UncleAndTransaction => {
+				let mut txs = RlpStream::new_list(1);
+				let keypair = Random.generate().unwrap();
+				// Update nonces value
+				self.nonces.write().insert(keypair.address(), U256::one());
+				let tx = Transaction {
+					action: Action::Create,
+					value: U256::from(100),
+					data: "3331600055".from_hex().unwrap(),
+					gas: U256::from(100_000),
+					gas_price: U256::from(200_000_000_000u64),
+					nonce: U256::zero()
+				};
+				let signed_tx = tx.sign(keypair.secret(), None);
+				txs.append(&signed_tx);
+				txs.out()
+			},
+			_ => ::rlp::EMPTY_LIST_RLP.to_vec()
+		};
+
 		let mut rlp = RlpStream::new_list(3);
 		rlp.append(&header);
-		rlp.append_raw(&::rlp::NULL_RLP, 1);
-		rlp.append_raw(&::rlp::NULL_RLP, 1);
-		self.blocks.write().insert(hash, rlp.out());
+		rlp.append_raw(&txs, 1);
+		rlp.append_raw(uncles.as_raw(), 1);
+		let unverified = Unverified::from_rlp(rlp.out()).unwrap();
+		self.import_block(unverified).unwrap();
+	}
+
+	/// Add blocks to test client.
+	pub fn add_blocks(&self, count: usize, with: EachBlockWith) {
+		for _ in 0..count {
+			self.add_block(with, |header| header);
+		}
 	}
 
 	/// Make a bad block by setting invalid parent hash.

--- a/ethcore/sync/src/block_sync.rs
+++ b/ethcore/sync/src/block_sync.rs
@@ -332,7 +332,7 @@ impl BlockDownloader {
 	}
 
 	/// Called by peer once it has new block bodies
-	pub fn import_bodies(&mut self, r: &Rlp) -> Result<(), BlockDownloaderImportError> {
+	pub fn import_bodies(&mut self, r: &Rlp, expected_hashes: &[H256]) -> Result<(), BlockDownloaderImportError> {
 		let item_count = r.item_count().unwrap_or(0);
 		if item_count == 0 {
 			return Err(BlockDownloaderImportError::Useless);
@@ -345,8 +345,13 @@ impl BlockDownloader {
 				bodies.push(body);
 			}
 
-			if self.blocks.insert_bodies(bodies) != item_count {
+			let hashes = self.blocks.insert_bodies(bodies);
+			if hashes.len() != item_count {
 				trace!(target: "sync", "Deactivating peer for giving invalid block bodies");
+				return Err(BlockDownloaderImportError::Invalid);
+			}
+			if !all_expected(hashes.as_slice(), expected_hashes, |&a, &b| a == b) {
+				trace!(target: "sync", "Deactivating peer for giving unexpected block bodies");
 				return Err(BlockDownloaderImportError::Invalid);
 			}
 		}
@@ -354,7 +359,7 @@ impl BlockDownloader {
 	}
 
 	/// Called by peer once it has new block bodies
-	pub fn import_receipts(&mut self, _io: &mut SyncIo, r: &Rlp) -> Result<(), BlockDownloaderImportError> {
+	pub fn import_receipts(&mut self, r: &Rlp, expected_hashes: &[H256]) -> Result<(), BlockDownloaderImportError> {
 		let item_count = r.item_count().unwrap_or(0);
 		if item_count == 0 {
 			return Err(BlockDownloaderImportError::Useless);
@@ -371,8 +376,13 @@ impl BlockDownloader {
 				})?;
 				receipts.push(receipt.as_raw().to_vec());
 			}
-			if self.blocks.insert_receipts(receipts) != item_count {
+			let hashes = self.blocks.insert_receipts(receipts);
+			if hashes.len() != item_count {
 				trace!(target: "sync", "Deactivating peer for giving invalid block receipts");
+				return Err(BlockDownloaderImportError::Invalid);
+			}
+			if !all_expected(hashes.as_slice(), expected_hashes, |a, b| a.contains(b)) {
+				trace!(target: "sync", "Deactivating peer for giving unexpected block receipts");
 				return Err(BlockDownloaderImportError::Invalid);
 			}
 		}
@@ -565,6 +575,21 @@ impl BlockDownloader {
 			self.round_parents.pop_front();
 		}
 	}
+}
+
+// Determines if the first argument matches an ordered subset of the second, according to some predicate.
+fn all_expected<A, B, F>(values: &[A], expected_values: &[B], is_expected: F) -> bool
+	where F: Fn(&A, &B) -> bool
+{
+	let mut expected_iter = expected_values.iter();
+	values.iter().all(|val1| {
+		while let Some(val2) = expected_iter.next() {
+			if is_expected(val1, val2) {
+				return true;
+			}
+		}
+		false
+	})
 }
 
 //TODO: module tests

--- a/ethcore/sync/src/blocks.rs
+++ b/ethcore/sync/src/blocks.rs
@@ -398,11 +398,6 @@ impl BlockCollection {
 		self.blocks.contains_key(hash)
 	}
 
-	/// Check if collection contains a block header.
-	pub fn contains_head(&self, hash: &H256) -> bool {
-		self.heads.contains(hash)
-	}
-
 	/// Return used heap size.
 	pub fn heap_size(&self) -> usize {
 		self.heads.heap_size_of_children()

--- a/ethcore/sync/src/blocks.rs
+++ b/ethcore/sync/src/blocks.rs
@@ -212,32 +212,28 @@ impl BlockCollection {
 	}
 
 	/// Insert a collection of block bodies for previously downloaded headers.
-	pub fn insert_bodies(&mut self, bodies: Vec<SyncBody>) -> usize {
-		let mut inserted = 0;
-		for b in bodies {
-			if let Err(e) =  self.insert_body(b) {
-				trace!(target: "sync", "Ignored invalid body: {:?}", e);
-			} else {
-				inserted += 1;
-			}
-		}
-		inserted
+	pub fn insert_bodies(&mut self, bodies: Vec<SyncBody>) -> Vec<H256> {
+		bodies.into_iter()
+			.filter_map(|b| {
+				self.insert_body(b)
+					.map_err(|e| trace!(target: "sync", "Ignored invalid body: {:?}", e))
+					.ok()
+			})
+			.collect()
 	}
 
 	/// Insert a collection of block receipts for previously downloaded headers.
-	pub fn insert_receipts(&mut self, receipts: Vec<Bytes>) -> usize {
+	pub fn insert_receipts(&mut self, receipts: Vec<Bytes>) -> Vec<Vec<H256>> {
 		if !self.need_receipts {
-			return 0;
+			return Vec::new();
 		}
-		let mut inserted = 0;
-		for r in receipts {
-			if let Err(e) =  self.insert_receipt(r) {
-				trace!(target: "sync", "Ignored invalid receipt: {:?}", e);
-			} else {
-				inserted += 1;
-			}
-		}
-		inserted
+		receipts.into_iter()
+			.filter_map(|r| {
+				self.insert_receipt(r)
+					.map_err(|e| trace!(target: "sync", "Ignored invalid receipt: {:?}", e))
+					.ok()
+			})
+			.collect()
 	}
 
 	/// Returns a set of block hashes that require a body download. The returned set is marked as being downloaded.
@@ -413,7 +409,7 @@ impl BlockCollection {
 		self.downloading_headers.contains(hash) || self.downloading_bodies.contains(hash)
 	}
 
-	fn insert_body(&mut self, body: SyncBody) -> Result<(), network::Error> {
+	fn insert_body(&mut self, body: SyncBody) -> Result<H256, network::Error> {
 		let header_id = {
 			let tx_root = ordered_trie_root(Rlp::new(&body.transactions_bytes).iter().map(|r| r.as_raw()));
 			let uncles = keccak(&body.uncles_bytes);
@@ -430,7 +426,7 @@ impl BlockCollection {
 					Some(ref mut block) => {
 						trace!(target: "sync", "Got body {}", h);
 						block.body = Some(body);
-						Ok(())
+						Ok(h)
 					},
 					None => {
 						warn!("Got body with no header {}", h);
@@ -445,7 +441,7 @@ impl BlockCollection {
 		}
 	}
 
-	fn insert_receipt(&mut self, r: Bytes) -> Result<(), network::Error> {
+	fn insert_receipt(&mut self, r: Bytes) -> Result<Vec<H256>, network::Error> {
 		let receipt_root = {
 			let receipts = Rlp::new(&r);
 			ordered_trie_root(receipts.iter().map(|r| r.as_raw()))
@@ -453,7 +449,8 @@ impl BlockCollection {
 		self.downloading_receipts.remove(&receipt_root);
 		match self.receipt_ids.entry(receipt_root) {
 			hash_map::Entry::Occupied(entry) => {
-				for h in entry.remove() {
+				let block_hashes = entry.remove();
+				for h in block_hashes.iter() {
 					match self.blocks.get_mut(&h) {
 						Some(ref mut block) => {
 							trace!(target: "sync", "Got receipt {}", h);
@@ -465,7 +462,7 @@ impl BlockCollection {
 						}
 					}
 				}
-				Ok(())
+				Ok(block_hashes)
 			},
 			hash_map::Entry::Vacant(_) => {
 				trace!(target: "sync", "Ignored unknown/stale block receipt {:?}", receipt_root);


### PR DESCRIPTION
This uses the `asking_hash` and `asking_blocks` fields set on the peer before making a request to ensure their responses are expected and valid. One major issue I noticed is clients with corrupted chains returning a sequence of block headers that do not connect with one another. The additional validation on block headers especially has improved the reliability of ancient block syncing in my testing.