### PR TITLE
Fix light client informant while syncing

### DIFF
--- a/ethcore/sync/src/light_sync/mod.rs
+++ b/ethcore/sync/src/light_sync/mod.rs
@@ -274,6 +274,7 @@ pub struct LightSync<L: AsLightClient> {
 	client: Arc<L>,
 	rng: Mutex<OsRng>,
 	state: Mutex<SyncStateWrapper>,
+	// We duplicate this state tracking to avoid deadlocks in `is_major_importing`.
 	is_idle: Mutex<bool>,
 }
 

--- a/ethcore/sync/src/light_sync/mod.rs
+++ b/ethcore/sync/src/light_sync/mod.rs
@@ -711,10 +711,11 @@ impl<L: AsLightClient> SyncInfo for LightSync<L> {
 	fn is_major_importing(&self) -> bool {
 		const EMPTY_QUEUE: usize = 3;
 
-		if self.client.as_light_client().queue_info().unverified_queue_size > EMPTY_QUEUE {
-			return true;
-		}
-		!*self.is_idle.lock()
+		let queue_info = self.client.as_light_client().queue_info();
+		let is_verifying = queue_info.unverified_queue_size + queue_info.verified_queue_size > EMPTY_QUEUE;
+		let is_syncing = !*self.is_idle.lock();
+
+		is_verifying || is_syncing
 	}
 
 }

--- a/ethcore/sync/src/light_sync/mod.rs
+++ b/ethcore/sync/src/light_sync/mod.rs
@@ -239,7 +239,7 @@ impl SyncStateWrapper {
 	}
 
 	/// Returns the internal state's value
-	pub fn get(self) -> SyncState {
+	pub fn into_inner(self) -> SyncState {
 		self.state
 	}
 }
@@ -354,7 +354,7 @@ impl<L: AsLightClient + Send + Sync> Handler for LightSync<L> {
 		} else {
 			let mut state = self.state.lock();
 
-			let next_state = match mem::replace(&mut *state, SyncStateWrapper::idle()).get() {
+			let next_state = match mem::replace(&mut *state, SyncStateWrapper::idle()).into_inner() {
 				SyncState::Idle => SyncState::Idle,
 				SyncState::AncestorSearch(search) =>
 					SyncState::AncestorSearch(search.requests_abandoned(unfulfilled)),
@@ -432,7 +432,7 @@ impl<L: AsLightClient + Send + Sync> Handler for LightSync<L> {
 				data: headers,
 			};
 
-			let next_state = match mem::replace(&mut *state, SyncStateWrapper::idle()).get() {
+			let next_state = match mem::replace(&mut *state, SyncStateWrapper::idle()).into_inner() {
 				SyncState::Idle => SyncState::Idle,
 				SyncState::AncestorSearch(search) =>
 					SyncState::AncestorSearch(search.process_response(&ctx, &*self.client)),
@@ -495,7 +495,7 @@ impl<L: AsLightClient> LightSync<L> {
 			loop {
 				if client.queue_info().is_full() { break }
 
-				let next_state = match mem::replace(&mut *state, SyncStateWrapper::idle()).get() {
+				let next_state = match mem::replace(&mut *state, SyncStateWrapper::idle()).into_inner() {
 					SyncState::Rounds(round)
 						=> SyncState::Rounds(round.drain(&mut sink, Some(DRAIN_AMOUNT))),
 					other => other,
@@ -539,7 +539,7 @@ impl<L: AsLightClient> LightSync<L> {
 				}
 			};
 
-			match mem::replace(&mut *state, SyncStateWrapper::idle()).get() {
+			match mem::replace(&mut *state, SyncStateWrapper::idle()).into_inner() {
 				SyncState::Rounds(SyncRound::Abort(reason, remaining)) => {
 					if remaining.len() > 0 {
 						self.set_state(&mut state, SyncState::Rounds(SyncRound::Abort(reason, remaining)));
@@ -594,7 +594,7 @@ impl<L: AsLightClient> LightSync<L> {
 				}
 				drop(pending_reqs);
 
-				let next_state = match mem::replace(&mut *state, SyncStateWrapper::idle()).get() {
+				let next_state = match mem::replace(&mut *state, SyncStateWrapper::idle()).into_inner() {
 					SyncState::Idle => SyncState::Idle,
 					SyncState::AncestorSearch(search) =>
 						SyncState::AncestorSearch(search.requests_abandoned(&unfulfilled)),
@@ -657,7 +657,7 @@ impl<L: AsLightClient> LightSync<L> {
 				None
 			};
 
-			let next_state = match mem::replace(&mut *state, SyncStateWrapper::idle()).get() {
+			let next_state = match mem::replace(&mut *state, SyncStateWrapper::idle()).into_inner() {
 				SyncState::Rounds(round) =>
 					SyncState::Rounds(round.dispatch_requests(dispatcher)),
 				SyncState::AncestorSearch(search) =>

--- a/ethcore/sync/src/light_sync/mod.rs
+++ b/ethcore/sync/src/light_sync/mod.rs
@@ -216,6 +216,7 @@ enum SyncState {
 
 /// A wrapper around the SyncState that makes sure to
 /// update the giving reference to `is_idle`
+#[derive(Debug)]
 struct SyncStateWrapper {
 	state: SyncState,
 }

--- a/parity/informant.rs
+++ b/parity/informant.rs
@@ -184,7 +184,7 @@ impl InformantData for LightNodeInformantData {
 	fn executes_transactions(&self) -> bool { false }
 
 	fn is_major_importing(&self) -> bool {
-		self.sync.is_major_importing_no_sync()
+		self.sync.is_major_importing()
 	}
 
 	fn report(&self) -> Report {


### PR DESCRIPTION
From #9385 , the informant wasn't displaying correctly the syncing state. This is because the `state` of `LightSync` had deadlock issues, and the default to `is_major_importing` was set to false if the lock couldn't be acquired. This lead to false logs in the informant.

In this PR, `is_idle` is added, and gets updated everytime the `state` is updated, such as `is_major_importing` can check this boolean instead of waiting for `state` to be unlocked.