### PR TITLE
ethcore: use Machine::verify_transaction on parent block

### DIFF
--- a/ethcore/src/machine.rs
+++ b/ethcore/src/machine.rs
@@ -371,11 +371,11 @@ impl EthereumMachine {
 	}
 
 	/// Does verification of the transaction against the parent state.
-	pub fn verify_transaction<C: BlockInfo + CallContract>(&self, t: &SignedTransaction, header: &Header, client: &C)
+	pub fn verify_transaction<C: BlockInfo + CallContract>(&self, t: &SignedTransaction, parent: &Header, client: &C)
 		-> Result<(), transaction::Error>
 	{
 		if let Some(ref filter) = self.tx_filter.as_ref() {
-			if !filter.transaction_allowed(header.parent_hash(), header.number(), t, client) {
+			if !filter.transaction_allowed(&parent.hash(), parent.number() + 1, t, client) {
 				return Err(transaction::Error::NotAllowed.into())
 			}
 		}

--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -147,7 +147,7 @@ pub fn verify_block_family<C: BlockInfo + CallContract>(header: &Header, parent:
 	verify_uncles(params.block, params.block_provider, engine)?;
 
 	for tx in &params.block.transactions {
-		engine.machine().verify_transaction(tx, header, params.client)?;
+		engine.machine().verify_transaction(tx, parent, params.client)?;
 	}
 
 	Ok(())

--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -147,6 +147,8 @@ pub fn verify_block_family<C: BlockInfo + CallContract>(header: &Header, parent:
 	verify_uncles(params.block, params.block_provider, engine)?;
 
 	for tx in &params.block.transactions {
+		// transactions are verified against the parent header since the current
+		// state wasn't available when the tx was created
 		engine.machine().verify_transaction(tx, parent, params.client)?;
 	}
 


### PR DESCRIPTION
`Machine::verify_transaction` is meant to be used against the parent header. When verifying transactions in a block we would pass the block header instead of the parent, it would be correct for this case since we'd use `header.parent_hash()`, but when the [miner called it with `best_block`](https://github.com/paritytech/parity-ethereum/blob/master/ethcore/src/miner/pool_client.rs#L122) it wouldn't work properly, e.g. transaction permission contract activation would be off-by-one and the `parent_hash` passed to `TransactionFilter` would be incorrect.