### PR TITLE
light-fetch: Differentiate between out-of-gas/manual throw and use required gas from response on failure

### DIFF
--- a/rpc/src/v1/helpers/light_fetch.rs
+++ b/rpc/src/v1/helpers/light_fetch.rs
@@ -627,7 +627,7 @@ fn execute_read_only_tx(gas_known: bool, params: ExecuteParams) -> impl Future<I
 						// `OutOfGas` exception, try double the gas
 						if let Some(vm::Error::OutOfGas) = executed.exception {
 							// block gas limit already tried, regard as an error and don't retry
-							if params.tx.gas == params.hdr.gas_limit() {
+							if params.tx.gas >= params.hdr.gas_limit() {
 								trace!(target: "light_fetch", "OutOutGas exception received, gas increase: failed");
 							} else {
 								params.tx.gas = cmp::min(params.tx.gas * 2_u32, params.hdr.gas_limit());

--- a/rpc/src/v1/helpers/light_fetch.rs
+++ b/rpc/src/v1/helpers/light_fetch.rs
@@ -19,12 +19,12 @@
 use std::cmp;
 use std::sync::Arc;
 
-use light::on_demand::error::Error as OnDemandError;
 use ethcore::basic_account::BasicAccount;
 use ethcore::encoded;
 use ethcore::filter::Filter as EthcoreFilter;
 use ethcore::ids::BlockId;
 use ethcore::receipt::Receipt;
+use ethcore::executed::ExecutionError;
 
 use jsonrpc_core::{Result, Error};
 use jsonrpc_core::futures::{future, Future};
@@ -38,6 +38,7 @@ use light::on_demand::{
 	request, OnDemand, HeaderRef, Request as OnDemandRequest,
 	Response as OnDemandResponse, ExecutionResult,
 };
+use light::on_demand::error::Error as OnDemandError;
 use light::request::Field;
 
 use sync::LightSync;
@@ -202,8 +203,8 @@ impl LightFetch {
 	/// Helper for getting proved execution.
 	pub fn proved_read_only_execution(&self, req: CallRequest, num: Trailing<BlockNumber>) -> impl Future<Item = ExecutionResult, Error = Error> + Send {
 		const DEFAULT_GAS_PRICE: u64 = 21_000;
-		// starting gas when gas not provided.
-		const START_GAS: u64 = 50_000;
+		// (21000 G_transaction + 32000 G_create + some marginal to allow a few operations)
+		const START_GAS: u64 = 60_000;
 
 		let (sync, on_demand, client) = (self.sync.clone(), self.on_demand.clone(), self.client.clone());
 		let req: CallRequestHelper = req.into();
@@ -615,28 +616,39 @@ struct ExecuteParams {
 	sync: Arc<LightSync>,
 }
 
-// has a peer execute the transaction with given params. If `gas_known` is false,
-// this will double the gas on each `OutOfGas` error.
+// Has a peer execute the transaction with given params. If `gas_known` is false, this will set the `gas value` to the
+// `required gas value` unless it exceeds the block gas limit
 fn execute_read_only_tx(gas_known: bool, params: ExecuteParams) -> impl Future<Item = ExecutionResult, Error = Error> + Send {
 	if !gas_known {
 		Box::new(future::loop_fn(params, |mut params| {
 			execute_read_only_tx(true, params.clone()).and_then(move |res| {
 				match res {
 					Ok(executed) => {
-						// TODO: how to distinguish between actual OOG and
-						// exception?
-						if executed.exception.is_some() {
+						// `OutOfGas` exception, try double the gas
+						if let Some(vm::Error::OutOfGas) = executed.exception {
 							let old_gas = params.tx.gas;
-							params.tx.gas = params.tx.gas * 2u32;
+							params.tx.gas = params.tx.gas * 2_u32;
 							if params.tx.gas > params.hdr.gas_limit() {
+								trace!(target: "light_fetch", "OutOutGas exception received, gas increase: failed");
 								params.tx.gas = old_gas;
 							} else {
+								trace!(target: "light_fetch", "OutOutGas exception received, gas increase: succeed");
 								return Ok(future::Loop::Continue(params))
 							}
 						}
-
 						Ok(future::Loop::Break(Ok(executed)))
 					}
+					Err(ExecutionError::NotEnoughBaseGas { required, got }) => {
+						trace!(target: "light_fetch", "Not enough start gas provided required: {}, got: {}", required, got);
+						if required <= params.hdr.gas_limit() {
+							params.tx.gas = required;
+							return Ok(future::Loop::Continue(params))
+						} else {
+							warn!(target: "light_fetch", "Required gas is bigger than block header's gas dropping the request");
+							Ok(future::Loop::Break(Err(ExecutionError::NotEnoughBaseGas { required, got })))
+						}
+					}
+					// Non-recoverable execution error
 					failed => Ok(future::Loop::Break(failed)),
 				}
 			})


### PR DESCRIPTION
Attempt to close https://github.com/paritytech/parity-ethereum/issues/6155 & close https://github.com/paritytech/parity-ethereum/issues/9031

What does this PR:

1. Differentiate between out-of-gas/manual throw
2. Changes the start_gas from 50_000 to 60_000
3. If too little gas is submitted in a transaction then we use to the required `start_gas` replied to us to set the next `start_gas` if it doesn't exceed the block's gas limit (however this could be changed to set the `start_gas` regardless of block_limit and continue until we get `BlockGasLimitReached` error instead, will probably require at least one extra network request)

Example execution with 50_000 as start_gas:
```bash
2018-10-29 15:45:05  jsonrpc-eventloop-1 TRACE light_fetch  Placing execution request for 50000 gas in on_demand
2018-10-29 15:45:05  jsonrpc-eventloop-1 TRACE light_fetch  Not enough start gas provided required: 53000, got: 50000
2018-10-29 15:45:05  jsonrpc-eventloop-1 TRACE light_fetch  Placing execution request for 53000 gas in on_demand
```