### PR TITLE
fix(light/response) : handle bad responses

### DIFF
--- a/ethcore/light/src/net/mod.rs
+++ b/ethcore/light/src/net/mod.rs
@@ -567,7 +567,12 @@ impl LightProtocol {
 			None => Err(Error::UnknownPeer), // probably only occurs in a race of some kind.
 		};
 
-		res.map(|_| IdGuard::new(peers, peer, req_id))
+		if let Err(err) = res {
+			trace!(target: "on_demand", "pre_verify_response_failed: {:?}", err);
+			Err(err)
+		} else {
+			Ok(IdGuard::new(peers, peer, req_id))
+		}
 	}
 
 	/// Handle a packet using the given io context.


### PR DESCRIPTION
#### This PR adds the following:

* Closes https://github.com/paritytech/parity-ethereum/issues/9133
* Registers empty responses as a `bad`
* Register bad responses or at least reponses that are validated as bad and only takes a decision when the  majority of the peers have come to the same conclusion.

This change the assumptions slightly i.e, before we assumed that all requests are valid and only dropped on a timeout or too many request attempts to each peer.

Might be overlapping abit with the timeouts and I plan the clean it up that code abit if/after this gets merged! Should be sufficient with this and timeouts only

### Unresolved questions:
How this will work `in a real``` network only verified by unit tests and running a light and full node locally
