### PR TITLE
Disable EIP-98 transition by default

### DIFF
--- a/ethcore/res/ethereum/byzantium_test.json
+++ b/ethcore/res/ethereum/byzantium_test.json
@@ -28,7 +28,6 @@
 		"eip160Transition": "0x0",
 		"eip161abcTransition": "0x0",
 		"eip161dTransition": "0x0",
-		"eip98Transition": "0xffffffffffffffff",
 		"eip140Transition": "0x0",
 		"eip211Transition": "0x0",
 		"eip214Transition": "0x0",

--- a/ethcore/res/ethereum/callisto.json
+++ b/ethcore/res/ethereum/callisto.json
@@ -32,7 +32,6 @@
 		"eip161abcTransition": 10,
 		"eip161dTransition": 10,
 		"eip155Transition": 10,
-		"eip98Transition": "0xffffffffffffffff",
 		"eip140Transition": 20,
 		"eip211Transition": 20,
 		"eip214Transition": 20,

--- a/ethcore/res/ethereum/classic.json
+++ b/ethcore/res/ethereum/classic.json
@@ -30,8 +30,7 @@
 		"eip160Transition": 3000000,
 		"eip161abcTransition": "0x7fffffffffffffff",
 		"eip161dTransition": "0x7fffffffffffffff",
-		"eip155Transition": 3000000,
-		"eip98Transition": "0x7fffffffffffff"
+		"eip155Transition": 3000000
 	},
 	"genesis": {
 		"seal": {

--- a/ethcore/res/ethereum/constantinople_test.json
+++ b/ethcore/res/ethereum/constantinople_test.json
@@ -24,7 +24,6 @@
 		"networkID" : "0x1",
 		"maxCodeSize": 24576,
 		"maxCodeSizeTransition": "0x0",
-		"eip98Transition": "0xffffffffffffffff",
 		"eip150Transition": "0x0",
 		"eip160Transition": "0x0",
 		"eip161abcTransition": "0x0",

--- a/ethcore/res/ethereum/easthub.json
+++ b/ethcore/res/ethereum/easthub.json
@@ -26,8 +26,7 @@
 		"eip160Transition": "0x0",
 		"eip155Transition": "0x0",
 		"eip161abcTransition": "0x7fffffffffffffff",
-		"eip161dTransition": "0x7fffffffffffffff",
-		"eip98Transition": "0x7fffffffffffff"
+		"eip161dTransition": "0x7fffffffffffffff"
 	},
 	"genesis": {
 		"seal": {

--- a/ethcore/res/ethereum/eip150_test.json
+++ b/ethcore/res/ethereum/eip150_test.json
@@ -22,7 +22,6 @@
 		"eip160Transition": "0x7fffffffffffffff",
 		"eip161abcTransition": "0x7fffffffffffffff",
 		"eip161dTransition": "0x7fffffffffffffff",
-		"eip98Transition": "0x7fffffffffffffff",
 		"eip155Transition": "0x7fffffffffffffff",
 		"maxCodeSize": 24576,
 		"maxCodeSizeTransition": "0x7fffffffffffffff"

--- a/ethcore/res/ethereum/eip161_test.json
+++ b/ethcore/res/ethereum/eip161_test.json
@@ -22,7 +22,6 @@
 		"eip160Transition": "0x0",
 		"eip161abcTransition": "0x0",
 		"eip161dTransition": "0x0",
-		"eip98Transition": "0x7fffffffffffffff",
 		"eip155Transition": "0x0",
 		"maxCodeSize": 24576,
 		"maxCodeSizeTransition": "0x0"

--- a/ethcore/res/ethereum/eip210_test.json
+++ b/ethcore/res/ethereum/eip210_test.json
@@ -20,7 +20,6 @@
 		"networkID" : "0x1",
 		"maxCodeSize": 24576,
 		"maxCodeSizeTransition": "0x0",
-		"eip98Transition": "0xffffffffffffffff",
 		"eip150Transition": "0x0",
 		"eip160Transition": "0x0",
 		"eip161abcTransition": "0x0",

--- a/ethcore/res/ethereum/ellaism.json
+++ b/ethcore/res/ethereum/ellaism.json
@@ -28,7 +28,6 @@
 		"eip161abcTransition": "0x7fffffffffffffff",
 		"eip161dTransition": "0x7fffffffffffffff",
 		"eip155Transition": "0x0",
-		"eip98Transition": "0x7fffffffffffff",
 		"wasmActivationTransition": 2000000,
 		"eip140Transition": 2000000,
 		"eip211Transition": 2000000,

--- a/ethcore/res/ethereum/expanse.json
+++ b/ethcore/res/ethereum/expanse.json
@@ -41,7 +41,6 @@
 		"eip160Transition": "0x927C0",
 		"eip161abcTransition": "0x927C0",
 		"eip161dTransition": "0x927C0",
-		"eip98Transition": "0x7fffffffffffff",
 		"eip155Transition": "0x927C0",
 		"eip140Transition": "0xC3500",
 		"eip211Transition": "0xC3500",

--- a/ethcore/res/ethereum/foundation.json
+++ b/ethcore/res/ethereum/foundation.json
@@ -153,7 +153,6 @@
 		"eip161abcTransition": 2675000,
 		"eip161dTransition": 2675000,
 		"eip155Transition": 2675000,
-		"eip98Transition": "0x7fffffffffffff",
 		"maxCodeSize": 24576,
 		"maxCodeSizeTransition": 2675000,
 		"eip140Transition": 4370000,

--- a/ethcore/res/ethereum/frontier_like_test.json
+++ b/ethcore/res/ethereum/frontier_like_test.json
@@ -142,7 +142,6 @@
 		"eip160Transition": "0x7fffffffffffffff",
 		"eip161abcTransition": "0x7fffffffffffffff",
 		"eip161dTransition": "0x7fffffffffffffff",
-		"eip98Transition": "0x7fffffffffffff",
 		"eip155Transition": "0x7fffffffffffffff"
 	},
 	"genesis": {

--- a/ethcore/res/ethereum/frontier_test.json
+++ b/ethcore/res/ethereum/frontier_test.json
@@ -22,7 +22,6 @@
 		"eip160Transition": "0x7fffffffffffffff",
 		"eip161abcTransition": "0x7fffffffffffffff",
 		"eip161dTransition": "0x7fffffffffffffff",
-		"eip98Transition": "0x7fffffffffffff",
 		"eip155Transition": "0x7fffffffffffffff"
 	},
 	"genesis": {

--- a/ethcore/res/ethereum/homestead_test.json
+++ b/ethcore/res/ethereum/homestead_test.json
@@ -18,7 +18,6 @@
 		"maximumExtraDataSize": "0x20",
 		"minGasLimit": "0x1388",
 		"networkID" : "0x1",
-		"eip98Transition": "0x7fffffffffffff",
 		"eip155Transition": "0x7fffffffffffffff",
 		"eip150Transition": "0x7fffffffffffffff",
 		"eip160Transition": "0x7fffffffffffffff",

--- a/ethcore/res/ethereum/kovan.json
+++ b/ethcore/res/ethereum/kovan.json
@@ -39,6 +39,7 @@
 		"maxCodeSizeTransition": 6600000,
 		"validateChainIdTransition": 1000000,
 		"validateReceiptsTransition" : 1000000,
+		"eip98Transition": 0,
 		"eip140Transition": 5067000,
 		"eip211Transition": 5067000,
 		"eip214Transition": 5067000,

--- a/ethcore/res/ethereum/kovan_wasm_test.json
+++ b/ethcore/res/ethereum/kovan_wasm_test.json
@@ -35,6 +35,7 @@
 		"forkBlock": 4297256,
 		"forkCanonHash": "0x0a66d93c2f727dca618fabaf70c39b37018c73d78b939d8b11efbbd09034778f",
 		"validateReceiptsTransition" : 1000000,
+		"eip98Transition": 0,
 		"eip155Transition": 1000000,
 		"validateChainIdTransition": 1000000,
 		"eip140Transition": 5067000,

--- a/ethcore/res/ethereum/mcip3_test.json
+++ b/ethcore/res/ethereum/mcip3_test.json
@@ -27,7 +27,6 @@
 		"eip160Transition":"0x7fffffffffffff",
 		"eip161abcTransition":"0x7fffffffffffff",
 		"eip161dTransition":"0x7fffffffffffff",
-		"eip98Transition":"0x7fffffffffffff",
 		"eip140Transition":"0x7fffffffffffff",
 		"eip155Transition":"0x7fffffffffffff",
 		"eip211Transition":"0x7fffffffffffff",

--- a/ethcore/res/ethereum/mix.json
+++ b/ethcore/res/ethereum/mix.json
@@ -44,8 +44,7 @@
 		"eip140Transition": 3000000,
 		"eip211Transition": 3000000,
 		"eip214Transition": 3000000,
-		"eip658Transition": 3000000,
-		"eip98Transition": "0x7fffffffffffff"
+		"eip658Transition": 3000000
 	},
 	"nodes": [
 		"enode://aeb6070deb50efeb41c5e4283a6a3b08ff701fef90e3522161c145f30df2852af3dfc51ba74591f7c9d96b11ca4c3c2b354bf58dd243f2d877f6eecc2373fd1d@139.162.15.124:30313",

--- a/ethcore/res/ethereum/morden.json
+++ b/ethcore/res/ethereum/morden.json
@@ -30,8 +30,7 @@
 		"eip160Transition": 1915000,
 		"eip161abcTransition": "0x7fffffffffffffff",
 		"eip161dTransition": "0x7fffffffffffffff",
-		"eip155Transition": 1915000,
-		"eip98Transition": "0x7fffffffffffff"
+		"eip155Transition": 1915000
 	},
 	"genesis": {
 		"seal": {

--- a/ethcore/res/ethereum/musicoin.json
+++ b/ethcore/res/ethereum/musicoin.json
@@ -31,7 +31,6 @@
 		"eip160Transition":"0x21e88e",
 		"eip161abcTransition":"0x21e88e",
 		"eip161dTransition":"0x21e88e",
-		"eip98Transition":"0x7fffffffffffff",
 		"eip140Transition":"0x21e88e",
 		"eip155Transition":"0x21e88e",
 		"eip211Transition":"0x21e88e",

--- a/ethcore/res/ethereum/ropsten.json
+++ b/ethcore/res/ethereum/ropsten.json
@@ -37,7 +37,6 @@
 		"eip161abcTransition": 10,
 		"eip161dTransition": 10,
 		"eip155Transition": 10,
-		"eip98Transition": "0x7fffffffffffff",
 		"eip140Transition": 1700000,
 		"eip211Transition": 1700000,
 		"eip214Transition": 1700000,

--- a/ethcore/res/ethereum/social.json
+++ b/ethcore/res/ethereum/social.json
@@ -26,8 +26,7 @@
 		"eip160Transition": "0x0",
 		"eip161abcTransition": "0x7fffffffffffffff",
 		"eip161dTransition": "0x7fffffffffffffff",
-		"eip155Transition": "0x0",
-		"eip98Transition": "0x7fffffffffffff"
+		"eip155Transition": "0x0"
 	},
 	"genesis": {
 		"seal": {

--- a/ethcore/res/ethereum/tobalaba.json
+++ b/ethcore/res/ethereum/tobalaba.json
@@ -16,6 +16,7 @@
 		"gasLimitBoundDivisor": "0x400",
 		"minGasLimit": "0x1388",
 		"networkID": "0x62121",
+		"eip98Transition": 0,
 		"wasmActivationTransition": 7250000,
 		"eip140Transition": 7250000,
 		"eip211Transition": 7250000,

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -250,7 +250,10 @@ impl From<ethjson::spec::Params> for CommonParams {
 			eip160_transition: p.eip160_transition.map_or(0, Into::into),
 			eip161abc_transition: p.eip161abc_transition.map_or(0, Into::into),
 			eip161d_transition: p.eip161d_transition.map_or(0, Into::into),
-			eip98_transition: p.eip98_transition.map_or(0, Into::into),
+			eip98_transition: p.eip98_transition.map_or_else(
+				BlockNumber::max_value,
+				Into::into,
+			),
 			eip155_transition: p.eip155_transition.map_or(0, Into::into),
 			validate_receipts_transition: p.validate_receipts_transition.map_or(0, Into::into),
 			validate_chain_id_transition: p.validate_chain_id_transition.map_or(0, Into::into),


### PR DESCRIPTION
This PR replaces the default value of `eip98Transition` to `BlockNumber::max_value`, to reduce the chance of chain mis-configs. Note that:

* If a chain has EIP-658 enabled at any point, then it "disables" EIP-98. So we don't need to specify them in `poacore` and `poasokol`.
* This leaves only Kovan configs need to be changed.
* Removing existing `"eip98Transition": "0xffffffffffffffff"` is entirely optional.

For release note, we need to specify that:

> For custom chain config, if you don't have `eip98Transition` specifically set, and you don't have `eip658Transition` enabled at block 0, then you need to add `"eip98Transition": 0`.