### PR TITLE
Support eth_chainId RPC method

### DIFF
--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -48,6 +48,7 @@ use v1::types::{
 	RichBlock, Block, BlockTransactions, BlockNumber, Bytes, SyncStatus, SyncInfo,
 	Transaction, CallRequest, Index, Filter, Log, Receipt, Work,
 	H64 as RpcH64, H256 as RpcH256, H160 as RpcH160, U256 as RpcU256, block_number_to_id,
+	U64 as RpcU64,
 };
 use v1::metadata::Metadata;
 
@@ -511,6 +512,10 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 
 	fn is_mining(&self) -> Result<bool> {
 		Ok(self.miner.is_currently_sealing())
+	}
+
+	fn chain_id(&self) -> Result<Option<RpcU64>> {
+		Ok(self.client.signing_chain_id().map(RpcU64::from))
 	}
 
 	fn hashrate(&self) -> Result<RpcU256> {

--- a/rpc/src/v1/impls/light/eth.rs
+++ b/rpc/src/v1/impls/light/eth.rs
@@ -49,6 +49,7 @@ use v1::types::{
 	RichBlock, Block, BlockTransactions, BlockNumber, LightBlockNumber, Bytes, SyncStatus, SyncInfo,
 	Transaction, CallRequest, Index, Filter, Log, Receipt, Work,
 	H64 as RpcH64, H256 as RpcH256, H160 as RpcH160, U256 as RpcU256,
+	U64 as RpcU64,
 };
 use v1::metadata::Metadata;
 
@@ -244,6 +245,10 @@ impl<T: LightChainClient + 'static> Eth for EthClient<T> {
 
 	fn is_mining(&self) -> Result<bool> {
 		Ok(false)
+	}
+
+	fn chain_id(&self) -> Result<Option<RpcU64>> {
+		Ok(self.client.signing_chain_id().map(RpcU64::from))
 	}
 
 	fn hashrate(&self) -> Result<RpcU256> {

--- a/rpc/src/v1/impls/light/parity.rs
+++ b/rpc/src/v1/impls/light/parity.rs
@@ -38,7 +38,7 @@ use v1::helpers::light_fetch::LightFetch;
 use v1::metadata::Metadata;
 use v1::traits::Parity;
 use v1::types::{
-	Bytes, U256, U64, H64, H160, H256, H512, CallRequest,
+	Bytes, U256, H64, H160, H256, H512, CallRequest,
 	Peers, Transaction, RpcSettings, Histogram,
 	TransactionStats, LocalTransactionStatus,
 	BlockNumber, LightBlockNumber, ConsensusCapability, VersionInfo,
@@ -326,10 +326,6 @@ impl Parity for ParityClient {
 
 	fn mode(&self) -> Result<String> {
 		Err(errors::light_unimplemented(None))
-	}
-
-	fn chain_id(&self) -> Result<Option<U64>> {
-		Ok(self.client.signing_chain_id().map(U64::from))
 	}
 
 	fn chain(&self) -> Result<String> {

--- a/rpc/src/v1/impls/parity.rs
+++ b/rpc/src/v1/impls/parity.rs
@@ -40,7 +40,7 @@ use v1::helpers::{self, errors, fake_sign, ipfs, SigningQueue, SignerService, Ne
 use v1::metadata::Metadata;
 use v1::traits::Parity;
 use v1::types::{
-	Bytes, U256, U64, H64, H160, H256, H512, CallRequest,
+	Bytes, U256, H64, H160, H256, H512, CallRequest,
 	Peers, Transaction, RpcSettings, Histogram,
 	TransactionStats, LocalTransactionStatus,
 	BlockNumber, ConsensusCapability, VersionInfo,
@@ -171,10 +171,6 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 
 	fn net_chain(&self) -> Result<String> {
 		Ok(self.settings.chain.clone())
-	}
-
-	fn chain_id(&self) -> Result<Option<U64>> {
-		Ok(self.client.signing_chain_id().map(U64::from))
 	}
 
 	fn chain(&self) -> Result<String> {

--- a/rpc/src/v1/tests/mocked/eth.rs
+++ b/rpc/src/v1/tests/mocked/eth.rs
@@ -179,6 +179,15 @@ fn rpc_eth_syncing() {
 }
 
 #[test]
+fn rpc_eth_chain_id() {
+	let tester = EthTester::default();
+	let request = r#"{"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":null,"id":1}"#;
+
+	assert_eq!(tester.io.handle_request_sync(request), Some(response.to_owned()));
+}
+
+#[test]
 fn rpc_eth_hashrate() {
 	let tester = EthTester::default();
 	tester.hashrates.lock().insert(H256::from(0), (Instant::now() + Duration::from_secs(2), U256::from(0xfffa)));

--- a/rpc/src/v1/tests/mocked/parity.rs
+++ b/rpc/src/v1/tests/mocked/parity.rs
@@ -194,17 +194,6 @@ fn rpc_parity_extra_data() {
 }
 
 #[test]
-fn rpc_parity_chain_id() {
-	let deps = Dependencies::new();
-	let io = deps.default_client();
-
-	let request = r#"{"jsonrpc": "2.0", "method": "parity_chainId", "params": [], "id": 1}"#;
-	let response = r#"{"jsonrpc":"2.0","result":null,"id":1}"#;
-
-	assert_eq!(io.handle_request_sync(request), Some(response.to_owned()));
-}
-
-#[test]
 fn rpc_parity_default_extra_data() {
 	use version::version_data;
 	use bytes::ToPretty;

--- a/rpc/src/v1/traits/eth.rs
+++ b/rpc/src/v1/traits/eth.rs
@@ -20,7 +20,7 @@ use jsonrpc_macros::Trailing;
 
 use v1::types::{RichBlock, BlockNumber, Bytes, CallRequest, Filter, FilterChanges, Index};
 use v1::types::{Log, Receipt, SyncStatus, Transaction, Work};
-use v1::types::{H64, H160, H256, U256};
+use v1::types::{H64, H160, H256, U256, U64};
 
 build_rpc_trait! {
 	/// Eth rpc interface.
@@ -46,6 +46,12 @@ build_rpc_trait! {
 		/// Returns true if client is actively mining new blocks.
 		#[rpc(name = "eth_mining")]
 		fn is_mining(&self) -> Result<bool>;
+
+		/// Returns the chain ID used for transaction signing at the
+		/// current best block. None is returned if not
+		/// available.
+		#[rpc(name = "eth_chainId")]
+		fn chain_id(&self) -> Result<Option<U64>>;
 
 		/// Returns current gas_price.
 		#[rpc(name = "eth_gasPrice")]

--- a/rpc/src/v1/traits/parity.rs
+++ b/rpc/src/v1/traits/parity.rs
@@ -22,7 +22,7 @@ use jsonrpc_core::{BoxFuture, Result};
 use jsonrpc_macros::Trailing;
 
 use v1::types::{
-	H64, H160, H256, H512, U256, U64, Bytes, CallRequest,
+	H64, H160, H256, H512, U256, Bytes, CallRequest,
 	Peers, Transaction, RpcSettings, Histogram,
 	TransactionStats, LocalTransactionStatus,
 	BlockNumber, ConsensusCapability, VersionInfo,
@@ -171,12 +171,6 @@ build_rpc_trait! {
 		/// Get the mode. Returns one of: "active", "passive", "dark", "offline".
 		#[rpc(name = "parity_mode")]
 		fn mode(&self) -> Result<String>;
-
-		/// Returns the chain ID used for transaction signing at the
-		/// current best block. None is returned if not
-		/// available.
-		#[rpc(name = "parity_chainId")]
-		fn chain_id(&self) -> Result<Option<U64>>;
 
 		/// Get the chain name. Returns one of the pre-configured chain names or a filename.
 		#[rpc(name = "parity_chain")]


### PR DESCRIPTION
 * https://github.com/ethereum/EIPs/pull/695
 * Original PR is #6329 by @sorpaas

This PR copy the original PR #6329 work to support both `eth_chainId` and `parity_chainId` temporary

`parity_chainId` could be dropped later.

- EIP:695 - Implement `eth_chainId` method in JSON-RPC - https://github.com/ethereum/EIPs/pull/695 ***accepted(Aug 22 2017)***
- `eth_chainId` PR for Ethereum (geth) - https://github.com/ethereum/go-ethereum/pull/15002,  https://github.com/ethereum/go-ethereum/pull/17617 ***merged(9/9)***
- `eth_chainId` PR for ETC (classic-geth) - https://github.com/ethereumproject/go-ethereum/pull/336 ***merged(Aug 16 2017)***
- `parity_chainId` PR - https://github.com/paritytech/parity-ethereum/pull/6329 ***merged (Aug 18 2017)***

See also https://github.com/MetaMask/metamask-extension/pull/5552

(Edit: for release note, we need to mention that this replaces `parity_chainId` with `eth_chainId`.)