### PR TITLE
Ignore global cache for patched accounts

### DIFF
--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -499,6 +499,7 @@ impl Provider where {
 			None => bail!(ErrorKind::ContractDoesNotExist),
 			Some(address) => {
 				let (code, storage) = state.into_account(&address)?;
+				trace!(target: "privatetx", "Private contract executed. code: {:?}, state: {:?}, result: {:?}", code, storage, result.output);
 				let enc_code = match code {
 					Some(c) => Some(self.encrypt(&address, &Self::iv_from_address(&address), &c)?),
 					None => None,
@@ -506,7 +507,6 @@ impl Provider where {
 				(enc_code, self.encrypt(&address, &Self::iv_from_transaction(transaction), &Self::snapshot_from_storage(&storage))?)
 			},
 		};
-		trace!(target: "privatetx", "Private contract executed. code: {:?}, state: {:?}, result: {:?}", encrypted_code, encrypted_storage, result.output);
 		Ok(PrivateExecutionResult {
 			code: encrypted_code,
 			state: encrypted_storage,

--- a/ethcore/private-tx/tests/private_contract.rs
+++ b/ethcore/private-tx/tests/private_contract.rs
@@ -91,6 +91,17 @@ fn private_contract() {
 	trace!("Transaction created. Pushing block");
 	push_block_with_transactions(&client, &[public_tx]);
 
+	trace!("Querying default private state");
+	let mut query_tx = Transaction::default();
+	query_tx.action = Action::Call(address.clone());
+	query_tx.data = "0c55699c".from_hex().unwrap();  // getX
+	query_tx.gas = 50000.into();
+	query_tx.nonce = 1.into();
+	let query_tx = query_tx.sign(&key1.secret(), chain_id);
+	let result = pm.private_call(BlockId::Latest, &query_tx).unwrap();
+	assert_eq!(&result.output[..], &("0000000000000000000000000000000000000000000000000000000000000000".from_hex().unwrap()[..]));
+	assert_eq!(pm.get_validators(BlockId::Latest, &address).unwrap(), validators);
+
 	trace!("Modifying private state");
 	let mut private_tx = Transaction::default();
 	private_tx.action = Action::Call(address.clone());

--- a/ethcore/src/state/account.rs
+++ b/ethcore/src/state/account.rs
@@ -76,6 +76,9 @@ pub struct Account {
 	code_filth: Filth,
 	// Cached address hash.
 	address_hash: Cell<Option<H256>>,
+	// Patched account used to operate on the patched state with all changes in memory only
+	// Such accounts should not be committed
+	patched_account: bool,
 }
 
 impl From<BasicAccount> for Account {
@@ -92,6 +95,7 @@ impl From<BasicAccount> for Account {
 			code_cache: Arc::new(vec![]),
 			code_filth: Filth::Clean,
 			address_hash: Cell::new(None),
+			patched_account: false,
 		}
 	}
 }
@@ -112,6 +116,7 @@ impl Account {
 			code_cache: Arc::new(code),
 			code_filth: Filth::Dirty,
 			address_hash: Cell::new(None),
+			patched_account: false,
 		}
 	}
 
@@ -133,6 +138,7 @@ impl Account {
 			code_size: Some(pod.code.as_ref().map_or(0, |c| c.len())),
 			code_cache: Arc::new(pod.code.map_or_else(|| { warn!("POD account with unknown code is being created! Assuming no code."); vec![] }, |c| c)),
 			address_hash: Cell::new(None),
+			patched_account: false,
 		}
 	}
 
@@ -150,6 +156,7 @@ impl Account {
 			code_size: Some(0),
 			code_filth: Filth::Clean,
 			address_hash: Cell::new(None),
+			patched_account: false,
 		}
 	}
 
@@ -179,6 +186,7 @@ impl Account {
 			code_size: None,
 			code_filth: Filth::Clean,
 			address_hash: Cell::new(None),
+			patched_account: false,
 		}
 	}
 
@@ -204,6 +212,16 @@ impl Account {
 		self.code_filth = Filth::Dirty;
 		self.storage_cache = Self::empty_storage_cache();
 		self.storage_changes = storage;
+	}
+
+	/// Swtich account to the patched mode
+	pub fn switch_to_patched(&mut self) {
+		self.patched_account = true;
+	}
+
+	/// Returns patched mode flag
+	pub fn patched(&self) -> bool {
+		self.patched_account
 	}
 
 	/// Set (and cache) the contents of the trie's storage at `key` to `value`.
@@ -262,6 +280,10 @@ impl Account {
 	pub fn cached_storage_at(&self, key: &H256) -> Option<H256> {
 		if let Some(value) = self.storage_changes.get(key) {
 			return Some(value.clone())
+		}
+		//Use only in memory state for the patched account
+		if self.patched_account {
+			return None;
 		}
 		self.cached_moved_original_storage_at(key)
 	}
@@ -474,6 +496,7 @@ impl Account {
 
 	/// Commit the `storage_changes` to the backing DB and update `storage_root`.
 	pub fn commit_storage(&mut self, trie_factory: &TrieFactory, db: &mut HashDB<KeccakHasher, DBValue>) -> TrieResult<()> {
+		assert!(!self.patched_account, "Patched account should not be committed");
 		let mut t = trie_factory.from_existing(db, &mut self.storage_root)?;
 		for (k, v) in self.storage_changes.drain() {
 			// cast key and value to trait type,
@@ -492,6 +515,7 @@ impl Account {
 	/// Commit any unsaved code. `code_hash` will always return the hash of the `code_cache` after this.
 	pub fn commit_code(&mut self, db: &mut HashDB<KeccakHasher, DBValue>) {
 		trace!("Commiting code of {:?} - {:?}, {:?}", self, self.code_filth == Filth::Dirty, self.code_cache.is_empty());
+		assert!(!self.patched_account, "Patched account should not be committed");
 		match (self.code_filth == Filth::Dirty, self.code_cache.is_empty()) {
 			(true, true) => {
 				self.code_size = Some(0);
@@ -530,6 +554,7 @@ impl Account {
 			code_cache: self.code_cache.clone(),
 			code_filth: self.code_filth,
 			address_hash: self.address_hash.clone(),
+			patched_account: self.patched_account,
 		}
 	}
 

--- a/ethcore/src/state/account.rs
+++ b/ethcore/src/state/account.rs
@@ -204,6 +204,9 @@ impl Account {
 		self.code_filth = Filth::Dirty;
 		self.storage_cache = Self::empty_storage_cache();
 		self.storage_changes = storage;
+		if self.storage_root != KECCAK_NULL_RLP {
+			self.original_storage_cache = Some((self.storage_root, Self::empty_storage_cache()));
+		}
 		self.storage_root = KECCAK_NULL_RLP;
 	}
 

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -635,6 +635,10 @@ impl<B: Backend> State<B> {
 						if let Some(value) = f_cached_at(account, key) {
 							return Ok(value);
 						} else {
+							if account.patched() {
+								// Use only local cache for patched accounts
+								return Ok(H256::new());
+							}
 							local_account = Some(maybe_acc);
 						}
 					},
@@ -1154,7 +1158,9 @@ impl<B: Backend> State<B> {
 
 	/// Replace account code and storage. Creates account if it does not exist.
 	pub fn patch_account(&self, a: &Address, code: Arc<Bytes>, storage: HashMap<H256, H256>) -> TrieResult<()> {
-		Ok(self.require(a, false)?.reset_code_and_storage(code, storage))
+		let mut account = self.require(a, false)?;
+		account.switch_to_patched();
+		Ok(account.reset_code_and_storage(code, storage))
 	}
 }
 

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -635,10 +635,6 @@ impl<B: Backend> State<B> {
 						if let Some(value) = f_cached_at(account, key) {
 							return Ok(value);
 						} else {
-							if account.patched() {
-								// Use only local cache for patched accounts
-								return Ok(H256::new());
-							}
 							local_account = Some(maybe_acc);
 						}
 					},
@@ -1158,9 +1154,7 @@ impl<B: Backend> State<B> {
 
 	/// Replace account code and storage. Creates account if it does not exist.
 	pub fn patch_account(&self, a: &Address, code: Arc<Bytes>, storage: HashMap<H256, H256>) -> TrieResult<()> {
-		let mut account = self.require(a, false)?;
-		account.switch_to_patched();
-		Ok(account.reset_code_and_storage(code, storage))
+		Ok(self.require(a, false)?.reset_code_and_storage(code, storage))
 	}
 }
 


### PR DESCRIPTION
For private transactions we patch the state in order to apply encrypted data upon it. Such state is not commited and used only in order to calculate the results of the private transaction. In terms of this PR patched state was introduced explicitly for the state and the account in order to work with cache properly. For such patched accounts only local cache should be used (as it was changed during "patching").

Closes #9494 