### PR TITLE
sync: retry different peer after empty subchain heads response

### DIFF
--- a/ethcore/sync/src/block_sync.rs
+++ b/ethcore/sync/src/block_sync.rs
@@ -328,6 +328,7 @@ impl BlockDownloader {
 						trace_sync!(self, "No common block, disabling peer");
 						return Err(BlockDownloaderImportError::Invalid);
 					} else {
+						trace_sync!(self, "No subchain heads received, expected hash {:?}. Try a different peer.", expected_hash);
 						return Err(BlockDownloaderImportError::Useless);
 					}
 				}

--- a/ethcore/sync/src/block_sync.rs
+++ b/ethcore/sync/src/block_sync.rs
@@ -327,7 +327,7 @@ impl BlockDownloader {
 					if self.limit_reorg && best > last && (last == 0 || last < oldest_reorg) {
 						trace_sync!(self, "No common block, disabling peer");
 						return Err(BlockDownloaderImportError::Invalid);
-					} else {
+					} else if !self.limit_reorg {
 						trace_sync!(self, "No subchain heads received, expected hash {:?}. Try a different peer.", expected_hash);
 						return Err(BlockDownloaderImportError::Useless);
 					}

--- a/ethcore/sync/src/block_sync.rs
+++ b/ethcore/sync/src/block_sync.rs
@@ -327,6 +327,8 @@ impl BlockDownloader {
 					if self.limit_reorg && best > last && (last == 0 || last < oldest_reorg) {
 						trace_sync!(self, "No common block, disabling peer");
 						return Err(BlockDownloaderImportError::Invalid);
+					} else {
+						return Err(BlockDownloaderImportError::Useless);
 					}
 				}
 			},

--- a/ethcore/sync/src/block_sync.rs
+++ b/ethcore/sync/src/block_sync.rs
@@ -136,8 +136,6 @@ pub struct BlockDownloader {
 	target_hash: Option<H256>,
 	/// Probing range for seeking common best block.
 	retract_step: u64,
-	/// Whether reorg should be limited.
-	limit_reorg: bool,
 	/// consecutive useless headers this round
 	useless_headers_count: usize,
 }
@@ -146,12 +144,12 @@ impl BlockDownloader {
 	/// Create a new instance of syncing strategy.
 	/// For BlockSet::NewBlocks this won't reorganize to before the last kept state.
 	pub fn new(block_set: BlockSet, start_hash: &H256, start_number: BlockNumber) -> Self {
-		let (limit_reorg, sync_receipts) = match block_set {
-			BlockSet::NewBlocks => (true, false),
-			BlockSet::OldBlocks => (false, true)
+		let sync_receipts = match block_set {
+			BlockSet::NewBlocks => false,
+			BlockSet::OldBlocks => true
 		};
 		BlockDownloader {
-			block_set: block_set,
+			block_set,
 			state: State::Idle,
 			highest_block: None,
 			last_imported_block: start_number,
@@ -164,7 +162,6 @@ impl BlockDownloader {
 			download_receipts: sync_receipts,
 			target_hash: None,
 			retract_step: 1,
-			limit_reorg: limit_reorg,
 			useless_headers_count: 0,
 		}
 	}
@@ -321,15 +318,20 @@ impl BlockDownloader {
 					self.state = State::Blocks;
 					return Ok(DownloadAction::Reset);
 				} else {
+					trace_sync!(self, "No useful subchain heads received, expected hash {:?}", expected_hash);
 					let best = io.chain().chain_info().best_block_number;
 					let oldest_reorg = io.chain().pruning_info().earliest_state;
 					let last = self.last_imported_block;
-					if self.limit_reorg && best > last && (last == 0 || last < oldest_reorg) {
-						trace_sync!(self, "No common block, disabling peer");
-						return Err(BlockDownloaderImportError::Invalid);
-					} else if !self.limit_reorg {
-						trace_sync!(self, "No subchain heads received, expected hash {:?}. Try a different peer.", expected_hash);
-						return Err(BlockDownloaderImportError::Useless);
+					match self.block_set {
+						BlockSet::NewBlocks if best > last && (last == 0 || last < oldest_reorg) => {
+							trace_sync!(self, "No common block, disabling peer");
+							return Err(BlockDownloaderImportError::Invalid)
+						},
+						BlockSet::OldBlocks => {
+							trace_sync!(self, "Expected some useful headers for downloading OldBlocks. Try a different peer");
+							return Err(BlockDownloaderImportError::Useless)
+						},
+						_ => (),
 					}
 				}
 			},
@@ -432,7 +434,7 @@ impl BlockDownloader {
 				} else {
 					let best = io.chain().chain_info().best_block_number;
 					let oldest_reorg = io.chain().pruning_info().earliest_state;
-					if self.limit_reorg && best > start && start < oldest_reorg {
+					if self.block_set == BlockSet::NewBlocks && best > start && start < oldest_reorg {
 						debug_sync!(self, "Could not revert to previous ancient block, last: {} ({})", start, start_hash);
 						self.reset();
 					} else {


### PR DESCRIPTION
Further to #9531, I've experienced another intermittent cause of the ancient block sync retracting:

- Ancient block queue fills up, reset downloads (`blocks` is empty)
- Start a new sync round; request subchain heads
- Receive empty/useless response; we end up [here](https://github.com/paritytech/parity-ethereum/blob/master/ethcore/sync/src/block_sync.rs#L324)
- When syncing old blocks this will return `Ok`, which will end up [giving the request to the same peer again](https://github.com/paritytech/parity-ethereum/blob/master/ethcore/sync/src/chain/handler.rs#L104)
- Since `blocks` is empty and we didn't download any blocks this round, we retract a block for the next round (and later exponentially)
- That dodgy peer returns an empty/useless response again, and this process repeats which quickly causes the sync to retract to 0.

Fix is to return `Err(BlockDownloaderImportError::Useless)` in this case, which will result in that peer [being deactivated](https://github.com/paritytech/parity-ethereum/blob/master/ethcore/sync/src/chain/handler.rs#L100) for this round.

*Edit*: this appears to have been causing the behaviour detailed here: https://github.com/paritytech/parity-ethereum/issues/9306#issuecomment-414756251

Have tested this with full ancient block sync successfully twice. 