### PR TITLE
Clean up serde rename and use rename_all = camelCase when possible

### DIFF
--- a/ethcore/wasm/run/src/fixture.rs
+++ b/ethcore/wasm/run/src/fixture.rs
@@ -24,7 +24,7 @@ use ethjson::bytes::Bytes;
 pub enum Source {
 	Raw(Cow<'static, String>),
 	Constructor {
-		#[serde(rename="constructor")]
+		#[serde(rename = "constructor")]
 		source: Cow<'static, String>,
 		arguments: Bytes,
 		sender: Address,
@@ -42,13 +42,13 @@ impl Source {
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Fixture {
 	pub caption: Cow<'static, String>,
 	pub source: Source,
 	pub address: Option<Address>,
 	pub sender: Option<Address>,
 	pub value: Option<Uint>,
-	#[serde(rename="gasLimit")]
 	pub gas_limit: Option<u64>,
 	pub payload: Option<Bytes>,
 	pub storage: Option<Vec<StorageEntry>>,
@@ -62,12 +62,12 @@ pub struct StorageEntry {
 }
 
 #[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct CallLocator {
 	pub sender: Option<Address>,
 	pub receiver: Option<Address>,
 	pub value: Option<Uint>,
 	pub data: Option<Bytes>,
-	#[serde(rename="codeAddress")]
 	pub code_address: Option<Address>,
 }
 

--- a/json/src/blockchain/block.rs
+++ b/json/src/blockchain/block.rs
@@ -23,11 +23,11 @@ use blockchain::transaction::Transaction;
 /// Blockchain test block deserializer.
 #[derive(Debug, PartialEq, Deserialize)]
 pub struct Block {
-	#[serde(rename="blockHeader")]
+	#[serde(rename = "blockHeader")]
 	header: Option<Header>,
 	rlp: Bytes,
 	transactions: Option<Vec<Transaction>>,
-	#[serde(rename="uncleHeaders")]
+	#[serde(rename = "uncleHeaders")]
 	uncles: Option<Vec<Header>>,
 }
 

--- a/json/src/blockchain/blockchain.rs
+++ b/json/src/blockchain/blockchain.rs
@@ -25,23 +25,23 @@ use spec::{ForkSpec, Genesis, Seal, Ethereum};
 
 /// Blockchain deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct BlockChain {
 	/// Genesis block header.
-	#[serde(rename="genesisBlockHeader")]
+	#[serde(rename = "genesisBlockHeader")]
 	pub genesis_block: Header,
 	/// Genesis block rlp.
-	#[serde(rename="genesisRLP")]
+	#[serde(rename = "genesisRLP")]
 	pub genesis_rlp: Option<Bytes>,
 	/// Blocks.
 	pub blocks: Vec<Block>,
 	/// Post state.
-	#[serde(rename="postState")]
 	pub post_state: State,
 	/// Pre state.
-	#[serde(rename="pre")]
+	#[serde(rename = "pre")]
 	pub pre_state: State,
 	/// Hash of best block.
-	#[serde(rename="lastblockhash")]
+	#[serde(rename = "lastblockhash")]
 	pub best_block: H256,
 	/// Network.
 	pub network: ForkSpec,

--- a/json/src/blockchain/header.rs
+++ b/json/src/blockchain/header.rs
@@ -22,26 +22,23 @@ use bytes::Bytes;
 
 /// Blockchain test header deserializer.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Header {
 	/// Blocks bloom.
 	pub bloom: Bloom,
 	/// Blocks author.
-	#[serde(rename="coinbase")]
+	#[serde(rename = "coinbase")]
 	pub author: Address,
 	/// Difficulty.
 	pub difficulty: Uint,
-	#[serde(rename="extraData")]
 	/// Extra data.
 	pub extra_data: Bytes,
 	/// Gas limit.
-	#[serde(rename="gasLimit")]
 	pub gas_limit: Uint,
 	/// Gas used.
-	#[serde(rename="gasUsed")]
 	pub gas_used: Uint,
 	/// Hash.
 	pub hash: H256,
-	#[serde(rename="mixHash")]
 	/// Mix hash.
 	pub mix_hash: H256,
 	/// Seal nonce.
@@ -49,21 +46,19 @@ pub struct Header {
 	/// Block number.
 	pub number: Uint,
 	/// Parent hash.
-	#[serde(rename="parentHash")]
 	pub parent_hash: H256,
 	/// Receipt root.
-	#[serde(rename="receiptTrie")]
+	#[serde(rename = "receiptTrie")]
 	pub receipts_root: H256,
 	/// State root.
-	#[serde(rename="stateRoot")]
 	pub state_root: H256,
 	/// Timestamp.
 	pub timestamp: Uint,
 	/// Transactions root.
-	#[serde(rename="transactionsTrie")]
+	#[serde(rename = "transactionsTrie")]
 	pub transactions_root: H256,
 	/// Uncles hash.
-	#[serde(rename="uncleHash")]
+	#[serde(rename = "uncleHash")]
 	pub uncles_hash: H256,
 }
 

--- a/json/src/blockchain/transaction.rs
+++ b/json/src/blockchain/transaction.rs
@@ -21,11 +21,10 @@ use bytes::Bytes;
 
 /// Blockchain test transaction deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Transaction {
 	data: Bytes,
-	#[serde(rename="gasLimit")]
 	gas_limit: Uint,
-	#[serde(rename="gasPrice")]
 	gas_price: Uint,
 	nonce: Uint,
 	r: Uint,

--- a/json/src/spec/authority_round.rs
+++ b/json/src/spec/authority_round.rs
@@ -23,49 +23,37 @@ use super::ValidatorSet;
 
 /// Authority params deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AuthorityRoundParams {
 	/// Block duration, in seconds.
-	#[serde(rename="stepDuration")]
 	pub step_duration: Uint,
 	/// Valid authorities
 	pub validators: ValidatorSet,
 	/// Starting step. Determined automatically if not specified.
 	/// To be used for testing only.
-	#[serde(rename="startStep")]
 	pub start_step: Option<Uint>,
 	/// Block at which score validation should start.
-	#[serde(rename="validateScoreTransition")]
 	pub validate_score_transition: Option<Uint>,
 	/// Block from which monotonic steps start.
-	#[serde(rename="validateStepTransition")]
 	pub validate_step_transition: Option<Uint>,
 	/// Whether transitions should be immediate.
-	#[serde(rename="immediateTransitions")]
 	pub immediate_transitions: Option<bool>,
 	/// Reward per block in wei.
-	#[serde(rename="blockReward")]
 	pub block_reward: Option<Uint>,
 	/// Block at which the block reward contract should start being used.
-	#[serde(rename="blockRewardContractTransition")]
 	pub block_reward_contract_transition: Option<Uint>,
 	/// Block reward contract address (setting the block reward contract
 	/// overrides the static block reward definition).
-	#[serde(rename="blockRewardContractAddress")]
 	pub block_reward_contract_address: Option<Address>,
 	/// Block reward code. This overrides the block reward contract address.
-	#[serde(rename="blockRewardContractCode")]
 	pub block_reward_contract_code: Option<Bytes>,
 	/// Block at which maximum uncle count should be considered.
-	#[serde(rename="maximumUncleCountTransition")]
 	pub maximum_uncle_count_transition: Option<Uint>,
 	/// Maximum number of accepted uncles.
-	#[serde(rename="maximumUncleCount")]
 	pub maximum_uncle_count: Option<Uint>,
 	/// Block at which empty step messages should start.
-	#[serde(rename="emptyStepsTransition")]
 	pub empty_steps_transition: Option<Uint>,
 	/// Maximum number of accepted empty steps.
-	#[serde(rename="maximumEmptySteps")]
 	pub maximum_empty_steps: Option<Uint>,
 }
 

--- a/json/src/spec/basic_authority.rs
+++ b/json/src/spec/basic_authority.rs
@@ -21,9 +21,9 @@ use super::ValidatorSet;
 
 /// Authority params deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct BasicAuthorityParams {
 	/// Block duration.
-	#[serde(rename="durationLimit")]
 	pub duration_limit: Uint,
 	/// Valid authorities
 	pub validators: ValidatorSet,

--- a/json/src/spec/builtin.rs
+++ b/json/src/spec/builtin.rs
@@ -45,15 +45,13 @@ pub struct AltBn128Pairing {
 
 /// Pricing variants.
 #[derive(Debug, PartialEq, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum Pricing {
 	/// Linear pricing.
-	#[serde(rename = "linear")]
 	Linear(Linear),
 	/// Pricing for modular exponentiation.
-	#[serde(rename = "modexp")]
 	Modexp(Modexp),
 	/// Pricing for alt_bn128_pairing exponentiation.
-	#[serde(rename = "alt_bn128_pairing")]
 	AltBn128Pairing(AltBn128Pairing),
 }
 

--- a/json/src/spec/builtin.rs
+++ b/json/src/spec/builtin.rs
@@ -47,13 +47,13 @@ pub struct AltBn128Pairing {
 #[derive(Debug, PartialEq, Deserialize, Clone)]
 pub enum Pricing {
 	/// Linear pricing.
-	#[serde(rename="linear")]
+	#[serde(rename = "linear")]
 	Linear(Linear),
 	/// Pricing for modular exponentiation.
-	#[serde(rename="modexp")]
+	#[serde(rename = "modexp")]
 	Modexp(Modexp),
 	/// Pricing for alt_bn128_pairing exponentiation.
-	#[serde(rename="alt_bn128_pairing")]
+	#[serde(rename = "alt_bn128_pairing")]
 	AltBn128Pairing(AltBn128Pairing),
 }
 

--- a/json/src/spec/engine.rs
+++ b/json/src/spec/engine.rs
@@ -22,21 +22,21 @@ use super::{Ethash, BasicAuthority, AuthorityRound, Tendermint, NullEngine, Inst
 #[derive(Debug, PartialEq, Deserialize)]
 pub enum Engine {
 	/// Null engine.
-	#[serde(rename="null")]
+	#[serde(rename = "null")]
 	Null(NullEngine),
 	/// Instantly sealing engine.
-	#[serde(rename="instantSeal")]
+	#[serde(rename = "instantSeal")]
 	InstantSeal(Option<InstantSeal>),
 	/// Ethash engine.
 	Ethash(Ethash),
 	/// BasicAuthority engine.
-	#[serde(rename="basicAuthority")]
+	#[serde(rename = "basicAuthority")]
 	BasicAuthority(BasicAuthority),
 	/// AuthorityRound engine.
-	#[serde(rename="authorityRound")]
+	#[serde(rename = "authorityRound")]
 	AuthorityRound(AuthorityRound),
 	/// Tendermint engine.
-	#[serde(rename="tendermint")]
+	#[serde(rename = "tendermint")]
 	Tendermint(Tendermint)
 }
 

--- a/json/src/spec/engine.rs
+++ b/json/src/spec/engine.rs
@@ -27,6 +27,7 @@ pub enum Engine {
 	/// Instantly sealing engine.
 	InstantSeal(Option<InstantSeal>),
 	/// Ethash engine.
+	#[serde(rename = "Ethash")]
 	Ethash(Ethash),
 	/// BasicAuthority engine.
 	BasicAuthority(BasicAuthority),

--- a/json/src/spec/engine.rs
+++ b/json/src/spec/engine.rs
@@ -20,23 +20,19 @@ use super::{Ethash, BasicAuthority, AuthorityRound, Tendermint, NullEngine, Inst
 
 /// Engine deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum Engine {
 	/// Null engine.
-	#[serde(rename = "null")]
 	Null(NullEngine),
 	/// Instantly sealing engine.
-	#[serde(rename = "instantSeal")]
 	InstantSeal(Option<InstantSeal>),
 	/// Ethash engine.
 	Ethash(Ethash),
 	/// BasicAuthority engine.
-	#[serde(rename = "basicAuthority")]
 	BasicAuthority(BasicAuthority),
 	/// AuthorityRound engine.
-	#[serde(rename = "authorityRound")]
 	AuthorityRound(AuthorityRound),
 	/// Tendermint engine.
-	#[serde(rename = "tendermint")]
 	Tendermint(Tendermint)
 }
 

--- a/json/src/spec/ethash.rs
+++ b/json/src/spec/ethash.rs
@@ -31,89 +31,67 @@ pub enum BlockReward {
 
 /// Deserializable doppelganger of EthashParams.
 #[derive(Clone, Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct EthashParams {
 	/// See main EthashParams docs.
-	#[serde(rename="minimumDifficulty")]
 	#[serde(deserialize_with="uint::validate_non_zero")]
 	pub minimum_difficulty: Uint,
 	/// See main EthashParams docs.
-	#[serde(rename="difficultyBoundDivisor")]
 	#[serde(deserialize_with="uint::validate_non_zero")]
 	pub difficulty_bound_divisor: Uint,
 	/// See main EthashParams docs.
-	#[serde(rename="difficultyIncrementDivisor")]
 	#[serde(default, deserialize_with="uint::validate_optional_non_zero")]
 	pub difficulty_increment_divisor: Option<Uint>,
 	/// See main EthashParams docs.
-	#[serde(rename="metropolisDifficultyIncrementDivisor")]
 	#[serde(default, deserialize_with="uint::validate_optional_non_zero")]
 	pub metropolis_difficulty_increment_divisor: Option<Uint>,
 	/// See main EthashParams docs.
-	#[serde(rename="durationLimit")]
 	pub duration_limit: Option<Uint>,
 
 	/// See main EthashParams docs.
-	#[serde(rename="homesteadTransition")]
 	pub homestead_transition: Option<Uint>,
 	/// Reward per block in wei.
-	#[serde(rename="blockReward")]
 	pub block_reward: Option<BlockReward>,
 	/// Block at which the block reward contract should start being used.
-	#[serde(rename="blockRewardContractTransition")]
 	pub block_reward_contract_transition: Option<Uint>,
 	/// Block reward contract address (setting the block reward contract
 	/// overrides all other block reward parameters).
-	#[serde(rename="blockRewardContractAddress")]
 	pub block_reward_contract_address: Option<Address>,
 	/// Block reward code. This overrides the block reward contract address.
-	#[serde(rename="blockRewardContractCode")]
 	pub block_reward_contract_code: Option<Bytes>,
 
 	/// See main EthashParams docs.
-	#[serde(rename="daoHardforkTransition")]
 	pub dao_hardfork_transition: Option<Uint>,
 	/// See main EthashParams docs.
-	#[serde(rename="daoHardforkBeneficiary")]
 	pub dao_hardfork_beneficiary: Option<Address>,
 	/// See main EthashParams docs.
-	#[serde(rename="daoHardforkAccounts")]
 	pub dao_hardfork_accounts: Option<Vec<Address>>,
 
 	/// See main EthashParams docs.
-	#[serde(rename="difficultyHardforkTransition")]
 	pub difficulty_hardfork_transition: Option<Uint>,
 	/// See main EthashParams docs.
-	#[serde(rename="difficultyHardforkBoundDivisor")]
 	#[serde(default, deserialize_with="uint::validate_optional_non_zero")]
 	pub difficulty_hardfork_bound_divisor: Option<Uint>,
 	/// See main EthashParams docs.
-	#[serde(rename="bombDefuseTransition")]
 	pub bomb_defuse_transition: Option<Uint>,
 
 	/// See main EthashParams docs.
-	#[serde(rename="eip100bTransition")]
 	pub eip100b_transition: Option<Uint>,
 
 	/// See main EthashParams docs.
-	#[serde(rename="ecip1010PauseTransition")]
 	pub ecip1010_pause_transition: Option<Uint>,
 	/// See main EthashParams docs.
-	#[serde(rename="ecip1010ContinueTransition")]
 	pub ecip1010_continue_transition: Option<Uint>,
 
 	/// See main EthashParams docs.
-	#[serde(rename="ecip1017EraRounds")]
 	pub ecip1017_era_rounds: Option<Uint>,
 
 	/// Delays of difficulty bombs.
-	#[serde(rename="difficultyBombDelays")]
 	pub difficulty_bomb_delays: Option<BTreeMap<Uint, Uint>>,
 
 	/// EXPIP-2 block height
-	#[serde(rename="expip2Transition")]
 	pub expip2_transition: Option<Uint>,
 	/// EXPIP-2 duration limit
-	#[serde(rename="expip2DurationLimit")]
 	pub expip2_duration_limit: Option<Uint>,
 }
 

--- a/json/src/spec/genesis.rs
+++ b/json/src/spec/genesis.rs
@@ -23,6 +23,7 @@ use spec::Seal;
 
 /// Spec genesis.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Genesis {
 	/// Seal.
 	pub seal: Seal,
@@ -33,26 +34,19 @@ pub struct Genesis {
 	/// Block timestamp, defaults to 0.
 	pub timestamp: Option<Uint>,
 	/// Parent hash, defaults to 0.
-	#[serde(rename="parentHash")]
 	pub parent_hash: Option<H256>,
 	/// Gas limit.
-	#[serde(rename="gasLimit")]
 	#[serde(deserialize_with="uint::validate_non_zero")]
 	pub gas_limit: Uint,
 	/// Transactions root.
-	#[serde(rename="transactionsRoot")]
 	pub transactions_root: Option<H256>,
 	/// Receipts root.
-	#[serde(rename="receiptsRoot")]
 	pub receipts_root: Option<H256>,
 	/// State root.
-	#[serde(rename="stateRoot")]
 	pub state_root: Option<H256>,
 	/// Gas used.
-	#[serde(rename="gasUsed")]
 	pub gas_used: Option<Uint>,
 	/// Extra data.
-	#[serde(rename="extraData")]
 	pub extra_data: Option<Bytes>,
 }
 

--- a/json/src/spec/hardcoded_sync.rs
+++ b/json/src/spec/hardcoded_sync.rs
@@ -21,14 +21,14 @@ use uint::Uint;
 
 /// Spec hardcoded sync.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct HardcodedSync {
 	/// Hexadecimal of the RLP encoding of the header of the block to start synchronization from.
 	pub header: String,
 	/// Total difficulty including the block of `header`.
-	#[serde(rename="totalDifficulty")]
 	pub total_difficulty: Uint,
 	/// Ordered trie roots of blocks before and including `header`.
-	#[serde(rename="CHTs")]
+	#[serde(rename = "CHTs")]
 	pub chts: Vec<H256>,
 }
 

--- a/json/src/spec/instant_seal.rs
+++ b/json/src/spec/instant_seal.rs
@@ -18,9 +18,9 @@
 
 /// Instant seal engine params deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InstantSealParams {
 	/// Whether to enable millisecond timestamp.
-	#[serde(rename="millisecondTimestamp")]
 	#[serde(default)]
 	pub millisecond_timestamp: bool,
 }

--- a/json/src/spec/null_engine.rs
+++ b/json/src/spec/null_engine.rs
@@ -20,9 +20,9 @@ use uint::Uint;
 
 /// Authority params deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct NullEngineParams {
 	/// Block reward.
-	#[serde(rename="blockReward")]
 	pub block_reward: Option<Uint>,
 }
 

--- a/json/src/spec/params.rs
+++ b/json/src/spec/params.rs
@@ -22,140 +22,103 @@ use bytes::Bytes;
 
 /// Spec params.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Params {
 	/// Account start nonce, defaults to 0.
-	#[serde(rename="accountStartNonce")]
 	pub account_start_nonce: Option<Uint>,
 	/// Maximum size of extra data.
-	#[serde(rename="maximumExtraDataSize")]
 	pub maximum_extra_data_size: Uint,
 	/// Minimum gas limit.
-	#[serde(rename="minGasLimit")]
 	pub min_gas_limit: Uint,
 
 	/// Network id.
-	#[serde(rename="networkID")]
+	#[serde(rename = "networkID")]
 	pub network_id: Uint,
 	/// Chain id.
-	#[serde(rename="chainID")]
+	#[serde(rename = "chainID")]
 	pub chain_id: Option<Uint>,
 
 	/// Name of the main ("eth") subprotocol.
-	#[serde(rename="subprotocolName")]
 	pub subprotocol_name: Option<String>,
 
 	/// Option fork block number to check.
-	#[serde(rename="forkBlock")]
 	pub fork_block: Option<Uint>,
 	/// Expected fork block hash.
-	#[serde(rename="forkCanonHash")]
+	#[serde(rename = "forkCanonHash")]
 	pub fork_hash: Option<H256>,
 
 	/// See main EthashParams docs.
-	#[serde(rename="eip150Transition")]
 	pub eip150_transition: Option<Uint>,
 
 	/// See main EthashParams docs.
-	#[serde(rename="eip160Transition")]
 	pub eip160_transition: Option<Uint>,
 
 	/// See main EthashParams docs.
-	#[serde(rename="eip161abcTransition")]
 	pub eip161abc_transition: Option<Uint>,
 	/// See main EthashParams docs.
-	#[serde(rename="eip161dTransition")]
 	pub eip161d_transition: Option<Uint>,
 
 	/// See `CommonParams` docs.
-	#[serde(rename="eip98Transition")]
 	pub eip98_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename="eip155Transition")]
 	pub eip155_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename="validateChainIdTransition")]
 	pub validate_chain_id_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename="validateReceiptsTransition")]
 	pub validate_receipts_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename="eip140Transition")]
 	pub eip140_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename="eip210Transition")]
 	pub eip210_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename="eip210ContractAddress")]
 	pub eip210_contract_address: Option<Address>,
 	/// See `CommonParams` docs.
-	#[serde(rename="eip210ContractCode")]
 	pub eip210_contract_code: Option<Bytes>,
 	/// See `CommonParams` docs.
-	#[serde(rename="eip210ContractGas")]
 	pub eip210_contract_gas: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename="eip211Transition")]
 	pub eip211_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename="eip145Transition")]
 	pub eip145_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename="eip214Transition")]
 	pub eip214_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename="eip658Transition")]
 	pub eip658_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename="eip1052Transition")]
 	pub eip1052_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename="eip1283Transition")]
 	pub eip1283_transition: Option<Uint>,
-	#[serde(rename="eip1014Transition")]
 	pub eip1014_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename="dustProtectionTransition")]
 	pub dust_protection_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename="nonceCapIncrement")]
 	pub nonce_cap_increment: Option<Uint>,
 	/// See `CommonParams` docs.
 	pub remove_dust_contracts : Option<bool>,
 	/// See `CommonParams` docs.
-	#[serde(rename="gasLimitBoundDivisor")]
 	#[serde(deserialize_with="uint::validate_non_zero")]
 	pub gas_limit_bound_divisor: Uint,
 	/// See `CommonParams` docs.
 	pub registrar: Option<Address>,
 	/// Apply reward flag
-	#[serde(rename="applyReward")]
 	pub apply_reward: Option<bool>,
 	/// Node permission contract address.
-	#[serde(rename="nodePermissionContract")]
 	pub node_permission_contract: Option<Address>,
 	/// See main EthashParams docs.
-	#[serde(rename="maxCodeSize")]
 	pub max_code_size: Option<Uint>,
 	/// Maximum size of transaction RLP payload.
-	#[serde(rename="maxTransactionSize")]
 	pub max_transaction_size: Option<Uint>,
 	/// See main EthashParams docs.
-	#[serde(rename="maxCodeSizeTransition")]
 	pub max_code_size_transition: Option<Uint>,
 	/// Transaction permission contract address.
-	#[serde(rename="transactionPermissionContract")]
 	pub transaction_permission_contract: Option<Address>,
 	/// Block at which the transaction permission contract should start being used.
-	#[serde(rename="transactionPermissionContractTransition")]
 	pub transaction_permission_contract_transition: Option<Uint>,
 	/// Wasm activation block height, if not activated from start
-	#[serde(rename="wasmActivationTransition")]
 	pub wasm_activation_transition: Option<Uint>,
 	/// KIP4 activiation block height.
-	#[serde(rename="kip4Transition")]
 	pub kip4_transition: Option<Uint>,
 	/// KIP6 activiation block height.
-	#[serde(rename="kip6Transition")]
 	pub kip6_transition: Option<Uint>,
 }
 

--- a/json/src/spec/seal.rs
+++ b/json/src/spec/seal.rs
@@ -22,11 +22,11 @@ use bytes::Bytes;
 
 /// Ethereum seal.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Ethereum {
 	/// Seal nonce.
 	pub nonce: H64,
 	/// Seal mix hash.
-	#[serde(rename="mixHash")]
 	pub mix_hash: H256,
 }
 
@@ -54,16 +54,16 @@ pub struct TendermintSeal {
 #[derive(Debug, PartialEq, Deserialize)]
 pub enum Seal {
 	/// Ethereum seal.
-	#[serde(rename="ethereum")]
+	#[serde(rename = "ethereum")]
 	Ethereum(Ethereum),
 	/// AuthorityRound seal.
-	#[serde(rename="authorityRound")]
+	#[serde(rename = "authorityRound")]
 	AuthorityRound(AuthorityRoundSeal),
 	/// Tendermint seal.
-	#[serde(rename="tendermint")]
+	#[serde(rename = "tendermint")]
 	Tendermint(TendermintSeal),
 	/// Generic seal.
-	#[serde(rename="generic")]
+	#[serde(rename = "generic")]
 	Generic(Bytes),
 }
 

--- a/json/src/spec/seal.rs
+++ b/json/src/spec/seal.rs
@@ -52,18 +52,15 @@ pub struct TendermintSeal {
 
 /// Seal variants.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum Seal {
 	/// Ethereum seal.
-	#[serde(rename = "ethereum")]
 	Ethereum(Ethereum),
 	/// AuthorityRound seal.
-	#[serde(rename = "authorityRound")]
 	AuthorityRound(AuthorityRoundSeal),
 	/// Tendermint seal.
-	#[serde(rename = "tendermint")]
 	Tendermint(TendermintSeal),
 	/// Generic seal.
-	#[serde(rename = "generic")]
 	Generic(Bytes),
 }
 

--- a/json/src/spec/spec.rs
+++ b/json/src/spec/spec.rs
@@ -38,11 +38,11 @@ pub enum ForkSpec {
 
 /// Spec deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Spec {
 	/// Spec name.
 	pub name: String,
 	/// Special fork name.
-	#[serde(rename="dataDir")]
 	pub data_dir: Option<String>,
 	/// Engine.
 	pub engine: Engine,
@@ -55,7 +55,6 @@ pub struct Spec {
 	/// Boot nodes.
 	pub nodes: Option<Vec<String>>,
 	/// Hardcoded synchronization for the light client.
-	#[serde(rename="hardcodedSync")]
 	pub hardcoded_sync: Option<HardcodedSync>,
 }
 

--- a/json/src/spec/tendermint.rs
+++ b/json/src/spec/tendermint.rs
@@ -21,23 +21,19 @@ use super::ValidatorSet;
 
 /// Tendermint params deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TendermintParams {
 	/// Valid validators.
 	pub validators: ValidatorSet,
 	/// Propose step timeout in milliseconds.
-	#[serde(rename="timeoutPropose")]
 	pub timeout_propose: Option<Uint>,
 	/// Prevote step timeout in milliseconds.
-	#[serde(rename="timeoutPrevote")]
 	pub timeout_prevote: Option<Uint>,
 	/// Precommit step timeout in milliseconds.
-	#[serde(rename="timeoutPrecommit")]
 	pub timeout_precommit: Option<Uint>,
 	/// Commit step timeout in milliseconds.
-	#[serde(rename="timeoutCommit")]
 	pub timeout_commit: Option<Uint>,
 	/// Reward per block.
-	#[serde(rename="blockReward")]
 	pub block_reward: Option<Uint>,
 }
 

--- a/json/src/spec/validator_set.rs
+++ b/json/src/spec/validator_set.rs
@@ -24,16 +24,16 @@ use hash::Address;
 #[derive(Debug, PartialEq, Deserialize)]
 pub enum ValidatorSet {
 	/// A simple list of authorities.
-	#[serde(rename="list")]
+	#[serde(rename = "list")]
 	List(Vec<Address>),
 	/// Address of a contract that indicates the list of authorities.
-	#[serde(rename="safeContract")]
+	#[serde(rename = "safeContract")]
 	SafeContract(Address),
 	/// Address of a contract that indicates the list of authorities and enables reporting of theor misbehaviour using transactions.
-	#[serde(rename="contract")]
+	#[serde(rename = "contract")]
 	Contract(Address),
 	/// A map of starting blocks for each validator set.
-	#[serde(rename="multi")]
+	#[serde(rename = "multi")]
 	Multi(BTreeMap<Uint, ValidatorSet>),
 }
 

--- a/json/src/spec/validator_set.rs
+++ b/json/src/spec/validator_set.rs
@@ -22,18 +22,15 @@ use hash::Address;
 
 /// Different ways of specifying validators.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum ValidatorSet {
 	/// A simple list of authorities.
-	#[serde(rename = "list")]
 	List(Vec<Address>),
 	/// Address of a contract that indicates the list of authorities.
-	#[serde(rename = "safeContract")]
 	SafeContract(Address),
 	/// Address of a contract that indicates the list of authorities and enables reporting of theor misbehaviour using transactions.
-	#[serde(rename = "contract")]
 	Contract(Address),
 	/// A map of starting blocks for each validator set.
-	#[serde(rename = "multi")]
 	Multi(BTreeMap<Uint, ValidatorSet>),
 }
 

--- a/json/src/state/state.rs
+++ b/json/src/state/state.rs
@@ -22,20 +22,20 @@ use state::{Env, AccountState, Transaction, Log};
 
 /// State test deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct State {
 	/// Environment.
 	pub env: Env,
 	/// Output.
-	#[serde(rename="out")]
+	#[serde(rename = "out")]
 	pub output: Bytes,
 	/// Pre state.
-	#[serde(rename="pre")]
+	#[serde(rename = "pre")]
 	pub pre_state: AccountState,
 	/// Post state.
-	#[serde(rename="post")]
+	#[serde(rename = "post")]
 	pub post_state: AccountState,
 	/// Post state root.
-	#[serde(rename="postStateRoot")]
 	pub post_state_root: H256,
 	/// Transaction.
 	pub transaction: Transaction,

--- a/json/src/state/test.rs
+++ b/json/src/state/test.rs
@@ -52,10 +52,10 @@ pub struct State {
 	/// Environment.
 	pub env: Env,
 	/// Pre state.
-	#[serde(rename="pre")]
+	#[serde(rename = "pre")]
 	pub pre_state: AccountState,
 	/// Post state.
-	#[serde(rename="post")]
+	#[serde(rename = "post")]
 	pub post_states: BTreeMap<ForkSpec, Vec<PostStateResult>>,
 	/// Transaction.
 	pub transaction: MultiTransaction,
@@ -63,19 +63,18 @@ pub struct State {
 
 /// State test transaction deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MultiTransaction {
 	/// Transaction data set.
 	pub data: Vec<Bytes>,
 	/// Gas limit set.
-	#[serde(rename="gasLimit")]
 	pub gas_limit: Vec<Uint>,
 	/// Gas price.
-	#[serde(rename="gasPrice")]
 	pub gas_price: Uint,
 	/// Nonce.
 	pub nonce: Uint,
 	/// Secret key.
-	#[serde(rename="secretKey")]
+	#[serde(rename = "secretKey")]
 	pub secret: Option<H256>,
 	/// To.
 	pub to: MaybeEmpty<Address>,

--- a/json/src/state/transaction.rs
+++ b/json/src/state/transaction.rs
@@ -23,19 +23,18 @@ use maybe::MaybeEmpty;
 
 /// State test transaction deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Transaction {
 	/// Transaction data.
 	pub data: Bytes,
 	/// Gas limit.
-	#[serde(rename="gasLimit")]
 	pub gas_limit: Uint,
 	/// Gas price.
-	#[serde(rename="gasPrice")]
 	pub gas_price: Uint,
 	/// Nonce.
 	pub nonce: Uint,
 	/// Secret key.
-	#[serde(rename="secretKey")]
+	#[serde(rename = "secretKey")]
 	pub secret: Option<H256>,
 	/// To.
 	pub to: MaybeEmpty<Address>,

--- a/json/src/test/mod.rs
+++ b/json/src/test/mod.rs
@@ -25,24 +25,19 @@ use uint::Uint;
 
 /// Blockchain test header deserializer.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DifficultyTestCase {
 	/// Parent timestamp.
-	#[serde(rename="parentTimestamp")]
 	pub parent_timestamp: Uint,
 	/// Parent difficulty.
-	#[serde(rename="parentDifficulty")]
 	pub parent_difficulty: Uint,
 	/// Parent uncle hash.
-	#[serde(rename="parentUncles")]
 	pub parent_uncles: H256,
 	/// Current timestamp.
-	#[serde(rename="currentTimestamp")]
 	pub current_timestamp: Uint,
 	/// Current difficulty.
-	#[serde(rename="currentDifficulty")]
 	pub current_difficulty: Uint,
 	/// Current block number.
-	#[serde(rename="currentBlockNumber")]
 	pub current_block_number: Uint,
 }
 

--- a/json/src/transaction/transaction.rs
+++ b/json/src/transaction/transaction.rs
@@ -23,14 +23,13 @@ use maybe::MaybeEmpty;
 
 /// Transaction test transaction deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Transaction {
 	/// Transaction data.
 	pub data: Bytes,
 	/// Gas limit.
-	#[serde(rename="gasLimit")]
 	pub gas_limit: Uint,
 	/// Gas price.
-	#[serde(rename="gasPrice")]
 	pub gas_price: Uint,
 	/// Nonce.
 	pub nonce: Uint,

--- a/json/src/trie/trie.rs
+++ b/json/src/trie/trie.rs
@@ -23,7 +23,7 @@ use trie::Input;
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Trie {
 	/// Trie test input.
-	#[serde(rename="in")]
+	#[serde(rename = "in")]
 	pub input: Input,
 	/// Trie root hash.
 	pub root: H256,

--- a/json/src/vm/call.rs
+++ b/json/src/vm/call.rs
@@ -23,13 +23,13 @@ use maybe::MaybeEmpty;
 
 /// Vm call deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Call {
 	/// Call data.
 	pub data: Bytes,
 	/// Call destination.
 	pub destination: MaybeEmpty<Address>,
 	/// Gas limit.
-	#[serde(rename="gasLimit")]
 	pub gas_limit: Uint,
 	/// Call value.
 	pub value: Uint,

--- a/json/src/vm/env.rs
+++ b/json/src/vm/env.rs
@@ -22,19 +22,19 @@ use uint::Uint;
 #[derive(Debug, PartialEq, Deserialize)]
 pub struct Env {
 	/// Address.
-	#[serde(rename="currentCoinbase")]
+	#[serde(rename = "currentCoinbase")]
 	pub author: Address,
 	/// Difficulty
-	#[serde(rename="currentDifficulty")]
+	#[serde(rename = "currentDifficulty")]
 	pub difficulty: Uint,
 	/// Gas limit.
-	#[serde(rename="currentGasLimit")]
+	#[serde(rename = "currentGasLimit")]
 	pub gas_limit: Uint,
 	/// Number.
-	#[serde(rename="currentNumber")]
+	#[serde(rename = "currentNumber")]
 	pub number: Uint,
 	/// Timestamp.
-	#[serde(rename="currentTimestamp")]
+	#[serde(rename = "currentTimestamp")]
 	pub timestamp: Uint,
 }
 

--- a/json/src/vm/transaction.rs
+++ b/json/src/vm/transaction.rs
@@ -21,11 +21,12 @@ use bytes::Bytes;
 
 /// Executed transaction.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Transaction {
 	/// Contract address.
 	pub address: Address,
 	/// Transaction sender.
-	#[serde(rename="caller")]
+	#[serde(rename = "caller")]
 	pub sender: Address,
 	/// Contract code.
 	pub code: Bytes,
@@ -34,7 +35,6 @@ pub struct Transaction {
 	/// Gas.
 	pub gas: Uint,
 	/// Gas price.
-	#[serde(rename="gasPrice")]
 	pub gas_price: Uint,
 	/// Transaction origin.
 	pub origin: Address,

--- a/json/src/vm/vm.rs
+++ b/json/src/vm/vm.rs
@@ -26,26 +26,26 @@ use vm::{Transaction, Call, Env};
 #[derive(Debug, PartialEq, Deserialize)]
 pub struct Vm {
 	/// Contract calls made internaly by executed transaction.
-	#[serde(rename="callcreates")]
+	#[serde(rename = "callcreates")]
 	pub calls: Option<Vec<Call>>,
 	/// Env info.
 	pub env: Env,
 	/// Executed transaction
-	#[serde(rename="exec")]
+	#[serde(rename = "exec")]
 	pub transaction: Transaction,
 	/// Gas left after transaction execution.
-	#[serde(rename="gas")]
+	#[serde(rename = "gas")]
 	pub gas_left: Option<Uint>,
 	/// Hash of logs created during execution of transaction.
 	pub logs: Option<H256>,
 	/// Transaction output.
-	#[serde(rename="out")]
+	#[serde(rename = "out")]
 	pub output: Option<Bytes>,
 	/// Post execution vm state.
-	#[serde(rename="post")]
+	#[serde(rename = "post")]
 	pub post_state: Option<State>,
 	/// Pre execution vm state.
-	#[serde(rename="pre")]
+	#[serde(rename = "pre")]
 	pub pre_state: State,
 }
 

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -1141,7 +1141,7 @@ struct Operating {
 	no_persistent_txqueue: Option<bool>,
 	no_hardcoded_sync: Option<bool>,
 
-	#[serde(rename="public_node")]
+	#[serde(rename = "public_node")]
 	_legacy_public_node: Option<bool>,
 }
 
@@ -1173,15 +1173,15 @@ struct PrivateTransactions {
 struct Ui {
 	path: Option<String>,
 
-	#[serde(rename="force")]
+	#[serde(rename = "force")]
 	_legacy_force: Option<bool>,
-	#[serde(rename="disable")]
+	#[serde(rename = "disable")]
 	_legacy_disable: Option<bool>,
-	#[serde(rename="port")]
+	#[serde(rename = "port")]
 	_legacy_port: Option<u16>,
-	#[serde(rename="interface")]
+	#[serde(rename = "interface")]
 	_legacy_interface: Option<String>,
-	#[serde(rename="hosts")]
+	#[serde(rename = "hosts")]
 	_legacy_hosts: Option<Vec<String>>,
 }
 
@@ -1244,21 +1244,21 @@ struct Ipc {
 #[derive(Default, Debug, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Dapps {
-	#[serde(rename="disable")]
+	#[serde(rename = "disable")]
 	_legacy_disable: Option<bool>,
-	#[serde(rename="port")]
+	#[serde(rename = "port")]
 	_legacy_port: Option<u16>,
-	#[serde(rename="interface")]
+	#[serde(rename = "interface")]
 	_legacy_interface: Option<String>,
-	#[serde(rename="hosts")]
+	#[serde(rename = "hosts")]
 	_legacy_hosts: Option<Vec<String>>,
-	#[serde(rename="cors")]
+	#[serde(rename = "cors")]
 	_legacy_cors: Option<String>,
-	#[serde(rename="path")]
+	#[serde(rename = "path")]
 	_legacy_path: Option<String>,
-	#[serde(rename="user")]
+	#[serde(rename = "user")]
 	_legacy_user: Option<String>,
-	#[serde(rename="pass")]
+	#[serde(rename = "pass")]
 	_legacy_pass: Option<String>,
 }
 

--- a/rpc/src/v1/types/block.rs
+++ b/rpc/src/v1/types/block.rs
@@ -44,14 +44,14 @@ impl Serialize for BlockTransactions {
 
 /// Block representation
 #[derive(Debug, Serialize)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct Block {
 	/// Hash of the block
 	pub hash: Option<H256>,
 	/// Hash of the parent
 	pub parent_hash: H256,
 	/// Hash of the uncles
-	#[serde(rename="sha3Uncles")]
+	#[serde(rename = "sha3Uncles")]
 	pub uncles_hash: H256,
 	/// Authors address
 	pub author: H160,
@@ -91,14 +91,14 @@ pub struct Block {
 
 /// Block header representation.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct Header {
 	/// Hash of the block
 	pub hash: Option<H256>,
 	/// Hash of the parent
 	pub parent_hash: H256,
 	/// Hash of the uncles
-	#[serde(rename="sha3Uncles")]
+	#[serde(rename = "sha3Uncles")]
 	pub uncles_hash: H256,
 	/// Authors address
 	pub author: H160,

--- a/rpc/src/v1/types/call_request.rs
+++ b/rpc/src/v1/types/call_request.rs
@@ -20,13 +20,13 @@ use v1::types::{Bytes, H160, U256};
 /// Call request
 #[derive(Debug, Default, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct CallRequest {
 	/// From
 	pub from: Option<H160>,
 	/// To
 	pub to: Option<H160>,
 	/// Gas Price
-	#[serde(rename="gasPrice")]
 	pub gas_price: Option<U256>,
 	/// Gas
 	pub gas: Option<U256>,

--- a/rpc/src/v1/types/confirmations.rs
+++ b/rpc/src/v1/types/confirmations.rs
@@ -161,18 +161,16 @@ pub struct ConfirmationResponseWithToken {
 /// Confirmation payload, i.e. the thing to be confirmed
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub enum ConfirmationPayload {
 	/// Send Transaction
-	#[serde(rename = "sendTransaction")]
 	SendTransaction(TransactionRequest),
 	/// Sign Transaction
-	#[serde(rename = "signTransaction")]
 	SignTransaction(TransactionRequest),
 	/// Signature
 	#[serde(rename = "sign")]
 	EthSignMessage(SignRequest),
 	/// Decryption
-	#[serde(rename = "decrypt")]
 	Decrypt(DecryptRequest),
 }
 

--- a/rpc/src/v1/types/confirmations.rs
+++ b/rpc/src/v1/types/confirmations.rs
@@ -163,16 +163,16 @@ pub struct ConfirmationResponseWithToken {
 #[serde(deny_unknown_fields)]
 pub enum ConfirmationPayload {
 	/// Send Transaction
-	#[serde(rename="sendTransaction")]
+	#[serde(rename = "sendTransaction")]
 	SendTransaction(TransactionRequest),
 	/// Sign Transaction
-	#[serde(rename="signTransaction")]
+	#[serde(rename = "signTransaction")]
 	SignTransaction(TransactionRequest),
 	/// Signature
-	#[serde(rename="sign")]
+	#[serde(rename = "sign")]
 	EthSignMessage(SignRequest),
 	/// Decryption
-	#[serde(rename="decrypt")]
+	#[serde(rename = "decrypt")]
 	Decrypt(DecryptRequest),
 }
 
@@ -196,11 +196,11 @@ impl From<helpers::ConfirmationPayload> for ConfirmationPayload {
 /// Possible modifications to the confirmed transaction sent by `Trusted Signer`
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct TransactionModification {
 	/// Modified transaction sender
 	pub sender: Option<H160>,
 	/// Modified gas price
-	#[serde(rename="gasPrice")]
 	pub gas_price: Option<U256>,
 	/// Modified gas
 	pub gas: Option<U256>,

--- a/rpc/src/v1/types/consensus_status.rs
+++ b/rpc/src/v1/types/consensus_status.rs
@@ -22,26 +22,26 @@ use updater::{self, CapState};
 #[derive(Debug, PartialEq, Serialize)]
 pub enum ConsensusCapability {
 	/// Unknown.
-	#[serde(rename="unknown")]
+	#[serde(rename = "unknown")]
 	Unknown,
 	/// Capable of consensus indefinitely.
-	#[serde(rename="capable")]
+	#[serde(rename = "capable")]
 	Capable,
-	/// Capable of consensus up until a definite block. 
-	#[serde(rename="capableUntil")]
+	/// Capable of consensus up until a definite block.
+	#[serde(rename = "capableUntil")]
 	CapableUntil(u64),
-	/// Incapable of consensus since a particular block. 
-	#[serde(rename="incapableSince")]
+	/// Incapable of consensus since a particular block.
+	#[serde(rename = "incapableSince")]
 	IncapableSince(u64),
 }
 
 impl Into<ConsensusCapability> for CapState {
 	fn into(self) -> ConsensusCapability {
 		match self {
-			CapState::Unknown => ConsensusCapability::Unknown, 
-			CapState::Capable => ConsensusCapability::Capable, 
-			CapState::CapableUntil(n) => ConsensusCapability::CapableUntil(n), 
-			CapState::IncapableSince(n) => ConsensusCapability::IncapableSince(n), 
+			CapState::Unknown => ConsensusCapability::Unknown,
+			CapState::Capable => ConsensusCapability::Capable,
+			CapState::CapableUntil(n) => ConsensusCapability::CapableUntil(n),
+			CapState::IncapableSince(n) => ConsensusCapability::IncapableSince(n),
 		}
 	}
 }
@@ -50,19 +50,19 @@ impl Into<ConsensusCapability> for CapState {
 #[derive(Debug, PartialEq, Serialize)]
 pub enum ReleaseTrack {
 	/// Stable track.
-	#[serde(rename="stable")]
+	#[serde(rename = "stable")]
 	Stable,
 	/// Beta track.
-	#[serde(rename="beta")]
+	#[serde(rename = "beta")]
 	Beta,
 	/// Nightly track.
-	#[serde(rename="nightly")]
+	#[serde(rename = "nightly")]
 	Nightly,
 	/// Testing track.
-	#[serde(rename="testing")]
+	#[serde(rename = "testing")]
 	Testing,
 	/// No known track.
-	#[serde(rename="null")]
+	#[serde(rename = "null")]
 	Unknown,
 }
 
@@ -99,7 +99,7 @@ impl Into<Version> for semver::Version {
 	}
 }
 
-/// Version information of a particular release. 
+/// Version information of a particular release.
 #[derive(Debug, PartialEq, Serialize)]
 pub struct VersionInfo {
 	/// The track on which it was released.
@@ -125,11 +125,11 @@ impl Into<VersionInfo> for updater::VersionInfo {
 pub struct ReleaseInfo {
 	/// Information on the version.
 	pub version: VersionInfo,
-	/// Does this release contain critical security updates? 
+	/// Does this release contain critical security updates?
 	pub is_critical: bool,
 	/// The latest fork that this release can handle.
 	pub fork: u64,
-	/// Our platform's binary, if known. 
+	/// Our platform's binary, if known.
 	pub binary: Option<H256>,
 }
 
@@ -149,9 +149,9 @@ impl Into<ReleaseInfo> for updater::ReleaseInfo {
 pub struct OperationsInfo {
 	/// Our blockchain's latest fork.
 	pub fork: u64,
-	/// Last fork our client supports, if known. 
+	/// Last fork our client supports, if known.
 	pub this_fork: Option<u64>,
-	/// Information on our track's latest release. 
+	/// Information on our track's latest release.
 	pub track: ReleaseInfo,
 	/// Information on our minor version's latest release.
 	pub minor: Option<ReleaseInfo>,

--- a/rpc/src/v1/types/consensus_status.rs
+++ b/rpc/src/v1/types/consensus_status.rs
@@ -20,18 +20,15 @@ use updater::{self, CapState};
 
 /// Capability info
 #[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub enum ConsensusCapability {
 	/// Unknown.
-	#[serde(rename = "unknown")]
 	Unknown,
 	/// Capable of consensus indefinitely.
-	#[serde(rename = "capable")]
 	Capable,
 	/// Capable of consensus up until a definite block.
-	#[serde(rename = "capableUntil")]
 	CapableUntil(u64),
 	/// Incapable of consensus since a particular block.
-	#[serde(rename = "incapableSince")]
 	IncapableSince(u64),
 }
 
@@ -48,18 +45,15 @@ impl Into<ConsensusCapability> for CapState {
 
 /// A release's track.
 #[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub enum ReleaseTrack {
 	/// Stable track.
-	#[serde(rename = "stable")]
 	Stable,
 	/// Beta track.
-	#[serde(rename = "beta")]
 	Beta,
 	/// Nightly track.
-	#[serde(rename = "nightly")]
 	Nightly,
 	/// Testing track.
-	#[serde(rename = "testing")]
 	Testing,
 	/// No known track.
 	#[serde(rename = "null")]

--- a/rpc/src/v1/types/derivation.rs
+++ b/rpc/src/v1/types/derivation.rs
@@ -34,7 +34,7 @@ pub enum DerivationType {
 #[derive(Deserialize)]
 pub struct DeriveHash {
 	hash: H256,
-	#[serde(rename="type")]
+	#[serde(rename = "type")]
 	d_type: DerivationType,
 }
 
@@ -42,7 +42,7 @@ pub struct DeriveHash {
 #[derive(Deserialize)]
 pub struct DeriveHierarchicalItem {
 	index: u64,
-	#[serde(rename="type")]
+	#[serde(rename = "type")]
 	d_type: DerivationType,
 }
 

--- a/rpc/src/v1/types/filter.rs
+++ b/rpc/src/v1/types/filter.rs
@@ -57,15 +57,13 @@ pub type Topic = VariadicValue<H256>;
 /// Filter
 #[derive(Debug, PartialEq, Clone, Deserialize, Eq, Hash)]
 #[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct Filter {
 	/// From Block
-	#[serde(rename="fromBlock")]
 	pub from_block: Option<BlockNumber>,
 	/// To Block
-	#[serde(rename="toBlock")]
 	pub to_block: Option<BlockNumber>,
 	/// Block hash
-	#[serde(rename="blockHash")]
 	pub block_hash: Option<H256>,
 	/// Address
 	pub address: Option<FilterAddress>,

--- a/rpc/src/v1/types/histogram.rs
+++ b/rpc/src/v1/types/histogram.rs
@@ -21,9 +21,9 @@ use v1::types::U256;
 /// Values of RPC settings.
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct Histogram {
 	/// Gas prices for bucket edges.
-	#[serde(rename="bucketBounds")]
 	pub bucket_bounds: Vec<U256>,
 	/// Transacion counts for each bucket.
 	pub counts: Vec<usize>,

--- a/rpc/src/v1/types/log.rs
+++ b/rpc/src/v1/types/log.rs
@@ -19,6 +19,7 @@ use v1::types::{Bytes, H160, H256, U256};
 
 /// Log
 #[derive(Debug, Serialize, PartialEq, Eq, Hash, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Log {
 	/// H160
 	pub address: H160,
@@ -27,25 +28,19 @@ pub struct Log {
 	/// Data
 	pub data: Bytes,
 	/// Block Hash
-	#[serde(rename="blockHash")]
 	pub block_hash: Option<H256>,
 	/// Block Number
-	#[serde(rename="blockNumber")]
 	pub block_number: Option<U256>,
 	/// Transaction Hash
-	#[serde(rename="transactionHash")]
 	pub transaction_hash: Option<H256>,
 	/// Transaction Index
-	#[serde(rename="transactionIndex")]
 	pub transaction_index: Option<U256>,
 	/// Log Index in Block
-	#[serde(rename="logIndex")]
 	pub log_index: Option<U256>,
 	/// Log Index in Transaction
-	#[serde(rename="transactionLogIndex")]
 	pub transaction_log_index: Option<U256>,
 	/// Log Type
-	#[serde(rename="type")]
+	#[serde(rename = "type")]
 	pub log_type: String,
 	/// Whether Log Type is Removed (Geth Compatibility Field)
 	#[serde(default)]

--- a/rpc/src/v1/types/node_kind.rs
+++ b/rpc/src/v1/types/node_kind.rs
@@ -28,24 +28,22 @@ pub struct NodeKind {
 
 /// Who the node is available to.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum Availability {
 	/// A personal node, not intended to be available to everyone.
-	#[serde(rename = "personal")]
 	Personal,
 	/// A public, open node.
-	#[serde(rename = "public")]
 	Public,
 }
 
 /// The capability of the node.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum Capability {
 	/// A full node stores the full state and fully enacts incoming blocks.
-	#[serde(rename = "full")]
 	Full,
 	/// A light node does a minimal header sync and fetches data as needed
 	/// from the network.
-	#[serde(rename = "light")]
 	Light,
 }
 

--- a/rpc/src/v1/types/node_kind.rs
+++ b/rpc/src/v1/types/node_kind.rs
@@ -30,10 +30,10 @@ pub struct NodeKind {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Availability {
 	/// A personal node, not intended to be available to everyone.
-	#[serde(rename="personal")]
+	#[serde(rename = "personal")]
 	Personal,
 	/// A public, open node.
-	#[serde(rename="public")]
+	#[serde(rename = "public")]
 	Public,
 }
 
@@ -41,11 +41,11 @@ pub enum Availability {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Capability {
 	/// A full node stores the full state and fully enacts incoming blocks.
-	#[serde(rename="full")]
+	#[serde(rename = "full")]
 	Full,
 	/// A light node does a minimal header sync and fetches data as needed
 	/// from the network.
-	#[serde(rename="light")]
+	#[serde(rename = "light")]
 	Light,
 }
 

--- a/rpc/src/v1/types/private_receipt.rs
+++ b/rpc/src/v1/types/private_receipt.rs
@@ -19,15 +19,14 @@ use ethcore_private_tx::{Receipt as EthPrivateReceipt};
 
 /// Receipt
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PrivateTransactionReceipt {
 	/// Transaction Hash
-	#[serde(rename="transactionHash")]
 	pub transaction_hash: H256,
 	/// Private contract address
-	#[serde(rename="contractAddress")]
 	pub contract_address: Option<H160>,
 	/// Status code
-	#[serde(rename="status")]
+	#[serde(rename = "status")]
 	pub status_code: u8,
 }
 
@@ -45,9 +44,7 @@ impl From<EthPrivateReceipt> for PrivateTransactionReceipt {
 #[derive(Debug, Serialize)]
 pub struct PrivateTransactionReceiptAndTransaction {
 	/// Receipt
-	#[serde(rename="receipt")]
 	pub receipt: PrivateTransactionReceipt,
 	/// Transaction
-	#[serde(rename="transaction")]
 	pub transaction: TransactionRequest,
 }

--- a/rpc/src/v1/types/provenance.rs
+++ b/rpc/src/v1/types/provenance.rs
@@ -22,30 +22,25 @@ use v1::types::H256;
 /// RPC request origin
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[serde(rename_all = "kebab-case")]
 pub enum Origin {
 	/// RPC server (includes request origin)
-	#[serde(rename = "rpc")]
 	Rpc(String),
 	/// IPC server (includes session hash)
-	#[serde(rename = "ipc")]
 	Ipc(H256),
 	/// WS server
-	#[serde(rename = "ws")]
 	Ws {
 		/// Session id
 		session: H256,
 	},
 	/// Signer (authorized WS server)
-	#[serde(rename = "signer")]
 	Signer {
 		/// Session id
 		session: H256
 	},
 	/// From the C API
-	#[serde(rename = "c-api")]
 	CApi,
 	/// Unknown
-	#[serde(rename = "unknown")]
 	Unknown,
 }
 

--- a/rpc/src/v1/types/provenance.rs
+++ b/rpc/src/v1/types/provenance.rs
@@ -24,28 +24,28 @@ use v1::types::H256;
 #[serde(deny_unknown_fields)]
 pub enum Origin {
 	/// RPC server (includes request origin)
-	#[serde(rename="rpc")]
+	#[serde(rename = "rpc")]
 	Rpc(String),
 	/// IPC server (includes session hash)
-	#[serde(rename="ipc")]
+	#[serde(rename = "ipc")]
 	Ipc(H256),
 	/// WS server
-	#[serde(rename="ws")]
+	#[serde(rename = "ws")]
 	Ws {
 		/// Session id
 		session: H256,
 	},
 	/// Signer (authorized WS server)
-	#[serde(rename="signer")]
+	#[serde(rename = "signer")]
 	Signer {
 		/// Session id
 		session: H256
 	},
 	/// From the C API
-	#[serde(rename="c-api")]
+	#[serde(rename = "c-api")]
 	CApi,
 	/// Unknown
-	#[serde(rename="unknown")]
+	#[serde(rename = "unknown")]
 	Unknown,
 }
 

--- a/rpc/src/v1/types/pubsub.rs
+++ b/rpc/src/v1/types/pubsub.rs
@@ -49,16 +49,16 @@ impl Serialize for Result {
 #[serde(deny_unknown_fields)]
 pub enum Kind {
 	/// New block headers subscription.
-	#[serde(rename="newHeads")]
+	#[serde(rename = "newHeads")]
 	NewHeads,
 	/// Logs subscription.
-	#[serde(rename="logs")]
+	#[serde(rename = "logs")]
 	Logs,
 	/// New Pending Transactions subscription.
-	#[serde(rename="newPendingTransactions")]
+	#[serde(rename = "newPendingTransactions")]
 	NewPendingTransactions,
 	/// Node syncing status subscription.
-	#[serde(rename="syncing")]
+	#[serde(rename = "syncing")]
 	Syncing,
 }
 

--- a/rpc/src/v1/types/pubsub.rs
+++ b/rpc/src/v1/types/pubsub.rs
@@ -47,18 +47,15 @@ impl Serialize for Result {
 /// Subscription kind.
 #[derive(Debug, Deserialize, PartialEq, Eq, Hash, Clone)]
 #[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub enum Kind {
 	/// New block headers subscription.
-	#[serde(rename = "newHeads")]
 	NewHeads,
 	/// Logs subscription.
-	#[serde(rename = "logs")]
 	Logs,
 	/// New Pending Transactions subscription.
-	#[serde(rename = "newPendingTransactions")]
 	NewPendingTransactions,
 	/// Node syncing status subscription.
-	#[serde(rename = "syncing")]
 	Syncing,
 }
 

--- a/rpc/src/v1/types/receipt.rs
+++ b/rpc/src/v1/types/receipt.rs
@@ -19,42 +19,35 @@ use ethcore::receipt::{Receipt as EthReceipt, RichReceipt, LocalizedReceipt, Tra
 
 /// Receipt
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Receipt {
 	/// Transaction Hash
-	#[serde(rename="transactionHash")]
 	pub transaction_hash: Option<H256>,
 	/// Transaction index
-	#[serde(rename="transactionIndex")]
 	pub transaction_index: Option<U256>,
 	/// Block hash
-	#[serde(rename="blockHash")]
 	pub block_hash: Option<H256>,
 	/// Sender
 	pub from: Option<H160>,
 	/// Recipient
 	pub to: Option<H160>,
 	/// Block number
-	#[serde(rename="blockNumber")]
 	pub block_number: Option<U256>,
 	/// Cumulative gas used
-	#[serde(rename="cumulativeGasUsed")]
 	pub cumulative_gas_used: U256,
 	/// Gas used
-	#[serde(rename="gasUsed")]
 	pub gas_used: Option<U256>,
 	/// Contract address
-	#[serde(rename="contractAddress")]
 	pub contract_address: Option<H160>,
 	/// Logs
 	pub logs: Vec<Log>,
 	/// State Root
-	#[serde(rename="root")]
+	#[serde(rename = "root")]
 	pub state_root: Option<H256>,
 	/// Logs bloom
-	#[serde(rename="logsBloom")]
 	pub logs_bloom: H2048,
 	/// Status code
-	#[serde(rename="status")]
+	#[serde(rename = "status")]
 	pub status_code: Option<U64>,
 }
 

--- a/rpc/src/v1/types/sync.rs
+++ b/rpc/src/v1/types/sync.rs
@@ -21,21 +21,17 @@ use v1::types::{U256, H512};
 
 /// Sync info
 #[derive(Default, Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct SyncInfo {
 	/// Starting block
-	#[serde(rename="startingBlock")]
 	pub starting_block: U256,
 	/// Current block
-	#[serde(rename="currentBlock")]
 	pub current_block: U256,
 	/// Highest block seen so far
-	#[serde(rename="highestBlock")]
 	pub highest_block: U256,
 	/// Warp sync snapshot chunks total.
-	#[serde(rename="warpChunksAmount")]
 	pub warp_chunks_amount: Option<U256>,
 	/// Warp sync snpashot chunks processed.
-	#[serde(rename="warpChunksProcessed")]
 	pub warp_chunks_processed: Option<U256>,
 }
 
@@ -69,12 +65,11 @@ pub struct PeerInfo {
 
 /// Peer network information
 #[derive(Default, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PeerNetworkInfo {
 	/// Remote endpoint address
-	#[serde(rename="remoteAddress")]
 	pub remote_address: String,
 	/// Local endpoint address
-	#[serde(rename="localAddress")]
 	pub local_address: String,
 }
 
@@ -150,12 +145,11 @@ impl Serialize for SyncStatus {
 
 /// Propagation statistics for pending transaction.
 #[derive(Default, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TransactionStats {
 	/// Block no this transaction was first seen.
-	#[serde(rename="firstSeen")]
 	pub first_seen: u64,
 	/// Peers this transaction was propagated to with count.
-	#[serde(rename="propagatedTo")]
 	pub propagated_to: BTreeMap<H512, usize>,
 }
 
@@ -191,9 +185,9 @@ impl From<SyncTransactionStats> for TransactionStats {
 
 /// Chain status.
 #[derive(Default, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ChainStatus {
 	/// Describes the gap in the blockchain, if there is one: (first, last)
-	#[serde(rename="blockGap")]
 	pub block_gap: Option<(U256, U256)>,
 }
 

--- a/rpc/src/v1/types/trace.rs
+++ b/rpc/src/v1/types/trace.rs
@@ -236,21 +236,17 @@ impl From<trace::Create> for Create {
 
 /// Call type.
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum CallType {
 	/// None
-	#[serde(rename = "none")]
 	None,
 	/// Call
-	#[serde(rename = "call")]
 	Call,
 	/// Call code
-	#[serde(rename = "callcode")]
 	CallCode,
 	/// Delegate call
-	#[serde(rename = "delegatecall")]
 	DelegateCall,
 	/// Static call
-	#[serde(rename = "staticcall")]
 	StaticCall,
 }
 
@@ -299,18 +295,15 @@ impl From<trace::Call> for Call {
 
 /// Reward type.
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub enum RewardType {
 	/// Block
-	#[serde(rename = "block")]
 	Block,
 	/// Uncle
-	#[serde(rename = "uncle")]
 	Uncle,
 	/// EmptyStep (AuthorityRound)
-	#[serde(rename = "emptyStep")]
 	EmptyStep,
 	/// External (attributed as part of an external protocol)
-	#[serde(rename = "external")]
 	External,
 }
 

--- a/rpc/src/v1/types/trace.rs
+++ b/rpc/src/v1/types/trace.rs
@@ -66,15 +66,12 @@ impl From<et::StorageDiff> for StorageDiff {
 /// A record of an executed VM operation.
 pub struct VMExecutedOperation {
 	/// The total gas used.
-	#[serde(rename="used")]
 	pub used: u64,
 	/// The stack item placed, if any.
 	pub push: Vec<U256>,
 	/// If altered, the memory delta.
-	#[serde(rename="mem")]
 	pub mem: Option<MemoryDiff>,
 	/// The altered storage value, if any.
-	#[serde(rename="store")]
 	pub store: Option<StorageDiff>,
 }
 
@@ -155,13 +152,13 @@ pub struct ChangedType<T> where T: Serialize {
 #[derive(Debug, Serialize)]
 /// Serde-friendly `Diff` shadow.
 pub enum Diff<T> where T: Serialize {
-	#[serde(rename="=")]
+	#[serde(rename = "=")]
 	Same,
-	#[serde(rename="+")]
+	#[serde(rename = "+")]
 	Born(T),
-	#[serde(rename="-")]
+	#[serde(rename = "-")]
 	Died(T),
-	#[serde(rename="*")]
+	#[serde(rename = "*")]
 	Changed(ChangedType<T>),
 }
 
@@ -241,19 +238,19 @@ impl From<trace::Create> for Create {
 #[derive(Debug, Serialize)]
 pub enum CallType {
 	/// None
-	#[serde(rename="none")]
+	#[serde(rename = "none")]
 	None,
 	/// Call
-	#[serde(rename="call")]
+	#[serde(rename = "call")]
 	Call,
 	/// Call code
-	#[serde(rename="callcode")]
+	#[serde(rename = "callcode")]
 	CallCode,
 	/// Delegate call
-	#[serde(rename="delegatecall")]
+	#[serde(rename = "delegatecall")]
 	DelegateCall,
 	/// Static call
-	#[serde(rename="staticcall")]
+	#[serde(rename = "staticcall")]
 	StaticCall,
 }
 
@@ -271,6 +268,7 @@ impl From<vm::CallType> for CallType {
 
 /// Call response
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Call {
 	/// Sender
 	from: H160,
@@ -283,7 +281,6 @@ pub struct Call {
 	/// Input data
 	input: Bytes,
 	/// The type of the call.
-	#[serde(rename="callType")]
 	call_type: CallType,
 }
 
@@ -304,16 +301,16 @@ impl From<trace::Call> for Call {
 #[derive(Debug, Serialize)]
 pub enum RewardType {
 	/// Block
-	#[serde(rename="block")]
+	#[serde(rename = "block")]
 	Block,
 	/// Uncle
-	#[serde(rename="uncle")]
+	#[serde(rename = "uncle")]
 	Uncle,
 	/// EmptyStep (AuthorityRound)
-	#[serde(rename="emptyStep")]
+	#[serde(rename = "emptyStep")]
 	EmptyStep,
 	/// External (attributed as part of an external protocol)
-	#[serde(rename="external")]
+	#[serde(rename = "external")]
 	External,
 }
 
@@ -330,13 +327,13 @@ impl From<trace::RewardType> for RewardType {
 
 /// Reward action
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Reward {
 	/// Author's address.
 	pub author: H160,
 	/// Reward amount.
 	pub value: U256,
 	/// Reward type.
-	#[serde(rename="rewardType")]
 	pub reward_type: RewardType,
 }
 
@@ -352,11 +349,11 @@ impl From<trace::Reward> for Reward {
 
 /// Suicide
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Suicide {
 	/// Address.
 	pub address: H160,
 	/// Refund address.
-	#[serde(rename="refundAddress")]
 	pub refund_address: H160,
 	/// Balance.
 	pub balance: U256,
@@ -398,9 +395,9 @@ impl From<trace::Action> for Action {
 
 /// Call Result
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CallResult {
 	/// Gas used
-	#[serde(rename="gasUsed")]
 	gas_used: U256,
 	/// Output bytes
 	output: Bytes,
@@ -417,9 +414,9 @@ impl From<trace::CallResult> for CallResult {
 
 /// Craete Result
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateResult {
 	/// Gas used
-	#[serde(rename="gasUsed")]
 	gas_used: U256,
 	/// Code
 	code: Bytes,
@@ -607,6 +604,7 @@ impl From<FlatTrace> for Trace {
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 /// A diff of some chunk of memory.
 pub struct TraceResults {
 	/// The output of the call/create
@@ -614,10 +612,8 @@ pub struct TraceResults {
 	/// The transaction trace.
 	pub trace: Vec<Trace>,
 	/// The transaction trace.
-	#[serde(rename="vmTrace")]
 	pub vm_trace: Option<VMTrace>,
 	/// The transaction trace.
-	#[serde(rename="stateDiff")]
 	pub state_diff: Option<StateDiff>,
 }
 
@@ -633,6 +629,7 @@ impl From<Executed> for TraceResults {
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 /// A diff of some chunk of memory.
 pub struct TraceResultsWithTransactionHash {
 	/// The output of the call/create
@@ -640,13 +637,10 @@ pub struct TraceResultsWithTransactionHash {
 	/// The transaction trace.
 	pub trace: Vec<Trace>,
 	/// The transaction trace.
-	#[serde(rename="vmTrace")]
 	pub vm_trace: Option<VMTrace>,
 	/// The transaction trace.
-	#[serde(rename="stateDiff")]
 	pub state_diff: Option<StateDiff>,
 	/// The transaction Hash.
-	#[serde(rename="transactionHash")]
 	pub transaction_hash: H256,
 }
 

--- a/rpc/src/v1/types/trace_filter.rs
+++ b/rpc/src/v1/types/trace_filter.rs
@@ -23,18 +23,15 @@ use v1::types::{BlockNumber, H160};
 /// Trace filter
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct TraceFilter {
 	/// From block
-	#[serde(rename="fromBlock")]
 	pub from_block: Option<BlockNumber>,
 	/// To block
-	#[serde(rename="toBlock")]
 	pub to_block: Option<BlockNumber>,
 	/// From address
-	#[serde(rename="fromAddress")]
 	pub from_address: Option<Vec<H160>>,
 	/// To address
-	#[serde(rename="toAddress")]
 	pub to_address: Option<Vec<H160>>,
 	/// Output offset
 	pub after: Option<usize>,

--- a/rpc/src/v1/types/transaction.rs
+++ b/rpc/src/v1/types/transaction.rs
@@ -25,19 +25,17 @@ use v1::types::{Bytes, H160, H256, U256, H512, U64, TransactionCondition};
 
 /// Transaction
 #[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Transaction {
 	/// Hash
 	pub hash: H256,
 	/// Nonce
 	pub nonce: U256,
 	/// Block hash
-	#[serde(rename="blockHash")]
 	pub block_hash: Option<H256>,
 	/// Block number
-	#[serde(rename="blockNumber")]
 	pub block_number: Option<U256>,
 	/// Transaction Index
-	#[serde(rename="transactionIndex")]
 	pub transaction_index: Option<U256>,
 	/// Sender
 	pub from: H160,
@@ -46,7 +44,6 @@ pub struct Transaction {
 	/// Transfered value
 	pub value: U256,
 	/// Gas Price
-	#[serde(rename="gasPrice")]
 	pub gas_price: U256,
 	/// Gas
 	pub gas: U256,
@@ -57,13 +54,10 @@ pub struct Transaction {
 	/// Raw transaction data
 	pub raw: Bytes,
 	/// Public key of the signer.
-	#[serde(rename="publicKey")]
 	pub public_key: Option<H512>,
 	/// The network id of the transaction, if any.
-	#[serde(rename="chainId")]
 	pub chain_id: Option<U64>,
 	/// The standardised V field of the signature (0 or 1).
-	#[serde(rename="standardV")]
 	pub standard_v: U256,
 	/// The standardised V field of the signature.
 	pub v: U256,
@@ -161,7 +155,7 @@ pub struct RichRawTransaction {
 	/// Raw transaction RLP
 	pub raw: Bytes,
 	/// Transaction details
-	#[serde(rename="tx")]
+	#[serde(rename = "tx")]
 	pub transaction: Transaction
 }
 

--- a/rpc/src/v1/types/transaction_condition.rs
+++ b/rpc/src/v1/types/transaction_condition.rs
@@ -21,10 +21,10 @@ use transaction;
 #[serde(deny_unknown_fields)]
 pub enum TransactionCondition {
 	/// Valid at this minimum block number.
-	#[serde(rename="block")]
+	#[serde(rename = "block")]
 	Number(u64),
 	/// Valid at given unix time.
-	#[serde(rename="time")]
+	#[serde(rename = "time")]
 	Timestamp(u64),
 }
 

--- a/rpc/src/v1/types/transaction_request.rs
+++ b/rpc/src/v1/types/transaction_request.rs
@@ -25,13 +25,13 @@ use std::fmt;
 /// Transaction request coming from RPC
 #[derive(Debug, Clone, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct TransactionRequest {
 	/// Sender
 	pub from: Option<H160>,
 	/// Recipient
 	pub to: Option<H160>,
 	/// Gas Price
-	#[serde(rename="gasPrice")]
 	pub gas_price: Option<U256>,
 	/// Gas
 	pub gas: Option<U256>,

--- a/whisper/src/rpc/types.rs
+++ b/whisper/src/rpc/types.rs
@@ -145,10 +145,9 @@ impl<'a, T: HexEncodable> Visitor<'a> for HexEncodeVisitor<T> {
 /// Receiver of a message. Either a public key, identity (presumably symmetric),
 /// or broadcast over the topics.
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum Receiver {
-	#[serde(rename = "public")]
 	Public(Public),
-	#[serde(rename = "identity")]
 	Identity(Identity),
 }
 

--- a/whisper/src/rpc/types.rs
+++ b/whisper/src/rpc/types.rs
@@ -146,9 +146,9 @@ impl<'a, T: HexEncodable> Visitor<'a> for HexEncodeVisitor<T> {
 /// or broadcast over the topics.
 #[derive(Deserialize)]
 pub enum Receiver {
-	#[serde(rename="public")]
+	#[serde(rename = "public")]
 	Public(Public),
-	#[serde(rename="identity")]
+	#[serde(rename = "identity")]
 	Identity(Identity),
 }
 
@@ -190,13 +190,13 @@ pub struct PostRequest {
 
 /// Request for filter or subscription creation.
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FilterRequest {
 	/// ID of key used for decryption.
 	///
 	/// If this identity is removed, then no further messages will be returned.
 	///
 	/// If optional, this will listen for broadcast messages.
-	#[serde(rename = "decryptWith")]
 	pub decrypt_with: Option<Identity>,
 
 	/// Accept only messages signed by given public key.
@@ -237,6 +237,7 @@ pub struct FilterItem {
 
 /// Whisper node info.
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct NodeInfo {
 	/// min PoW to be accepted into the local pool.
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -250,7 +251,6 @@ pub struct NodeInfo {
 	pub memory: usize,
 
 	/// Target memory of the pool.
-	#[serde(rename = "targetMemory")]
 	pub target_memory: usize,
 }
 


### PR DESCRIPTION
This cleans up all cases where:

* Use `rename_all = camelCase` whenever possible.
* Remove unnecessary `rename`.