### PR TITLE
Remove runtime from secret_store.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,6 +918,7 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-crypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-runtime 0.1.0",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -739,7 +739,7 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 		account_provider: account_provider,
 		accounts_passwords: &passwords,
 	};
-	let secretstore_key_server = secretstore::start(cmd.secretstore_conf.clone(), secretstore_deps)?;
+	let secretstore_key_server = secretstore::start(cmd.secretstore_conf.clone(), secretstore_deps, runtime.executor())?;
 
 	// the ipfs server
 	let ipfs_server = ipfs::start_server(cmd.ipfs_conf.clone(), client.clone())?;

--- a/secret_store/Cargo.toml
+++ b/secret_store/Cargo.toml
@@ -17,6 +17,7 @@ futures = "0.1"
 rustc-hex = "1.0"
 tiny-keccak = "1.4"
 tokio = "~0.1.11"
+parity-runtime = { path = "../util/runtime" }
 tokio-io = "0.1"
 tokio-service = "0.1"
 url = "1.0"

--- a/secret_store/src/key_server_cluster/client_sessions/generation_session.rs
+++ b/secret_store/src/key_server_cluster/client_sessions/generation_session.rs
@@ -1367,12 +1367,12 @@ pub mod tests {
 			let clusters_clone = clusters.clone();
 
 			// establish connections
-			loop_until(&mut core, CONN_TIMEOUT, move || clusters_clone.iter().all(all_connections_established));
+			loop_until(&core.executor(), CONN_TIMEOUT, move || clusters_clone.iter().all(all_connections_established));
 
 			// run session to completion
 			let session_id = SessionId::default();
 			let session = clusters[0].client().new_generation_session(session_id, Default::default(), Default::default(), threshold).unwrap();
-			loop_until(&mut core, SESSION_TIMEOUT, move || session.joint_public_and_secret().is_some());
+			loop_until(&core.executor(), SESSION_TIMEOUT, move || session.joint_public_and_secret().is_some());
 		}
 	}
 

--- a/secret_store/src/key_server_cluster/cluster_sessions.rs
+++ b/secret_store/src/key_server_cluster/cluster_sessions.rs
@@ -582,7 +582,6 @@ mod tests {
 	pub fn make_cluster_sessions() -> ClusterSessions {
 		let key_pair = Random.generate().unwrap();
 		let config = ClusterConfiguration {
-			threads: 1,
 			self_key_pair: Arc::new(PlainNodeKeyPair::new(key_pair.clone())),
 			listen_address: ("127.0.0.1".to_owned(), 100_u16),
 			key_server_set: Arc::new(MapKeyServerSet::new(false, vec![(key_pair.public().clone(), format!("127.0.0.1:{}", 100).parse().unwrap())].into_iter().collect())),

--- a/secret_store/src/types/all.rs
+++ b/secret_store/src/types/all.rs
@@ -75,8 +75,6 @@ pub struct ServiceConfiguration {
 /// Key server cluster configuration
 #[derive(Debug)]
 pub struct ClusterConfiguration {
-	/// Number of threads reserved by cluster.
-	pub threads: usize,
 	/// This node address.
 	pub listener_address: NodeAddress,
 	/// All cluster nodes addresses.


### PR DESCRIPTION
* Remove the independent runtimes from `KeyServerHttpListener` and
  `KeyServerCore` and instead require a `parity_runtime::Executor`
  to be passed upon creation of each.

* Remove the `threads` parameter from both `ClusterConfiguration` structs.

* Implement the `future::Executor` trait for `parity_runtime::Executor`.

* Update tests.
  - Update the `loop_until` function to instead use a oneshot to signal
    completion.
  - Modify the `make_key_servers` function to create and return a runtime.
