### PR TITLE
ci: fix push script

### DIFF
--- a/scripts/gitlab/build-unix.sh
+++ b/scripts/gitlab/build-unix.sh
@@ -26,7 +26,11 @@ mkdir -p artifacts
 cd artifacts
 mkdir -p $CARGO_TARGET
 cd $CARGO_TARGET
-cp ../../target/$CARGO_TARGET/release/{parity,parity-evm,ethstore,ethkey,whisper} .
+cp ../../target/$CARGO_TARGET/release/parity ./parity
+cp ../../target/$CARGO_TARGET/release/parity-evm ./parity-evm
+cp ../../target/$CARGO_TARGET/release/ethstore ./ethstore
+cp ../../target/$CARGO_TARGET/release/ethkey ./ethkey
+cp ../../target/$CARGO_TARGET/release/whisper ./whisper
 strip -v ./*
 echo "_____ Calculating checksums _____"
 for binary in $(ls)

--- a/scripts/gitlab/build-windows.sh
+++ b/scripts/gitlab/build-windows.sh
@@ -31,7 +31,7 @@ echo "_____ Calculating checksums _____"
 for binary in $(ls)
 do
   rhash --sha256 $binary -o $binary.sha256
-  parity.exe tools hash $binary > $binary.sha3
+  ./parity.exe tools hash $binary > $binary.sha3
 done
 cp parity.exe.sha256 parity.sha256
 cp parity.exe.sha3 parity.sha3

--- a/scripts/gitlab/push.sh
+++ b/scripts/gitlab/push.sh
@@ -8,10 +8,10 @@ echo "__________Register Release__________"
 DATA="secret=$RELEASES_SECRET"
 
 echo "Pushing release to Mainnet"
-../../scripts/gitlab/safe_curl.sh $DATA "http://update.parity.io:1337/push-release/$CI_BUILD_REF_NAME/$CI_BUILD_REF"
+./scripts/gitlab/safe_curl.sh $DATA "http://update.parity.io:1337/push-release/$CI_BUILD_REF_NAME/$CI_BUILD_REF"
 
 echo "Pushing release to Kovan"
-../../scripts/gitlab/safe_curl.sh $DATA "http://update.parity.io:1338/push-release/$CI_BUILD_REF_NAME/$CI_BUILD_REF"
+./scripts/gitlab/safe_curl.sh $DATA "http://update.parity.io:1338/push-release/$CI_BUILD_REF_NAME/$CI_BUILD_REF"
 
 echo "__________Set ENVIROMENT__________"
 DESCRIPTION="$(cat CHANGELOG.md)"


### PR DESCRIPTION
Fixes https://github.com/paritytech/parity-ethereum/pull/9673#discussion_r221478221, thanks @natlg!

I guess `../..` was copied from lines below, but it was used in the context of `cd artifacts`, `cd $DIR`.