### PR TITLE
Schedule nightly builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,10 +24,13 @@ cache:
     - stable
     - beta
     - tags
+    variables:
+      - $SCHEDULE_TAG == "nightly"
+
 
 .collect_artifacts:                &collect_artifacts
   artifacts:
-    name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
+    name:                          "${CI_JOB_NAME}_${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}"
     when:                          on_success
     expire_in:                     1 mos
     paths:
@@ -37,7 +40,7 @@ cache:
   - VERSION="$(sed -r -n '1,/^version/s/^version = "([^"]+)".*$/\1/p' Cargo.toml)"
   - DATE_STR="$(date +%Y%m%d)"
   - ID_SHORT="$(echo ${CI_COMMIT_SHA} | cut -c 1-7)"
-  - test "${CI_COMMIT_REF_NAME}" = "nightly" && VERSION="${VERSION}-${ID_SHORT}-${DATE_STR}"
+  - test "${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}" = "nightly" && VERSION="${VERSION}-${ID_SHORT}-${DATE_STR}"
   - export VERSION
   - echo "Version = ${VERSION}"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,9 +21,10 @@ cache:
 
 .releaseable_branches:             # list of git refs for building GitLab artifacts (think "pre-release binaries")
   only:                            &releaseable_branches
-    - stable
-    - beta
-    - tags
+    refs:
+      - stable
+      - beta
+      - tags
     variables:
       - $SCHEDULE_TAG == "nightly"
 

--- a/scripts/gitlab/docs-jsonrpc.sh
+++ b/scripts/gitlab/docs-jsonrpc.sh
@@ -35,10 +35,10 @@ set_remote_wiki() {
 
 commit_files() {
     echo "__________Commit files__________"
-    git checkout -b rpcdoc-update-${CI_COMMIT_REF_NAME}
+    git checkout -b rpcdoc-update-${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}
     git add .
-    git commit -m "Update docs to ${CI_COMMIT_REF_NAME}"
-    git tag -a "${CI_COMMIT_REF_NAME}" -m "Update RPC docs to ${CI_COMMIT_REF_NAME}"
+    git commit -m "Update docs to ${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}"
+    git tag -a "${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}" -m "Update RPC docs to ${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}"
 }
 
 upload_files() {

--- a/scripts/gitlab/publish-awss3.sh
+++ b/scripts/gitlab/publish-awss3.sh
@@ -7,10 +7,10 @@ echo "__________Register Release__________"
 DATA="secret=$RELEASES_SECRET"
 
 echo "Pushing release to Mainnet"
-./scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1337/push-release/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA"
+./scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1337/push-release/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$CI_COMMIT_SHA"
 
 echo "Pushing release to Kovan"
-./scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1338/push-release/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA"
+./scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1338/push-release/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$CI_COMMIT_SHA"
 
 cd artifacts
 ls -l | sort -k9
@@ -29,9 +29,9 @@ do
   case $DIR in
     x86_64* )
       DATA="commit=$CI_COMMIT_SHA&sha3=$sha3&filename=parity$WIN&secret=$RELEASES_SECRET"
-      ../../scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1337/push-build/$CI_COMMIT_REF_NAME/$DIR"
+      ../../scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1337/push-build/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$DIR"
       # Kovan
-      ../../scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1338/push-build/$CI_COMMIT_REF_NAME/$DIR"
+      ../../scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1338/push-build/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$DIR"
       ;;
   esac
   cd ..
@@ -40,10 +40,15 @@ done
 echo "__________Push binaries to AWS S3____________"
 aws configure set aws_access_key_id $s3_key
 aws configure set aws_secret_access_key $s3_secret
-if [[ "$CI_COMMIT_REF_NAME" = "beta" || "$CI_COMMIT_REF_NAME" = "stable" || "$CI_COMMIT_REF_NAME" = "nightly" ]];
-  then
+
+case "${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}" in
+  (beta|stable|nightly)
     export S3_BUCKET=builds-parity-published;
-  else
+    ;;
+  (*)
     export S3_BUCKET=builds-parity;
-fi
-aws s3 sync ./ s3://$S3_BUCKET/$CI_COMMIT_REF_NAME/
+    ;;
+esac
+
+aws s3 sync ./ s3://$S3_BUCKET/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/
+

--- a/scripts/gitlab/publish-docker.sh
+++ b/scripts/gitlab/publish-docker.sh
@@ -4,7 +4,7 @@ set -e # fail on any error
 set -u # treat unset variables as error
 
 if [ "$CI_COMMIT_REF_NAME" == "master" ];
-	then export DOCKER_BUILD_TAG="latest";
+	then export DOCKER_BUILD_TAG="${SCHEDULE_TAG:-latest}";
 	else export DOCKER_BUILD_TAG=$CI_COMMIT_REF_NAME;
 fi
 docker login -u $Docker_Hub_User_Parity -p $Docker_Hub_Pass_Parity

--- a/scripts/gitlab/test-all.sh
+++ b/scripts/gitlab/test-all.sh
@@ -6,9 +6,9 @@ set -u # treat unset variables as error
 
 git log --graph --oneline --all --decorate=short -n 10
 
-case $CI_COMMIT_REF_NAME in
+case ${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}} in
   (beta|stable)
-    export GIT_COMPARE=$CI_COMMIT_REF_NAME~
+    export GIT_COMPARE=${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}~
     ;;
   (master|nightly)
     export GIT_COMPARE=master~


### PR DESCRIPTION
with this pr one can add a scheduled pipeline with gitlab for building nightly.

the scheduled pipeline has to have the $SCHEDULE_TAG variable set to nightly in order to make this work. after that no nightly tags on the repositories itself are needed anymore.