### PR TITLE
Don't hash the init_code of CREATE.

### DIFF
--- a/ethcore/evm/src/interpreter/mod.rs
+++ b/ethcore/evm/src/interpreter/mod.rs
@@ -385,8 +385,7 @@ impl<Cost: CostType> Interpreter<Cost> {
 		match result {
 			InstructionResult::JumpToPosition(position) => {
 				if self.valid_jump_destinations.is_none() {
-					let code_hash = self.params.code_hash.clone().unwrap_or_else(|| keccak(self.reader.code.as_ref()));
-					self.valid_jump_destinations = Some(self.cache.jump_destinations(&code_hash, &self.reader.code));
+					self.valid_jump_destinations = Some(self.cache.jump_destinations(&self.params.code_hash, &self.reader.code));
 				}
 				let jump_destinations = self.valid_jump_destinations.as_ref().expect("jump_destinations are initialized on first jump; qed");
 				let pos = self.verify_jump(position, jump_destinations)?;

--- a/ethcore/evm/src/interpreter/shared_cache.rs
+++ b/ethcore/evm/src/interpreter/shared_cache.rs
@@ -50,17 +50,22 @@ impl SharedCache {
 	}
 
 	/// Get jump destinations bitmap for a contract.
-	pub fn jump_destinations(&self, code_hash: &H256, code: &[u8]) -> Arc<BitSet> {
-		if code_hash == &KECCAK_EMPTY {
-			return Self::find_jump_destinations(code);
-		}
+	pub fn jump_destinations(&self, code_hash: &Option<H256>, code: &[u8]) -> Arc<BitSet> {
+		if let Some(ref code_hash) = code_hash {
+			if code_hash == &KECCAK_EMPTY {
+				return Self::find_jump_destinations(code);
+			}
 
-		if let Some(d) = self.jump_destinations.lock().get_mut(code_hash) {
-			return d.0.clone();
+			if let Some(d) = self.jump_destinations.lock().get_mut(code_hash) {
+				return d.0.clone();
+			}
 		}
 
 		let d = Self::find_jump_destinations(code);
-		self.jump_destinations.lock().insert(code_hash.clone(), Bits(d.clone()));
+
+		if let Some(ref code_hash) = code_hash {
+			self.jump_destinations.lock().insert(*code_hash, Bits(d.clone()));
+		}
 
 		d
 	}


### PR DESCRIPTION
It's usually wasteful to cache it anyway, since it's rarely re-used. Also for large init codes it hashing might be slower then jump destination computation anyway.

Similar PR for geth: https://github.com/ethereum/go-ethereum/pull/17806