### PR TITLE
Add readiness check for docker container

### DIFF
--- a/scripts/docker/hub/Dockerfile
+++ b/scripts/docker/hub/Dockerfile
@@ -31,6 +31,8 @@ COPY artifacts/x86_64-unknown-linux-gnu/$TARGET ./bin/$TARGET
 RUN echo "#!/bin/bash \n ${TARGET} \$@" > ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh
 
+ADD check_sync.sh /check_sync.sh
+
 # setup ENTRYPOINT
 EXPOSE 5001 8080 8082 8083 8545 8546 8180 30303/tcp 30303/udp
 ENTRYPOINT ["./entrypoint.sh"]

--- a/scripts/docker/hub/Dockerfile
+++ b/scripts/docker/hub/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGET
 ENV TARGET ${TARGET}
 
 # install tools and dependencies
-RUN apt update && apt install -y --no-install-recommends openssl libudev-dev file
+RUN apt update && apt install -y --no-install-recommends openssl libudev-dev file curl jq
 
 # show backtraces
 ENV RUST_BACKTRACE 1

--- a/scripts/docker/hub/check_sync.sh
+++ b/scripts/docker/hub/check_sync.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# checks if parity has a fully synced blockchain
+
+ETH_SYNCING=$(curl -X POST --data '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' http://localhost:8545 -H 'Content-Type: application/json')
+RESULT=$(echo "$ETH_SYNCING" | jq -r .result)
+
+if [ "$RESULT" == "false" ]; then
+  echo "Parity is ready to start accepting traffic"
+  exit 0
+else
+  echo "Parity is still syncing the blockchain"
+  exit 1
+fi


### PR DESCRIPTION
Since parity is built for "mission critical use", I thought other operators may see the need for this.

Adding the `curl` and `jq` commands allows for an extremely simple health check to be usable in container orchestrators.

For ease of use, I've added a simple health check script that is ready to go.

Here is an example of it being used in Kubernetes

```yaml
    spec:
      containers:
        image: parity/parity:stable
        imagePullPolicy: Always
        name: parity
        readinessProbe:
          exec:
            command:
            - /check_sync.sh
          failureThreshold: 3
          initialDelaySeconds: 5
          periodSeconds: 5
          successThreshold: 1
          timeoutSeconds: 1
        resources:
          limits:
            cpu: "1"
            memory: 4Gi
          requests:
            cpu: 500m
            memory: 2Gi
```