### PR TITLE
Unbreak parity-rpc build on rust -stable

### DIFF
--- a/rpc/src/v1/helpers/light_fetch.rs
+++ b/rpc/src/v1/helpers/light_fetch.rs
@@ -625,7 +625,7 @@ fn execute_read_only_tx(gas_known: bool, params: ExecuteParams) -> impl Future<I
 				match res {
 					Ok(executed) => {
 						// `OutOfGas` exception, try double the gas
-						if let Some(vm::Error::OutOfGas) = executed.exception {
+						if let Some(::vm::Error::OutOfGas) = executed.exception {
 							// block gas limit already tried, regard as an error and don't retry
 							if params.tx.gas >= params.hdr.gas_limit() {
 								trace!(target: "light_fetch", "OutOutGas exception received, gas increase: failed");


### PR DESCRIPTION
```
   Compiling parity-rpc v1.12.0 (file:///home/reyk/devel/parity-ethereum/rpc)
error[E0658]: access to extern crates through prelude is experimental (see issue #44660)
   --> rpc/src/v1/helpers/light_fetch.rs:628:19
    |
628 |                         if let Some(vm::Error::OutOfGas) = executed.exception {
    |                                     ^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0658`.
error: Could not compile `parity-rpc`.

```