### PR TITLE
Calculate sha3 instead of sha256 for push-release.

### DIFF
--- a/scripts/gitlab/build-unix.sh
+++ b/scripts/gitlab/build-unix.sh
@@ -32,4 +32,5 @@ echo "_____ Calculating checksums _____"
 for binary in $(ls)
 do
   rhash --sha256 $binary -o $binary.sha256
+  ./parity tools hash $binary > $binary.sha3
 done

--- a/scripts/gitlab/build-windows.sh
+++ b/scripts/gitlab/build-windows.sh
@@ -31,5 +31,7 @@ echo "_____ Calculating checksums _____"
 for binary in $(ls)
 do
   rhash --sha256 $binary -o $binary.sha256
+  parity.exe tools hash $binary > $binary.sha3
 done
 cp parity.exe.sha256 parity.sha256
+cp parity.exe.sha3 parity.sha3

--- a/scripts/gitlab/push.sh
+++ b/scripts/gitlab/push.sh
@@ -35,9 +35,10 @@ do
   for binary in $(ls parity.sha256)
   do
     sha256=$(cat $binary | awk '{ print $1}' )
+    sha3=$(cat ${binary/sha256/sha3} | awk '{ print $1}' )
     case $DIR in
       x86_64* )
-        DATA="commit=$CI_BUILD_REF&sha3=$sha256&filename=parity$WIN&secret=$RELEASES_SECRET"
+        DATA="commit=$CI_BUILD_REF&sha3=$sha3&filename=parity$WIN&secret=$RELEASES_SECRET"
         ../../scripts/gitlab/safe_curl.sh $DATA "http://update.parity.io:1337/push-build/$CI_BUILD_REF_NAME/$DIR"
         # Kovan
         ../../scripts/gitlab/safe_curl.sh $DATA "http://update.parity.io:1338/push-build/$CI_BUILD_REF_NAME/$DIR"

--- a/scripts/gitlab/push.sh
+++ b/scripts/gitlab/push.sh
@@ -2,11 +2,17 @@
 
 set -e # fail on any error
 set -u # treat unset variables as error
-updater_push_release () {
-  echo "push release"
-  # Mainnet
 
-}
+
+echo "__________Register Release__________"
+DATA="secret=$RELEASES_SECRET"
+
+echo "Pushing release to Mainnet"
+../../scripts/gitlab/safe_curl.sh $DATA "http://update.parity.io:1337/push-release/$CI_BUILD_REF_NAME/$CI_BUILD_REF"
+
+echo "Pushing release to Kovan"
+../../scripts/gitlab/safe_curl.sh $DATA "http://update.parity.io:1338/push-release/$CI_BUILD_REF_NAME/$CI_BUILD_REF"
+
 echo "__________Set ENVIROMENT__________"
 DESCRIPTION="$(cat CHANGELOG.md)"
 RELEASE_TABLE="$(cat scripts/gitlab/templates/release-table.md)"


### PR DESCRIPTION
Closes #9668

Don't really know how to test this, so will be good if all our bash magicians could have a look.