### PR TITLE
Docker: run parity as normal user

### DIFF
--- a/scripts/docker/hub/Dockerfile
+++ b/scripts/docker/hub/Dockerfile
@@ -15,8 +15,17 @@ RUN apt autoremove -y
 RUN apt clean -y
 RUN rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
+RUN groupadd -g 1000 parity \
+  && useradd -m -u 1000 -g parity -s /bin/sh parity
+
+USER parity
+
+WORKDIR /home/parity
+
+ENV PATH "~/bin:${PATH}"
+
 #add TARGET to docker image
-COPY artifacts/x86_64-unknown-linux-gnu/$TARGET /usr/bin/$TARGET
+COPY artifacts/x86_64-unknown-linux-gnu/$TARGET ./bin/$TARGET
 
 # Build a shell script because the ENTRYPOINT command doesn't like using ENV
 RUN echo "#!/bin/bash \n ${TARGET} \$@" > ./entrypoint.sh


### PR DESCRIPTION
To avoid users shooting themselves in the foot, it's [best practice](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user) to avoid running the binary with superuser powers, if possible. This is designed to make privilege escalation harder.

This is actually done in [some](https://github.com/paritytech/parity-ethereum/blob/1e9aebbc86c079d23488d0c91b46491f78ae2c8a/scripts/docker/alpine/Dockerfile#L34) of the other `Dockerfile`s already, so this PR applies the same logic to the one that's pushed to Docker Hub. 