### PR TITLE
removed "rustup" & added new runner tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,6 +85,7 @@ build-windows:
     - sh scripts/gitlab/build-windows.sh
   tags:
    - rust-windows
+   - windows
   <<:                              *collect_artifacts
 
 publish-docker:
@@ -162,6 +163,7 @@ test-windows:
     - sh scripts/gitlab/test-all.sh stable
   tags:
    - rust-windows
+   - windows
 
 test-beta:
   stage:                           optional

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,6 @@ build-windows:
   script:
     - sh scripts/gitlab/build-windows.sh
   tags:
-   - rust-windows
    - windows
   <<:                              *collect_artifacts
 
@@ -162,7 +161,6 @@ test-windows:
   script:
     - sh scripts/gitlab/test-all.sh stable
   tags:
-   - rust-windows
    - windows
 
 test-beta:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ build-windows:
   script:
     - sh scripts/gitlab/build-windows.sh
   tags:
-   - windows
+   - rust-windows
   <<:                              *collect_artifacts
 
 publish-docker:
@@ -161,7 +161,7 @@ test-windows:
   script:
     - sh scripts/gitlab/test-all.sh stable
   tags:
-   - windows
+   - rust-windows
 
 test-beta:
   stage:                           optional

--- a/scripts/gitlab/build-windows.sh
+++ b/scripts/gitlab/build-windows.sh
@@ -5,8 +5,6 @@ set -u # treat unset variables as error
 set INCLUDE="C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Include;C:\vs2015\VC\include;C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt"
 set LIB="C:\vs2015\VC\lib;C:\Program Files (x86)\Windows Kits\10\Lib\10.0.10240.0\ucrt\x64"
 
-rustup default stable-x86_64-pc-windows-msvc
-
 echo "__________Show ENVIROMENT__________"
 echo "CI_SERVER_NAME:   " $CI_SERVER_NAME
 echo "CARGO_HOME:       " $CARGO_HOME


### PR DESCRIPTION
* added new tag **windows** for the new windows-runner(s)
* removed the *rustup* comand from build-script. rustversion & target installed via ansible
  (https://gitlab.parity.io/parity/devops/blob/master/ansible/roles/win-gitlab-runner/tasks/main.yml)