### PR TITLE
Fix a deadlock

### DIFF
--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -1187,8 +1187,8 @@ impl BlockChain {
 		let mut pending_block_details = self.pending_block_details.write();
 		let mut pending_write_txs = self.pending_transaction_addresses.write();
 
-		let mut best_ancient_block = self.best_ancient_block.write();
 		let mut best_block = self.best_block.write();
+		let mut best_ancient_block = self.best_ancient_block.write();
 		let mut write_block_details = self.block_details.write();
 		let mut write_hashes = self.block_hashes.write();
 		let mut write_txs = self.transaction_addresses.write();
@@ -1530,8 +1530,8 @@ impl BlockChain {
 		let genesis_hash = self.genesis_hash();
 
 		// ensure data consistencly by locking everything first
-		let best_ancient_block = self.best_ancient_block.read();
 		let best_block = self.best_block.read();
+		let best_ancient_block = self.best_ancient_block.read();
 		BlockChainInfo {
 			total_difficulty: best_block.total_difficulty,
 			pending_total_difficulty: best_block.total_difficulty,

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -1530,8 +1530,8 @@ impl BlockChain {
 		let genesis_hash = self.genesis_hash();
 
 		// ensure data consistencly by locking everything first
-		let best_block = self.best_block.read();
 		let best_ancient_block = self.best_ancient_block.read();
+		let best_block = self.best_block.read();
 		BlockChainInfo {
 			total_difficulty: best_block.total_difficulty,
 			pending_total_difficulty: best_block.total_difficulty,

--- a/parity/informant.rs
+++ b/parity/informant.rs
@@ -256,16 +256,13 @@ impl<T: InformantData> Informant<T> {
 	}
 
 	pub fn tick(&self) {
-		let elapsed = self.last_tick.read().elapsed();
-		if elapsed < Duration::from_secs(5) {
-			return;
-		}
+		let now = Instant::now();
+		let elapsed = now.duration_since(*self.last_tick.read());
 
 		let (client_report, full_report) = {
 			let mut last_report = self.last_report.lock();
 			let full_report = self.target.report();
 			let diffed = full_report.client_report.clone() - &*last_report;
-			*last_report = full_report.client_report.clone();
 			(diffed, full_report)
 		};
 
@@ -289,7 +286,8 @@ impl<T: InformantData> Informant<T> {
 			return;
 		}
 
-		*self.last_tick.write() = Instant::now();
+		*self.last_tick.write() = now;
+		*self.last_report.lock() = full_report.client_report.clone();
 
 		let paint = |c: Style, t: String| match self.with_color && atty::is(atty::Stream::Stdout) {
 			true => format!("{}", c.paint(t)),
@@ -306,7 +304,7 @@ impl<T: InformantData> Informant<T> {
 							format!("{} blk/s {} tx/s {} Mgas/s",
 								paint(Yellow.bold(), format!("{:7.2}", (client_report.blocks_imported * 1000) as f64 / elapsed.as_milliseconds() as f64)),
 								paint(Yellow.bold(), format!("{:6.1}", (client_report.transactions_applied * 1000) as f64 / elapsed.as_milliseconds() as f64)),
-								paint(Yellow.bold(), format!("{:4}", (client_report.gas_processed / (elapsed.as_milliseconds() * 1000)).low_u64()))
+								paint(Yellow.bold(), format!("{:6.1}", (client_report.gas_processed / 1000).low_u64() as f64 / elapsed.as_milliseconds() as f64))
 							)
 						} else {
 							format!("{} hdr/s",


### PR DESCRIPTION
A deadlock has been introduced in #8643:
In `fn commit(&self)` there were:
https://github.com/paritytech/parity-ethereum/blob/9475a2e474d9175abf05b30167bc543bd25a4e3c/ethcore/src/blockchain/blockchain.rs#L1190-L1191

And in `fn chain_info(&self) ` there were:
https://github.com/paritytech/parity-ethereum/blob/9475a2e474d9175abf05b30167bc543bd25a4e3c/ethcore/src/blockchain/blockchain.rs#L1533-L1534

So basically, if `chain_info` was called while `commit` was undergoing, it could happen that `commit` would W-lock `self.best_ancient_block`, `chain_info` would R-lock `self.best_block`, and then `commit` would wait to lock `self.best_block` while `chain_info` would wait to lock `self.best_ancient_block`.

I'm not sure if there is a better way to fix this, since it's not the first time we had an issue with this (#9385 fixed a deadlock, but broke the informant, then fixed in #9932).

I try to update `chain_info` so that it could return an `Option` with `try_read`, and the informant would just keep trying to get a `Report` until one is available, but that breaks a dozen of other files. If anyone has a better idea...

This PR also updates the informant, so that it prints info every 5 seconds, instead of previously varying randomly between 5s and 10s.