### PR TITLE
allow rust-nightly builds fail in nightly builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,3 +150,4 @@ test-nightly:
     - scripts/gitlab/test-all.sh nightly
   tags:
     - rust-nightly
+  allow_failure:                   true


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/guide/continuous-integration.html#gitlab-ci

allow rust-nightly builds to fail

https://gitlab.parity.io/parity/parity-ethereum/pipelines/26136