### PR TITLE
Fix performance issue importing Kovan blocks

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -481,7 +481,7 @@ impl Importer {
 
 		let mut batch = DBTransaction::new();
 
-		let ancestry_actions = self.engine.ancestry_actions(&block, &mut chain.ancestry_with_metadata_iter(*parent));
+		let ancestry_actions = self.engine.ancestry_actions(&header, &mut chain.ancestry_with_metadata_iter(*parent));
 
 		let receipts = block.receipts;
 		let traces = block.traces.drain();

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -429,7 +429,7 @@ pub trait Engine<M: Machine>: Sync + Send {
 
 	/// Gather all ancestry actions. Called at the last stage when a block is committed. The Engine must guarantee that
 	/// the ancestry exists.
-	fn ancestry_actions(&self, _block: &M::LiveBlock, _ancestry: &mut Iterator<Item=M::ExtendedHeader>) -> Vec<AncestryAction> {
+	fn ancestry_actions(&self, _header: &M::Header, _ancestry: &mut Iterator<Item=M::ExtendedHeader>) -> Vec<AncestryAction> {
 		Vec::new()
 	}
 


### PR DESCRIPTION
The `block` passed to `self.engine.ancestry_actions` didn't have all the Header's data, thus the `block.header.hash()` was wrong, and the condition `finality_checker.subchain_head() != Some(*chain_head.parent_hash())` in `AuthorityRound::build_finality` would never be `false`, so we would check all ancestry for every imported blocks, until a finalised one was to be found. This was very costly in same cases, eg. when first syncing the chain: on current `master` I would sync at 50 blocks/s, with this PR (as on stable) it goes at about 1_000 blocks/s.