### PR TITLE
[fix] Incompatible match arms in parity-clib

### DIFF
--- a/parity-clib/src/lib.rs
+++ b/parity-clib/src/lib.rs
@@ -191,7 +191,7 @@ pub unsafe extern "system" fn Java_io_parity_ethereum_Parity_configFromCli(env: 
 			},
 			Err(err) => {
 				let _ = env.throw_new("java/lang/Exception", err.to_string());
-				0
+				return 0
 			}
 		};
 	}


### PR DESCRIPTION
This error only shows up when building with `--all-features` so the `jni` code is built.