### PR TITLE
Alternative fix for hash function independence.

### DIFF
--- a/util/bloom/src/lib.rs
+++ b/util/bloom/src/lib.rs
@@ -178,11 +178,7 @@ impl Bloom {
 	}
 
 	fn bloom_hash(base_hash: u64, k_i: u32) -> u64 {
-		if k_i < 2 {
-			base_hash
-		} else {
-			base_hash.wrapping_add((k_i as u64).wrapping_mul(base_hash) % 0xffffffffffffffc5)
-		}
+		base_hash.wrapping_add((k_i as u64).wrapping_mul(base_hash) % 0xffffffffffffffc5)
 	}
 
 	/// Drains the bloom journal returning the updated bloom part


### PR DESCRIPTION
This simplifies the bloom_hash function to not special case k_i = 0 or
1.  Because we are using wrapping_add and wrapping_mul, the 0 case
just returns the base_hash and the 1 case returns base_hash +
(base_hash % 0xff...fc5), so these two cases should differ.

The current buggy code tries to have k independent hashes, but in actuality is using k-1 different hashes.