### PR TITLE
Stable release 2.0.8 backports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,7 +1957,7 @@ source = "git+https://github.com/paritytech/parity-common#0045887fecd2fec39e56c9
 name = "parity-clib"
 version = "1.12.0"
 dependencies = [
- "parity-ethereum 2.0.7",
+ "parity-ethereum 2.0.8",
 ]
 
 [[package]]
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "parity-ethereum"
-version = "2.0.7"
+version = "2.0.8"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2023,7 +2023,7 @@ dependencies = [
  "parity-rpc 1.12.0",
  "parity-rpc-client 1.4.0",
  "parity-updater 1.12.0",
- "parity-version 2.0.7",
+ "parity-version 2.0.8",
  "parity-whisper 0.1.0",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "path 0.1.1 (git+https://github.com/paritytech/parity-common)",
@@ -2162,7 +2162,7 @@ dependencies = [
  "parity-crypto 0.1.0 (git+https://github.com/paritytech/parity-common)",
  "parity-reactor 0.1.0",
  "parity-updater 1.12.0",
- "parity-version 2.0.7",
+ "parity-version 2.0.8",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "patricia-trie 0.2.1 (git+https://github.com/paritytech/parity-common)",
  "plain_hasher 0.1.0 (git+https://github.com/paritytech/parity-common)",
@@ -2233,7 +2233,7 @@ dependencies = [
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (git+https://github.com/paritytech/parity-common)",
  "parity-hash-fetch 1.12.0",
- "parity-version 2.0.7",
+ "parity-version 2.0.8",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "path 0.1.1 (git+https://github.com/paritytech/parity-common)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "2.0.7"
+version = "2.0.8"
 dependencies = [
  "parity-bytes 0.1.0 (git+https://github.com/paritytech/parity-common)",
  "rlp 0.2.1 (git+https://github.com/paritytech/parity-common)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Parity Ethereum client"
 name = "parity-ethereum"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "2.0.7"
+version = "2.0.8"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 

--- a/ethcore/evm/src/interpreter/gasometer.rs
+++ b/ethcore/evm/src/interpreter/gasometer.rs
@@ -403,7 +403,7 @@ fn calculate_eip1283_sstore_gas<Gas: evm::CostType>(schedule: &Schedule, origina
 }
 
 pub fn handle_eip1283_sstore_clears_refund(ext: &mut vm::Ext, original: &U256, current: &U256, new: &U256) {
-	let sstore_clears_schedule = U256::from(ext.schedule().sstore_refund_gas);
+	let sstore_clears_schedule = ext.schedule().sstore_refund_gas;
 
 	if current == new {
 		// 1. If current value equals new value (this is a no-op), 200 gas is deducted.
@@ -438,11 +438,11 @@ pub fn handle_eip1283_sstore_clears_refund(ext: &mut vm::Ext, original: &U256, c
 				// 2.2.2. If original value equals new value (this storage slot is reset)
 				if original.is_zero() {
 					// 2.2.2.1. If original value is 0, add 19800 gas to refund counter.
-					let refund = U256::from(ext.schedule().sstore_set_gas - ext.schedule().sload_gas);
+					let refund = ext.schedule().sstore_set_gas - ext.schedule().sload_gas;
 					ext.add_sstore_refund(refund);
 				} else {
 					// 2.2.2.2. Otherwise, add 4800 gas to refund counter.
-					let refund = U256::from(ext.schedule().sstore_reset_gas - ext.schedule().sload_gas);
+					let refund = ext.schedule().sstore_reset_gas - ext.schedule().sload_gas;
 					ext.add_sstore_refund(refund);
 				}
 			}

--- a/ethcore/evm/src/interpreter/mod.rs
+++ b/ethcore/evm/src/interpreter/mod.rs
@@ -519,7 +519,7 @@ impl<Cost: CostType> Interpreter<Cost> {
 					gasometer::handle_eip1283_sstore_clears_refund(ext, &original_val, &current_val, &val);
 				} else {
 					if !current_val.is_zero() && val.is_zero() {
-						let sstore_clears_schedule = U256::from(ext.schedule().sstore_refund_gas);
+						let sstore_clears_schedule = ext.schedule().sstore_refund_gas;
 						ext.add_sstore_refund(sstore_clears_schedule);
 					}
 				}

--- a/ethcore/evm/src/tests.rs
+++ b/ethcore/evm/src/tests.rs
@@ -716,7 +716,7 @@ fn test_jumps(factory: super::Factory) {
 		test_finalize(vm.exec(params, &mut ext)).unwrap()
 	};
 
-	assert_eq!(ext.sstore_clears, U256::from(ext.schedule.sstore_refund_gas));
+	assert_eq!(ext.sstore_clears, ext.schedule.sstore_refund_gas as i128);
 	assert_store(&ext, 0, "0000000000000000000000000000000000000000000000000000000000000000"); // 5!
 	assert_store(&ext, 1, "0000000000000000000000000000000000000000000000000000000000000078"); // 5!
 	assert_eq!(gas_left, U256::from(54_117));

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -317,7 +317,7 @@ impl EmptyStep {
 
 impl fmt::Display for EmptyStep {
 	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-		write!(f, "({}, {}, {})", self.signature, self.step, self.parent_hash)
+		write!(f, "({:x}, {}, {:x})", self.signature, self.step, self.parent_hash)
 	}
 }
 
@@ -825,6 +825,10 @@ impl Engine<EthereumMachine> for AuthorityRound {
 
 	/// Additional engine-specific information for the user/developer concerning `header`.
 	fn extra_info(&self, header: &Header) -> BTreeMap<String, String> {
+		if header.seal().len() < header_expected_seal_fields(header, self.empty_steps_transition) {
+			return BTreeMap::default();
+		}
+
 		let step = header_step(header, self.empty_steps_transition).as_ref().map(ToString::to_string).unwrap_or("".into());
 		let signature = header_signature(header, self.empty_steps_transition).as_ref().map(ToString::to_string).unwrap_or("".into());
 
@@ -1409,10 +1413,12 @@ impl Engine<EthereumMachine> for AuthorityRound {
 
 #[cfg(test)]
 mod tests {
+	use std::collections::BTreeMap;
 	use std::sync::Arc;
 	use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 	use hash::keccak;
 	use ethereum_types::{Address, H520, H256, U256};
+	use ethkey::Signature;
 	use header::Header;
 	use rlp::encode;
 	use block::*;
@@ -2066,5 +2072,41 @@ mod tests {
 			b2.block().state().balance(&addr1).unwrap(),
 			addr1_balance + (1000 + 0).into() + (1000 + 2).into(),
 		)
+	}
+
+	#[test]
+	fn extra_info_from_seal() {
+		let (spec, tap, accounts) = setup_empty_steps();
+		let engine = &*spec.engine;
+
+		let addr1 = accounts[0];
+		engine.set_signer(tap.clone(), addr1, "1".into());
+
+		let mut header: Header = Header::default();
+		let empty_step = empty_step(engine, 1, &header.parent_hash());
+		let sealed_empty_step = empty_step.sealed();
+
+		header.set_number(2);
+		header.set_seal(vec![
+			encode(&2usize).to_vec(),
+			encode(&H520::default()).to_vec(),
+			::rlp::encode_list(&vec![sealed_empty_step]).to_vec(),
+		]);
+
+		let info = engine.extra_info(&header);
+
+		let mut expected = BTreeMap::default();
+		expected.insert("step".into(), "2".into());
+		expected.insert("signature".into(), Signature::from(H520::default()).to_string());
+		expected.insert("emptySteps".into(), format!("[{}]", empty_step));
+
+		assert_eq!(info, expected);
+
+		header.set_seal(vec![]);
+
+		assert_eq!(
+			engine.extra_info(&header),
+			BTreeMap::default(),
+		);
 	}
 }

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -613,7 +613,8 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 		let schedule = self.machine.schedule(self.info.number);
 
 		// refunds from SSTORE nonzero -> zero
-		let sstore_refunds = substate.sstore_clears_refund;
+		assert!(substate.sstore_clears_refund >= 0, "On transaction level, sstore clears refund cannot go below zero.");
+		let sstore_refunds = U256::from(substate.sstore_clears_refund as u64);
 		// refunds from contract suicides
 		let suicide_refunds = U256::from(schedule.suicide_refund_gas) * U256::from(substate.suicides.len());
 		let refunds_bound = sstore_refunds + suicide_refunds;
@@ -1625,7 +1626,7 @@ mod tests {
 		let gas_used = gas - gas_left;
 		// sstore: 0 -> (1) -> () -> (1 -> 0 -> 1)
 		assert_eq!(gas_used, U256::from(41860));
-		assert_eq!(refund, U256::from(19800));
+		assert_eq!(refund, 19800);
 
 		assert_eq!(state.storage_at(&operating_address, &k).unwrap(), H256::from(U256::from(1)));
 		// Test a call via top-level -> y2 -> x2
@@ -1643,7 +1644,7 @@ mod tests {
 		let gas_used = gas - gas_left;
 		// sstore: 1 -> (1) -> () -> (0 -> 1 -> 0)
 		assert_eq!(gas_used, U256::from(11860));
-		assert_eq!(refund, U256::from(19800));
+		assert_eq!(refund, 19800);
 	}
 
 	fn wasm_sample_code() -> Arc<Vec<u8>> {

--- a/ethcore/src/externalities.rs
+++ b/ethcore/src/externalities.rs
@@ -398,12 +398,12 @@ impl<'a, T: 'a, V: 'a, B: 'a> Ext for Externalities<'a, T, V, B>
 		self.depth
 	}
 
-	fn add_sstore_refund(&mut self, value: U256) {
-		self.substate.sstore_clears_refund = self.substate.sstore_clears_refund.saturating_add(value);
+	fn add_sstore_refund(&mut self, value: usize) {
+		self.substate.sstore_clears_refund += value as i128;
 	}
 
-	fn sub_sstore_refund(&mut self, value: U256) {
-		self.substate.sstore_clears_refund = self.substate.sstore_clears_refund.saturating_sub(value);
+	fn sub_sstore_refund(&mut self, value: usize) {
+		self.substate.sstore_clears_refund -= value as i128;
 	}
 
 	fn trace_next_instruction(&mut self, pc: usize, instruction: u8, current_gas: U256) -> bool {

--- a/ethcore/src/json_tests/executive.rs
+++ b/ethcore/src/json_tests/executive.rs
@@ -209,11 +209,11 @@ impl<'a, T: 'a, V: 'a, B: 'a> Ext for TestExt<'a, T, V, B>
 		false
 	}
 
-	fn add_sstore_refund(&mut self, value: U256) {
+	fn add_sstore_refund(&mut self, value: usize) {
 		self.ext.add_sstore_refund(value)
 	}
 
-	fn sub_sstore_refund(&mut self, value: U256) {
+	fn sub_sstore_refund(&mut self, value: usize) {
 		self.ext.sub_sstore_refund(value)
 	}
 }

--- a/ethcore/src/state/substate.rs
+++ b/ethcore/src/state/substate.rs
@@ -16,7 +16,7 @@
 
 //! Execution environment substate.
 use std::collections::HashSet;
-use ethereum_types::{U256, Address};
+use ethereum_types::Address;
 use log_entry::LogEntry;
 use evm::{Schedule, CleanDustMode};
 use super::CleanupMode;
@@ -35,7 +35,7 @@ pub struct Substate {
 	pub logs: Vec<LogEntry>,
 
 	/// Refund counter of SSTORE.
-	pub sstore_clears_refund: U256,
+	pub sstore_clears_refund: i128,
 
 	/// Created contracts.
 	pub contracts_created: Vec<Address>,
@@ -52,7 +52,7 @@ impl Substate {
 		self.suicides.extend(s.suicides);
 		self.touched.extend(s.touched);
 		self.logs.extend(s.logs);
-		self.sstore_clears_refund = self.sstore_clears_refund + s.sstore_clears_refund;
+		self.sstore_clears_refund += s.sstore_clears_refund;
 		self.contracts_created.extend(s.contracts_created);
 	}
 

--- a/ethcore/vm/src/ext.rs
+++ b/ethcore/vm/src/ext.rs
@@ -141,10 +141,10 @@ pub trait Ext {
 	fn depth(&self) -> usize;
 
 	/// Increments sstore refunds counter.
-	fn add_sstore_refund(&mut self, value: U256);
+	fn add_sstore_refund(&mut self, value: usize);
 
 	/// Decrements sstore refunds counter.
-	fn sub_sstore_refund(&mut self, value: U256);
+	fn sub_sstore_refund(&mut self, value: usize);
 
 	/// Decide if any more operations should be traced. Passthrough for the VM trace.
 	fn trace_next_instruction(&mut self, _pc: usize, _instruction: u8, _current_gas: U256) -> bool { false }

--- a/ethcore/vm/src/tests.rs
+++ b/ethcore/vm/src/tests.rs
@@ -56,7 +56,7 @@ pub struct FakeExt {
 	pub store: HashMap<H256, H256>,
 	pub suicides: HashSet<Address>,
 	pub calls: HashSet<FakeCall>,
-	pub sstore_clears: U256,
+	pub sstore_clears: i128,
 	pub depth: usize,
 	pub blockhashes: HashMap<U256, H256>,
 	pub codes: HashMap<Address, Arc<Bytes>>,
@@ -221,12 +221,12 @@ impl Ext for FakeExt {
 		self.is_static
 	}
 
-	fn add_sstore_refund(&mut self, value: U256) {
-		self.sstore_clears = self.sstore_clears + value;
+	fn add_sstore_refund(&mut self, value: usize) {
+		self.sstore_clears += value as i128;
 	}
 
-	fn sub_sstore_refund(&mut self, value: U256) {
-		self.sstore_clears = self.sstore_clears - value;
+	fn sub_sstore_refund(&mut self, value: usize) {
+		self.sstore_clears -= value as i128;
 	}
 
 	fn trace_next_instruction(&mut self, _pc: usize, _instruction: u8, _gas: U256) -> bool {

--- a/ethcore/wasm/src/runtime.rs
+++ b/ethcore/wasm/src/runtime.rs
@@ -284,7 +284,7 @@ impl<'a> Runtime<'a> {
 		self.ext.set_storage(key, val).map_err(|_| Error::StorageUpdateError)?;
 
 		if former_val != H256::zero() && val == H256::zero() {
-			let sstore_clears_schedule = U256::from(self.schedule().sstore_refund_gas);
+			let sstore_clears_schedule = self.schedule().sstore_refund_gas;
 			self.ext.add_sstore_refund(sstore_clears_schedule);
 		}
 

--- a/scripts/gitlab/cargo-audit.sh
+++ b/scripts/gitlab/cargo-audit.sh
@@ -3,5 +3,5 @@
 set -e # fail on any error
 set -u # treat unset variables as error
 
-CARGO_TARGET_DIR=./target cargo +stable install cargo-audit
+CARGO_TARGET_DIR=./target cargo +stable install cargo-audit --force
 cargo +stable audit

--- a/scripts/gitlab/test-all.sh
+++ b/scripts/gitlab/test-all.sh
@@ -4,11 +4,11 @@
 set -e # fail on any error
 set -u # treat unset variables as error
 
-git log --graph --oneline --all --decorate=short -n 10
+git log --graph --oneline --decorate=short -n 10
 
-case $CI_COMMIT_REF_NAME in
+case ${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}} in
   (beta|stable)
-    export GIT_COMPARE=$CI_COMMIT_REF_NAME~
+    export GIT_COMPARE=origin/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}~
     ;;
   (master|nightly)
     export GIT_COMPARE=master~

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for Parity version string (via env CARGO_PKG_VERSION)
-version = "2.0.7"
+version = "2.0.8"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 
@@ -16,9 +16,9 @@ track = "stable"
 # Latest supported fork blocks.
 # Indicates a critical release in this track (i.e. consensus issue).
 [package.metadata.networks]
-foundation = { forkBlock = 4370000, critical = false }
-ropsten = { forkBlock = 10, critical = false }
-kovan = { forkBlock = 6600000, critical = false }
+foundation = { forkBlock = 4370000, critical = true }
+ropsten = { forkBlock = 10, critical = true }
+kovan = { forkBlock = 6600000, critical = true }
 
 [dependencies]
 parity-bytes = { git = "https://github.com/paritytech/parity-common" }


### PR DESCRIPTION
- [x] parity-version: mark 2.0.8 stable as critical
- [ ] shutdown devp2p connections (#9711)
- [ ] removed "rustup" & added new runner tag (#9731)
- [x] Add --force to cargo audit install script (#9735)
- [x] heads ref not present for branches beta and stable (#9741)
- [ ] WIP gitlab-ci: remove default variables (#9743)
- [x] Use signed 256-bit integer for sstore gas refund substate (#9746)
- [x] aura: fix panic on extra_info with unsealed block (#9755)