### PR TITLE
Do not use the home directory as the working dir in docker

### DIFF
--- a/scripts/docker/hub/Dockerfile
+++ b/scripts/docker/hub/Dockerfile
@@ -16,7 +16,7 @@ RUN apt clean -y
 RUN rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
 RUN groupadd -g 1000 parity \
-  && useradd -u 1000 -g parity -s /bin/sh parity
+  && useradd -m -u 1000 -g parity -s /bin/sh parity
 
 USER parity
 

--- a/scripts/docker/hub/Dockerfile
+++ b/scripts/docker/hub/Dockerfile
@@ -16,16 +16,12 @@ RUN apt clean -y
 RUN rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
 RUN groupadd -g 1000 parity \
-  && useradd -m -u 1000 -g parity -s /bin/sh parity
+  && useradd -u 1000 -g parity -s /bin/sh parity
 
 USER parity
 
-WORKDIR /home/parity
-
-ENV PATH "~/bin:${PATH}"
-
 #add TARGET to docker image
-COPY artifacts/x86_64-unknown-linux-gnu/$TARGET ./bin/$TARGET
+COPY artifacts/x86_64-unknown-linux-gnu/$TARGET /bin/$TARGET
 
 # Build a shell script because the ENTRYPOINT command doesn't like using ENV
 RUN echo "#!/bin/bash \n ${TARGET} \$@" > ./entrypoint.sh


### PR DESCRIPTION
Moving the binary and the entry point to the home directory makes using the docker image in Kubernetes really hard. At the same time, there is no good reason to do so as far as I can tell (all that we want is to use a non-root user which we can absolutely do even without the home directory).