### PR TITLE
RPC: parity_allTransactionHashes

### DIFF
--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -938,6 +938,10 @@ impl miner::MinerService for Miner {
 		self.transaction_queue.all_transactions()
 	}
 
+	fn queued_transaction_hashes(&self) -> Vec<H256> {
+		self.transaction_queue.all_transaction_hashes()
+	}
+
 	fn pending_transaction_hashes<C>(&self, chain: &C) -> BTreeSet<H256> where
 		C: ChainInfo + Sync,
 	{

--- a/ethcore/src/miner/mod.rs
+++ b/ethcore/src/miner/mod.rs
@@ -185,6 +185,9 @@ pub trait MinerService : Send + Sync {
 	/// Get a list of all transactions in the pool (some of them might not be ready for inclusion yet).
 	fn queued_transactions(&self) -> Vec<Arc<VerifiedTransaction>>;
 
+	/// Get a list of all transaction hashes in the pool (some of them might not be ready for inclusion yet).
+	fn queued_transaction_hashes(&self) -> Vec<H256>;
+
 	/// Get a list of local transactions with statuses.
 	fn local_transactions(&self) -> BTreeMap<H256, local_transactions::Status>;
 

--- a/miner/src/pool/queue.rs
+++ b/miner/src/pool/queue.rs
@@ -315,6 +315,12 @@ impl TransactionQueue {
 		self.pool.read().unordered_pending(ready).collect()
 	}
 
+	/// Returns all transaction hashes in the queue without explicit ordering.
+	pub fn all_transaction_hashes(&self) -> Vec<H256> {
+		let ready = |_tx: &pool::VerifiedTransaction| txpool::Readiness::Ready;
+		self.pool.read().unordered_pending(ready).map(|tx| tx.hash).collect()
+	}
+
 	/// Computes unordered set of pending hashes.
 	///
 	/// Since strict nonce-checking is not required, you may get some false positive future transactions as well.

--- a/rpc/src/v1/helpers/light_fetch.rs
+++ b/rpc/src/v1/helpers/light_fetch.rs
@@ -50,13 +50,11 @@ use transaction::{Action, Transaction as EthTransaction, PendingTransaction, Sig
 use v1::helpers::{CallRequest as CallRequestHelper, errors, dispatch};
 use v1::types::{BlockNumber, CallRequest, Log, Transaction};
 
-pub use self::dispatch::{LightDispatcher};
-
 const NO_INVALID_BACK_REFS_PROOF: &str = "Fails only on invalid back-references; back-references here known to be valid; qed";
 
 const WRONG_RESPONSE_AMOUNT_TYPE_PROOF: &str = "responses correspond directly with requests in amount and type; qed";
 
-pub fn light_all_transactions(dispatch: &Arc<LightDispatcher>) -> impl Iterator<Item=PendingTransaction> {
+pub fn light_all_transactions(dispatch: &Arc<dispatch::LightDispatcher>) -> impl Iterator<Item=PendingTransaction> {
 	let txq = dispatch.transaction_queue.read();
 	let chain_info = dispatch.client.chain_info();
 

--- a/rpc/src/v1/helpers/light_fetch.rs
+++ b/rpc/src/v1/helpers/light_fetch.rs
@@ -45,14 +45,25 @@ use ethereum_types::{U256, Address};
 use hash::H256;
 use parking_lot::Mutex;
 use fastmap::H256FastMap;
-use transaction::{Action, Transaction as EthTransaction, SignedTransaction, LocalizedTransaction};
+use transaction::{Action, Transaction as EthTransaction, PendingTransaction, SignedTransaction, LocalizedTransaction};
 
 use v1::helpers::{CallRequest as CallRequestHelper, errors, dispatch};
 use v1::types::{BlockNumber, CallRequest, Log, Transaction};
 
+pub use self::dispatch::{LightDispatcher};
+
 const NO_INVALID_BACK_REFS_PROOF: &str = "Fails only on invalid back-references; back-references here known to be valid; qed";
 
 const WRONG_RESPONSE_AMOUNT_TYPE_PROOF: &str = "responses correspond directly with requests in amount and type; qed";
+
+pub fn light_all_transactions(dispatch: &Arc<LightDispatcher>) -> impl Iterator<Item=PendingTransaction> {
+	let txq = dispatch.transaction_queue.read();
+	let chain_info = dispatch.client.chain_info();
+
+	let current = txq.ready_transactions(chain_info.best_block_number, chain_info.best_block_timestamp);
+	let future = txq.future_transactions(chain_info.best_block_number, chain_info.best_block_timestamp);
+	current.into_iter().chain(future.into_iter())
+}
 
 /// Helper for fetching blockchain data either from the light client or the network
 /// as necessary.

--- a/rpc/src/v1/helpers/mod.rs
+++ b/rpc/src/v1/helpers/mod.rs
@@ -36,10 +36,6 @@ mod subscribers;
 mod subscription_manager;
 mod work;
 
-use std::sync::Arc;
-
-use transaction::PendingTransaction;
-
 pub use self::dispatch::{Dispatcher, FullDispatcher, LightDispatcher};
 pub use self::network_settings::NetworkSettings;
 pub use self::poll_manager::PollManager;
@@ -59,13 +55,4 @@ pub use self::work::submit_work_detail;
 
 pub fn to_url(address: &Option<::Host>) -> Option<String> {
 	address.as_ref().map(|host| (**host).to_owned())
-}
-
-pub fn light_all_transactions(dispatch: &Arc<LightDispatcher>) -> impl Iterator<Item=PendingTransaction> {
-	let txq = dispatch.transaction_queue.read();
-	let chain_info = dispatch.client.chain_info();
-
-	let current = txq.ready_transactions(chain_info.best_block_number, chain_info.best_block_timestamp);
-	let future = txq.future_transactions(chain_info.best_block_number, chain_info.best_block_timestamp);
-	current.into_iter().chain(future.into_iter())
 }

--- a/rpc/src/v1/helpers/mod.rs
+++ b/rpc/src/v1/helpers/mod.rs
@@ -38,7 +38,7 @@ mod work;
 
 use std::sync::Arc;
 
-use transaction::{PendingTransaction};
+use transaction::PendingTransaction;
 
 pub use self::dispatch::{Dispatcher, FullDispatcher, LightDispatcher};
 pub use self::network_settings::NetworkSettings;

--- a/rpc/src/v1/impls/light/parity.rs
+++ b/rpc/src/v1/impls/light/parity.rs
@@ -34,7 +34,7 @@ use jsonrpc_core::futures::Future;
 use jsonrpc_macros::Trailing;
 use v1::helpers::{self, errors, ipfs, SigningQueue, SignerService, NetworkSettings};
 use v1::helpers::dispatch::LightDispatcher;
-use v1::helpers::light_fetch::LightFetch;
+use v1::helpers::light_fetch::{LightFetch, light_all_transactions};
 use v1::metadata::Metadata;
 use v1::traits::Parity;
 use v1::types::{
@@ -264,7 +264,7 @@ impl Parity for ParityClient {
 
 	fn all_transactions(&self) -> Result<Vec<Transaction>> {
 		Ok(
-			helpers::light_all_transactions(&self.light_dispatch)
+			light_all_transactions(&self.light_dispatch)
 				.map(|tx| Transaction::from_pending(tx))
 				.collect()
 		)
@@ -272,7 +272,7 @@ impl Parity for ParityClient {
 
 	fn all_transaction_hashes(&self) -> Result<Vec<H256>> {
 		Ok(
-			helpers::light_all_transactions(&self.light_dispatch)
+			light_all_transactions(&self.light_dispatch)
 				.map(|tx| tx.transaction.hash().into())
 				.collect()
 		)

--- a/rpc/src/v1/impls/light/parity.rs
+++ b/rpc/src/v1/impls/light/parity.rs
@@ -263,32 +263,18 @@ impl Parity for ParityClient {
 	}
 
 	fn all_transactions(&self) -> Result<Vec<Transaction>> {
-		let txq = self.light_dispatch.transaction_queue.read();
-		let chain_info = self.light_dispatch.client.chain_info();
-
-		let current = txq.ready_transactions(chain_info.best_block_number, chain_info.best_block_timestamp);
-		let future = txq.future_transactions(chain_info.best_block_number, chain_info.best_block_timestamp);
 		Ok(
-			current
-				.into_iter()
-				.chain(future.into_iter())
+			helpers::light_all_transactions(&self.light_dispatch)
 				.map(|tx| Transaction::from_pending(tx))
-				.collect::<Vec<_>>()
+				.collect()
 		)
 	}
 
 	fn all_transaction_hashes(&self) -> Result<Vec<H256>> {
-		let txq = self.light_dispatch.transaction_queue.read();
-		let chain_info = self.light_dispatch.client.chain_info();
-
-		let current = txq.ready_transactions(chain_info.best_block_number, chain_info.best_block_timestamp);
-		let future = txq.future_transactions(chain_info.best_block_number, chain_info.best_block_timestamp);
 		Ok(
-			current
-				.into_iter()
-				.chain(future.into_iter())
-				.map(|tx| Transaction::from_pending(tx).hash.into())
-				.collect::<Vec<_>>()
+			helpers::light_all_transactions(&self.light_dispatch)
+				.map(|tx| tx.transaction.hash().into())
+				.collect()
 		)
 	}
 

--- a/rpc/src/v1/impls/light/parity.rs
+++ b/rpc/src/v1/impls/light/parity.rs
@@ -277,6 +277,21 @@ impl Parity for ParityClient {
 		)
 	}
 
+	fn all_transaction_hashes(&self) -> Result<Vec<H256>> {
+		let txq = self.light_dispatch.transaction_queue.read();
+		let chain_info = self.light_dispatch.client.chain_info();
+
+		let current = txq.ready_transactions(chain_info.best_block_number, chain_info.best_block_timestamp);
+		let future = txq.future_transactions(chain_info.best_block_number, chain_info.best_block_timestamp);
+		Ok(
+			current
+				.into_iter()
+				.chain(future.into_iter())
+				.map(|tx| Transaction::from_pending(tx).hash.into())
+				.collect::<Vec<_>>()
+		)
+	}
+
 	fn future_transactions(&self) -> Result<Vec<Transaction>> {
 		let txq = self.light_dispatch.transaction_queue.read();
 		let chain_info = self.light_dispatch.client.chain_info();

--- a/rpc/src/v1/impls/parity.rs
+++ b/rpc/src/v1/impls/parity.rs
@@ -309,6 +309,16 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 		)
 	}
 
+	fn all_transaction_hashes(&self) -> Result<Vec<H256>> {
+		let all_transaction_hashes = self.miner.queued_transaction_hashes();
+
+		Ok(all_transaction_hashes
+			.into_iter()
+			.map(|hash| hash.into())
+			.collect()
+		)
+	}
+
 	fn future_transactions(&self) -> Result<Vec<Transaction>> {
 		Err(errors::deprecated("Use `parity_allTransaction` instead."))
 	}

--- a/rpc/src/v1/tests/helpers/miner_service.rs
+++ b/rpc/src/v1/tests/helpers/miner_service.rs
@@ -230,6 +230,10 @@ impl MinerService for TestMinerService {
 		}).collect()
 	}
 
+	fn queued_transaction_hashes(&self) -> Vec<H256> {
+		self.pending_transactions.lock().keys().cloned().map(|hash| hash).collect()
+	}
+
 	fn pending_receipts(&self, _best_block: BlockNumber) -> Option<Vec<RichReceipt>> {
 		Some(self.pending_receipts.lock().clone())
 	}

--- a/rpc/src/v1/traits/parity.rs
+++ b/rpc/src/v1/traits/parity.rs
@@ -148,6 +148,10 @@ build_rpc_trait! {
 		#[rpc(name = "parity_allTransactions")]
 		fn all_transactions(&self) -> Result<Vec<Transaction>>;
 
+		/// Same as parity_allTransactions, but return only transactions hashes.
+		#[rpc(name = "parity_allTransactionHashes")]
+		fn all_transaction_hashes(&self) -> Result<Vec<H256>>;
+
 		/// Returns all future transactions from transaction queue (deprecated)
 		#[rpc(name = "parity_futureTransactions")]
 		fn future_transactions(&self) -> Result<Vec<Transaction>>;


### PR DESCRIPTION
Issue: https://github.com/paritytech/parity-ethereum/issues/9713
Sorry, probably you will say that code is shitty and I'll agree :) this is my first attempt write something on Rust and I made quick patch.
I tested with pool size 20k, `parity_allTransactionHashes` need ~100-200ms.
I'll try make measurements how `eth_getTransactionByHash` for new transactions will slow process when will have time.