### PR TITLE
chore(rpc-tests): remove unused rand

### DIFF
--- a/rpc/src/tests/ws.rs
+++ b/rpc/src/tests/ws.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 
 use devtools::http_client;
 use jsonrpc_core::MetaIoHandler;
-use rand;
 use ws;
 
 use v1::{extractors, informant};


### PR DESCRIPTION
Fixes:

```bash
    Checking parity-rpc v1.12.0 (/home/niklasad1/Github/Parity/parity-ethereum/rpc)
warning: unused import: `rand`
  --> rpc/src/tests/ws.rs:23:5
   |
23 | use rand;
   |     ^^^^

```