### PR TITLE
add --force, it's installed somewhere

### DIFF
--- a/scripts/gitlab/cargo-audit.sh
+++ b/scripts/gitlab/cargo-audit.sh
@@ -3,5 +3,5 @@
 set -e # fail on any error
 set -u # treat unset variables as error
 
-cargo install cargo-audit
+cargo install cargo-audit --force
 cargo audit


### PR DESCRIPTION
it appeared that `cargo audit` was installed previously, that failed the beta and stable builds:
```
cargo-audit v0.5.2
error: binary `cargo-audit` already exists in destination as part of `cargo-audit v0.5.2`
Add --force to overwrite
```