### PR TITLE
fix: Missing blocks in filter_changes RPC

### DIFF
--- a/rpc/src/v1/helpers/poll_filter.rs
+++ b/rpc/src/v1/helpers/poll_filter.rs
@@ -17,7 +17,7 @@
 //! Helper type with all filter state data.
 
 use std::{
-	collections::{BTreeSet, HashSet},
+	collections::{BTreeSet, HashSet, VecDeque},
 	sync::Arc,
 };
 use ethereum_types::H256;
@@ -49,7 +49,11 @@ impl SyncPollFilter {
 #[derive(Clone)]
 pub enum PollFilter {
 	/// Number of last block which client was notified about.
-	Block(BlockNumber),
+	Block {
+		last_block_number: BlockNumber,
+		#[doc(hidden)]
+		recent_reported_hashes: VecDeque<(BlockNumber, H256)>,
+	},
 	/// Hashes of all pending transactions the client knows about.
 	PendingTransaction(BTreeSet<H256>),
 	/// Number of From block number, last seen block hash, pending logs and log filter itself.
@@ -60,6 +64,10 @@ pub enum PollFilter {
 		filter: Filter,
 		include_pending: bool,
 	}
+}
+
+impl PollFilter {
+	pub (in v1) const MAX_BLOCK_HISTORY_SIZE: usize = 32;
 }
 
 /// Returns only last `n` logs

--- a/rpc/src/v1/impls/eth_filter.rs
+++ b/rpc/src/v1/impls/eth_filter.rs
@@ -17,7 +17,7 @@
 //! Eth Filter RPC implementation
 
 use std::sync::Arc;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, VecDeque};
 
 use ethcore::miner::{self, MinerService};
 use ethcore::filter::Filter as EthcoreFilter;
@@ -153,7 +153,10 @@ impl<T: Filterable + Send + Sync + 'static> EthFilter for T {
 	fn new_block_filter(&self) -> Result<RpcU256> {
 		let mut polls = self.polls().lock();
 		// +1, since we don't want to include the current block
-		let id = polls.create_poll(SyncPollFilter::new(PollFilter::Block(self.best_block_number() + 1)));
+		let id = polls.create_poll(SyncPollFilter::new(PollFilter::Block {
+			last_block_number: self.best_block_number() + 1,
+			recent_reported_hashes: VecDeque::with_capacity(PollFilter::MAX_BLOCK_HISTORY_SIZE),
+		}));
 		Ok(id.into())
 	}
 
@@ -171,15 +174,33 @@ impl<T: Filterable + Send + Sync + 'static> EthFilter for T {
 		};
 
 		Box::new(filter.modify(|filter| match *filter {
-			PollFilter::Block(ref mut block_number) => {
-				// +1, cause we want to return hashes including current block hash.
-				let current_number = self.best_block_number() + 1;
-				let hashes = (*block_number..current_number).into_iter()
-					.map(BlockId::Number)
-					.filter_map(|id| self.block_hash(id).map(Into::into))
-					.collect::<Vec<RpcH256>>();
-
-				*block_number = current_number;
+			PollFilter::Block {
+				ref mut last_block_number,
+				ref mut recent_reported_hashes,
+			} => {
+				// Check validity of recently reported blocks -- in case of re-org, rewind block to last valid
+				while let Some((num, hash)) = recent_reported_hashes.front().cloned() {
+					if self.block_hash(BlockId::Number(num)) == Some(hash) { break; }
+					*last_block_number = num - 1;
+					recent_reported_hashes.pop_front();
+				}
+				let current_number = self.best_block_number();
+				let mut hashes = Vec::new();
+				for n in (*last_block_number + 1)..=current_number {
+					let block_number = BlockId::Number(n);
+					match self.block_hash(block_number) {
+						Some(hash) => {
+							*last_block_number = n;
+							hashes.push(RpcH256::from(hash));
+							// Only keep the most recent history
+							if recent_reported_hashes.len() >= PollFilter::MAX_BLOCK_HISTORY_SIZE {
+								recent_reported_hashes.pop_back();
+							}
+							recent_reported_hashes.push_front((n, hash));
+						},
+						None => (),
+					}
+				}
 
 				Either::A(future::ok(FilterChanges::Hashes(hashes)))
 			},


### PR DESCRIPTION
Fixes: [#9858](https://github.com/paritytech/parity-ethereum/issues/9858)

Implement validity check of reported hashes (in case of re-org)
to determine the last block reported that is still valid. This will return hashes for 
block numbers that have previously been reported if the hash is different.

Add const to set history length for validity check. Currently set to 32 blocks.