### PR TITLE
Adjust requests costs for light client

### DIFF
--- a/ethcore/light/src/net/mod.rs
+++ b/ethcore/light/src/net/mod.rs
@@ -373,7 +373,8 @@ impl Statistics {
 		if len == 0 {
 			return 1.0;
 		}
-		let avg = self.peer_counts.iter().map(|&v| v as u32).sum::<u32>() as f64
+		let avg = self.peer_counts.iter()
+			.fold(0, |sum: u32, &v| sum.saturating_add(v as u32)) as f64
 			/ len as f64;
 		avg.max(1.0)
 	}

--- a/ethcore/light/src/net/mod.rs
+++ b/ethcore/light/src/net/mod.rs
@@ -76,6 +76,10 @@ const STATISTICS_INTERVAL: Duration = Duration::from_secs(15);
 /// Maximum load share for the light server
 pub const MAX_LIGHTSERV_LOAD: f64 = 0.5;
 
+/// Factor to multiply leecher count to cater for
+/// extra sudden connections (should be >= 1.0)
+pub const LEECHER_COUNT_FACTOR: f64 = 1.25;
+
 // minimum interval between updates.
 const UPDATE_INTERVAL: Duration = Duration::from_millis(5000);
 
@@ -827,8 +831,8 @@ impl LightProtocol {
 		self.load_distribution.end_period(&*self.sample_store);
 
 		let avg_peer_count = self.statistics.read().avg_peer_count();
-		// Load share relative to average peer count +25%
-		let load_share = MAX_LIGHTSERV_LOAD / (avg_peer_count * 1.25);
+		// Load share relative to average peer count +LEECHER_COUNT_FACTOR%
+		let load_share = MAX_LIGHTSERV_LOAD / (avg_peer_count * LEECHER_COUNT_FACTOR);
 		let new_params = Arc::new(FlowParams::from_request_times(
 			|kind| self.load_distribution.expected_time(kind),
 			load_share,

--- a/ethcore/light/src/net/mod.rs
+++ b/ethcore/light/src/net/mod.rs
@@ -848,8 +848,13 @@ impl LightProtocol {
 	}
 
 	fn tick_statistics(&self) {
-		let active_peer_count = self.peer_count().1;
-		self.statistics.write().add_peer_count(active_peer_count);
+		let peer_count = self.peers.read().len();
+		let credit_limit = *self.flow_params.read().limit();
+		let alt_peer_count = self.peers.read().iter()
+			.filter(|(_, p)| p.lock().local_credits.current() < credit_limit)
+			.count();
+		info!(target: "pip", "Found {} connected peers ; {} from credit score", peer_count, alt_peer_count);
+		self.statistics.write().add_peer_count(peer_count);
 	}
 }
 

--- a/ethcore/light/src/net/mod.rs
+++ b/ethcore/light/src/net/mod.rs
@@ -347,12 +347,13 @@ mod id_guard {
 
 /// Provides various statistics that could
 /// be used to compute costs
-struct Statistics {
+pub struct Statistics {
 	/// Samples of peer count
 	peer_counts: VecDeque<usize>,
 }
 
 impl Statistics {
+	/// Create a new Statistics instance
 	pub fn new() -> Self {
 		Statistics {
 			peer_counts: VecDeque::with_capacity(MOVING_SAMPLE_SIZE),

--- a/ethcore/light/src/net/mod.rs
+++ b/ethcore/light/src/net/mod.rs
@@ -373,7 +373,7 @@ impl Statistics {
 		if len == 0 {
 			return 1.0;
 		}
-		let avg = self.peer_counts.iter().map(|&v| v as u64).sum::<u64>() as f64
+		let avg = self.peer_counts.iter().map(|&v| v as u32).sum::<u32>() as f64
 			/ len as f64;
 		avg.max(1.0)
 	}

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -264,7 +264,7 @@ pub struct EthSync {
 
 fn light_params(
 	network_id: u64,
-	max_peers: u32,
+	median_peers: f64,
 	pruning_info: PruningInfo,
 	sample_store: Option<Box<SampleStore>>,
 ) -> LightParams {
@@ -282,9 +282,8 @@ fn light_params(
 		sample_store: sample_store,
 	};
 
-	let max_peers = ::std::cmp::max(max_peers, 1);
-	light_params.config.load_share = MAX_LIGHTSERV_LOAD / max_peers as f64;
-
+	light_params.config.load_share = MAX_LIGHTSERV_LOAD;
+	light_params.config.median_peers = median_peers;
 	light_params
 }
 
@@ -301,9 +300,10 @@ impl EthSync {
 					.map(|mut p| { p.push("request_timings"); light_net::FileStore(p) })
 					.map(|store| Box::new(store) as Box<_>);
 
+				let median_peers = (params.network_config.min_peers + params.network_config.max_peers) as f64 / 2.0;
 				let light_params = light_params(
 					params.config.network_id,
-					params.network_config.max_peers,
+					median_peers,
 					pruning_info,
 					sample_store,
 				);

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -940,19 +940,3 @@ impl LightSyncProvider for LightSync {
 		Default::default() // TODO
 	}
 }
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn light_params_load_share_depends_on_max_peers() {
-		let pruning_info = PruningInfo {
-			earliest_chain: 0,
-			earliest_state: 0,
-		};
-		let params1 = light_params(0, 10.0, pruning_info.clone(), None);
-		let params2 = light_params(0, 20.0, pruning_info, None);
-		assert!(params1.config.load_share > params2.config.load_share)
-	}
-}

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -268,8 +268,6 @@ fn light_params(
 	pruning_info: PruningInfo,
 	sample_store: Option<Box<SampleStore>>,
 ) -> LightParams {
-	const MAX_LIGHTSERV_LOAD: f64 = 0.5;
-
 	let mut light_params = LightParams {
 		network_id: network_id,
 		config: Default::default(),
@@ -282,7 +280,6 @@ fn light_params(
 		sample_store: sample_store,
 	};
 
-	light_params.config.load_share = MAX_LIGHTSERV_LOAD;
 	light_params.config.median_peers = median_peers;
 	light_params
 }

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -951,8 +951,8 @@ mod tests {
 			earliest_chain: 0,
 			earliest_state: 0,
 		};
-		let params1 = light_params(0, 10, pruning_info.clone(), None);
-		let params2 = light_params(0, 20, pruning_info, None);
+		let params1 = light_params(0, 10.0, pruning_info.clone(), None);
+		let params2 = light_params(0, 20.0, pruning_info, None);
 		assert!(params1.config.load_share > params2.config.load_share)
 	}
 }


### PR DESCRIPTION
Fixes #9880

The issue was that since late-August, the PIP request costs were relative to the config max number of peers (the PR fixed an issue where the max number of peers was always 1). However, this doesn't really reflect the load of the server. 

With this PR, the costs are relative to the average number of _PIP leeching peers_, ie. the number of peers sending requests to the node. This should lower the requests costs, without overloading the serving nodes (it seems that less than 5 leeching peers are usually connected, so it should decrease the costs by 100x on Kovan since our bootnodes were setup with 500 max peers).