### PR TITLE
Allow to seal work on latest block

### DIFF
--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -576,10 +576,9 @@ impl Miner {
 		trace!(target: "miner", "requires_reseal: sealing enabled");
 
 		// Disable sealing if there were no requests for SEALING_TIMEOUT_IN_BLOCKS
-		let had_requests = sealing.last_request.map(|last_request| {
-			best_block > last_request
-				&& best_block - last_request <= SEALING_TIMEOUT_IN_BLOCKS
-		}).unwrap_or(false);
+		let had_requests = sealing.last_request.map(|last_request| 
+			best_block.saturating_sub(last_request) <= SEALING_TIMEOUT_IN_BLOCKS
+		).unwrap_or(false);
 
 		// keep sealing enabled if any of the conditions is met
 		let sealing_enabled = self.forced_sealing()


### PR DESCRIPTION
With recent enhancement on the txqueue, issue appears for miners that forces them to use  the 'force_sealing=true' option when using 'reseal_on_txs = all', as seen on #9278 .

What was happening : when there is transaction in every block, the condition did never trigger because 'best_block' was always equal to 'last_request'.

Changing the condition to allow reseal on latest block fix that, with this PR it is possible again to run mining without using force_sealing.

The new condition also allows blocks over the latest one, but I talk with @tomusdrw and it should not be an issue.

Edit : added test from @tomusdrw .