### PR TITLE
fix: new_blocks notifications sometimes not triggered during normal conditions

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -327,23 +327,25 @@ impl Importer {
 		};
 
 		{
-			if !imported_blocks.is_empty() && is_empty {
+			if !imported_blocks.is_empty() {
 				let route = ChainRoute::from(import_results.as_ref());
 
 				if is_empty {
 					self.miner.chain_new_blocks(client, &imported_blocks, &invalid_blocks, route.enacted(), route.retracted(), false);
 				}
 
-				client.notify(|notify| {
-					notify.new_blocks(
-						imported_blocks.clone(),
-						invalid_blocks.clone(),
-						route.clone(),
-						Vec::new(),
-						proposed_blocks.clone(),
-						duration,
-					);
-				});
+				if client.queue_info().total_queue_size() < 10 {
+					client.notify(|notify| {
+						notify.new_blocks(
+							imported_blocks.clone(),
+							invalid_blocks.clone(),
+							route.clone(),
+							Vec::new(),
+							proposed_blocks.clone(),
+							duration,
+						);
+					});
+				}
 			}
 		}
 


### PR DESCRIPTION
Remove duplicate check for ```is_empty```. Check total queue size is < 10 to send new blocks notifications (to indicate not doing major sync). Tried initially with queue size of 3 (as used in ```pub fn is_major_importing_or_waiting``` in ```rpc/src/v1/helpers/block_import.rs```) but during overnight testing it missed a block; increasing to 10 returned all canonical blocks in the same test setup.

Closes [9865](https://github.com/paritytech/parity-ethereum/issues/9865)