### PR TITLE
HF in POA Core (2018-10-22)

### DIFF
--- a/ethcore/res/ethereum/poacore.json
+++ b/ethcore/res/ethereum/poacore.json
@@ -15,9 +15,14 @@
 						},
 						"772000": {
 							"safeContract": "0x83451c8bc04d4ee9745ccc58edfab88037bc48cc"
+						},
+						"5329160": {
+							"safeContract": "0xa105Db0e6671C7B5f4f350ff1Af6460E6C696e71"
 						}
 					}
-				}
+				},
+				"blockRewardContractAddress": "0x4d0153D434384128D17243409e02fca1B3EE21D6",
+				"blockRewardContractTransition": 5761140
 			}
 		}
 	},


### PR DESCRIPTION
Hard fork in POA Core is scheduled for `October 22, 2018` (block number `5329160`): https://github.com/poanetwork/wiki/wiki/HFs-Core-2018-10-22

The proposed changes correspond to the changes in our spec.json for Core: https://github.com/poanetwork/poa-chain-spec/pull/87/files#diff-42eb5109ad96d4ac46cdcbf18f2938de