### PR TITLE
Fix json tracer overflow

### DIFF
--- a/evmbin/src/display/json.rs
+++ b/evmbin/src/display/json.rs
@@ -197,7 +197,6 @@ impl trace::VMTracer for Informant {
 			let subdepth = self.subdepth;
 
 			Self::with_informant_in_depth(&mut self, subdepth, |informant: &mut Informant| {
-				let store_diff = informant.store_written.clone();
 				let info = ::evm::Instruction::from_u8(informant.instruction).map(|i| i.info());
 
 				let trace = json!({

--- a/evmbin/src/display/json.rs
+++ b/evmbin/src/display/json.rs
@@ -296,6 +296,17 @@ mod tests {
 {"pc":0,"op":248,"opName":"","gas":"0xffff","gasCost":"0x0","memory":"0x","stack":[],"storage":{},"depth":1}
 			"#,
 		);
+
+		run_test(
+			Informant::default(),
+			&compare_json,
+			"5A51",
+			0xfffff,
+			r#"
+{"depth":1,"gas":"0xfffff","gasCost":"0x2","memory":"0x","op":90,"opName":"GAS","pc":0,"stack":[],"storage":{}}
+{"depth":1,"gas":"0xffffd","gasCost":"0x0","memory":"0x","op":81,"opName":"MLOAD","pc":1,"stack":["0xffffd"],"storage":{}}
+			"#,
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
Fixes #9872 by resizing the memory in case of overflow.

The current logic in json tracer does an artificial `trace_executed` on VM error return, within which the previous `trace_prepare_execute`'s `mem_written` might not be valid. This is replaced by a direct trace push.