### PR TITLE
ci: nuke the gitlab caches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,12 +13,6 @@ variables:
   BUILD_ARCH:                      amd64
   CARGO_TARGET:                    x86_64-unknown-linux-gnu
 
-cache:
-  key:                             "${CI_JOB_NAME}"
-  paths:
-    - ./target
-    - ./.cargo
-
 .releaseable_branches:             # list of git refs for building GitLab artifacts (think "pre-release binaries")
   only:                            &releaseable_branches
     - stable


### PR DESCRIPTION
For comparison: 

- **70 minutes** with cache: https://gitlab.parity.io/parity/parity-ethereum/-/jobs/107291
- **33 seconds** without cache: https://gitlab.parity.io/parity/parity-ethereum/-/jobs/107307

Both don't build anything. Just plain pipeline without and with cache.