### PR TITLE
ethcore: minor optimization of modexp by using LR exponentiation

### DIFF
--- a/ethcore/benches/builtin.rs
+++ b/ethcore/benches/builtin.rs
@@ -25,12 +25,10 @@ extern crate ethereum_types;
 extern crate parity_bytes as bytes;
 extern crate rustc_hex;
 
-use std::collections::BTreeMap;
-
 use bytes::BytesRef;
 use ethcore::builtin::Builtin;
 use ethcore::machine::EthereumMachine;
-use ethereum_types::{Address, U256};
+use ethereum_types::U256;
 use ethcore::ethereum::new_byzantium_test_machine;
 use rustc_hex::FromHex;
 use self::test::Bencher;


### PR DESCRIPTION
Optimize `modexp` implementation by doing left-to-right binary exponentiation to keep multiplicands lower. The implementation can be further optimised by using a bigger limb size for the `BigUint` currently `num` is using `u32`.

benchcmp:

```
 name                          modexp_base ns/iter  modexp_final ns/iter  diff ns/iter   diff %  speedup
 modexp_eip_example1           501,834              304,093                   -197,741  -39.40%   x 1.65
 modexp_eip_example2           267                  200                            -67  -25.09%   x 1.33
 modexp_nagydani_1_pow0x10001  38,693               38,748                          55    0.14%   x 1.00
 modexp_nagydani_1_qube        7,477                6,087                       -1,390  -18.59%   x 1.23
 modexp_nagydani_1_square      5,180                3,528                       -1,652  -31.89%   x 1.47
 modexp_nagydani_2_pow0x10001  82,100               82,079                         -21   -0.03%   x 1.00
 modexp_nagydani_2_qube        14,532               10,895                      -3,637  -25.03%   x 1.33
 modexp_nagydani_2_square      10,033               6,095                       -3,938  -39.25%   x 1.65
 modexp_nagydani_3_pow0x10001  251,002              242,514                     -8,488   -3.38%   x 1.04
 modexp_nagydani_3_qube        43,365               30,771                     -12,594  -29.04%   x 1.41
 modexp_nagydani_3_square      29,139               16,189                     -12,950  -44.44%   x 1.80
 modexp_nagydani_4_pow0x10001  825,013              772,208                    -52,805   -6.40%   x 1.07
 modexp_nagydani_4_qube        137,210              94,985                     -42,225  -30.77%   x 1.44
 modexp_nagydani_4_square      92,899               47,773                     -45,126  -48.58%   x 1.94
 modexp_nagydani_5_pow0x10001  2,930,324            2,760,226                 -170,098   -5.80%   x 1.06
 modexp_nagydani_5_qube        493,096              330,857                   -162,239  -32.90%   x 1.49
 modexp_nagydani_5_square      330,625              166,783                   -163,842  -49.56%   x 1.98

```