### PR TITLE
[WIP] - Reliable sync check for new_blocks notifications

### DIFF
--- a/util/len-caching-mutex/Cargo.toml
+++ b/util/len-caching-mutex/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+description = "Mutex with cached len, for use with collections"
+homepage = "http://parity.io"
+license = "GPL-3.0"
+name = "len-caching-mutex"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+
+[dependencies]
+
+[workspace]

--- a/util/len-caching-mutex/src/lib.rs
+++ b/util/len-caching-mutex/src/lib.rs
@@ -1,0 +1,111 @@
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::VecDeque;
+use std::ops::{Deref, DerefMut};
+use std::sync::Mutex;
+use std::sync::MutexGuard;
+use std::sync::PoisonError;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+/// Implement to allow a type with a len() method to be used
+/// with [`LenCachingMutex`](struct.LenCachingMutex.html)
+pub trait Len {
+	fn len(&self) -> usize;
+}
+
+impl<T> Len for Vec<T> {
+	fn len(&self) -> usize { self.len() }
+}
+
+impl<T> Len for VecDeque<T> {
+	fn len(&self) -> usize { self.len() }
+}
+
+/// Can be used in place of a `Mutex` where reading `T`'s `len()` without 
+/// needing to lock, is advantageous. 
+/// When the Guard is released, `T`'s `len()` will be cached.
+pub struct LenCachingMutex<T> {
+  data: Mutex<T>,
+  len: AtomicUsize,
+}
+
+impl<T: Len> LenCachingMutex<T> {
+	pub fn new(data: T) -> LenCachingMutex<T> {
+		LenCachingMutex {
+			len: AtomicUsize::new(data.len()),
+			data: Mutex::new(data),
+		}
+	}
+
+	/// Load the most recent value returned from your `T`'s `len()`
+	pub fn load_len(&self) -> usize {
+		self.len.load(Ordering::Relaxed)
+	}
+
+	pub fn lock(&self) -> Result<Guard<T>, PoisonError<MutexGuard<T>>> {
+		Ok( Guard {
+			mutex_guard: self.data.lock()?,
+			len: &self.len,
+		})
+	}
+
+	pub fn try_lock(&self) -> Result<Guard<T>, PoisonError<MutexGuard<T>>> {
+		Ok( Guard {
+			mutex_guard: self.data.lock()?,
+			len: &self.len,
+		})
+	}
+}
+
+pub struct Guard<'a, T: Len + 'a> {
+	mutex_guard: MutexGuard<'a, T>,
+	len: &'a AtomicUsize,
+}
+
+impl<'a, T: Len> Drop for Guard<'a, T> {
+	fn drop(&mut self) {
+		self.len.store(self.mutex_guard.len(), Ordering::Relaxed);
+	}
+}
+
+impl<'a, T: Len> Deref for Guard<'a, T> {
+	type Target = T;
+	fn deref(&self)	-> &T {
+		self.mutex_guard.deref()
+	}
+}
+
+impl<'a, T: Len> DerefMut for Guard<'a, T> {
+	fn deref_mut(&mut self)	-> &mut T {
+		self.mutex_guard.deref_mut()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+    #[test]
+    fn caches_len() {
+		let v = vec![1,2,3];
+		let lcm = LenCachingMutex::new(v);
+        assert_eq!(lcm.load_len(), 3);
+		lcm.lock().unwrap().push(4);
+        assert_eq!(lcm.load_len(), 4);
+    }
+}


### PR DESCRIPTION
New block notifications are sometimes dropped during normal operation due to a false-positive check for whether node is in state of (major) syncing. 

- [x] Create new type to cache the size of collection in an AtomicUsize when releasing Mutex.
- [ ] Implement for `Verification`.
- [ ] Use this to determine sync state in `ethcore` `Client`

Will fix issue [9865](https://github.com/paritytech/parity-ethereum/issues/9865)