### PR TITLE
LenCachingMutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,7 @@ dependencies = [
  "kvdb-memorydb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb-rocksdb 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "len-caching-mutex 0.1.0",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "macros 0.1.0",
@@ -1835,6 +1836,13 @@ dependencies = [
 name = "lazycell"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "len-caching-mutex"
+version = "0.1.0"
+dependencies = [
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libc"

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -70,6 +70,7 @@ kvdb-rocksdb = "0.1.3"
 serde = "1.0"
 serde_derive = "1.0"
 tempdir = {version="0.3", optional = true}
+len-caching-mutex = { path = "../util/len-caching-mutex" }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "android"))'.dependencies]
 hardware-wallet = { path = "../hw" }

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -112,6 +112,7 @@ extern crate journaldb;
 extern crate serde;
 #[cfg(any(test, feature = "json-tests", feature = "test-helpers"))]
 extern crate tempdir;
+extern crate len_caching_mutex;
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "android"))]
 extern crate hardware_wallet;

--- a/util/len-caching-mutex/Cargo.toml
+++ b/util/len-caching-mutex/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+description = "Mutex with cached len, for use with collections"
+homepage = "http://parity.io"
+license = "GPL-3.0"
+name = "len-caching-mutex"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+
+[dependencies]
+
+[workspace]

--- a/util/len-caching-mutex/Cargo.toml
+++ b/util/len-caching-mutex/Cargo.toml
@@ -7,5 +7,4 @@ version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
-
-[workspace]
+parking_lot = "0.6"

--- a/util/len-caching-mutex/src/lib.rs
+++ b/util/len-caching-mutex/src/lib.rs
@@ -123,6 +123,13 @@ mod tests {
 
 	#[test]
 	fn works_with_vec() {
+		let v: Vec<i32> = Vec::new();
+		let lcm = LenCachingMutex::new(v);
+		assert_eq!(lcm.lock().shrink_to_fit(), ());
+	}
+
+	#[test]
+	fn works_with_vecdeque() {
 		let v: VecDeque<i32> = VecDeque::new();
 		let lcm = LenCachingMutex::new(v);
 		assert_eq!(lcm.lock().shrink_to_fit(), ());

--- a/util/len-caching-mutex/src/lib.rs
+++ b/util/len-caching-mutex/src/lib.rs
@@ -1,0 +1,111 @@
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::VecDeque;
+use std::ops::{Deref, DerefMut};
+use std::sync::Mutex;
+use std::sync::MutexGuard;
+use std::sync::PoisonError;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+/// Implement to allow a type with a len() method to be used
+/// with [`LenCachingMutex`](struct.LenCachingMutex.html)
+pub trait Len {
+	fn len(&self) -> usize;
+}
+
+impl<T> Len for Vec<T> {
+	fn len(&self) -> usize { self.len() }
+}
+
+impl<T> Len for VecDeque<T> {
+	fn len(&self) -> usize { self.len() }
+}
+
+/// Can be used in place of a `Mutex` where reading `T`'s `len()` without 
+/// needing to lock, is advantageous. 
+/// When the Guard is released, `T`'s `len()` will be cached.
+pub struct LenCachingMutex<T> {
+  data: Mutex<T>,
+  len: AtomicUsize,
+}
+
+impl<T: Len> LenCachingMutex<T> {
+	pub fn new(data: T) -> LenCachingMutex<T> {
+		LenCachingMutex {
+			len: AtomicUsize::new(data.len()),
+			data: Mutex::new(data),
+		}
+	}
+
+	/// Load the most recent value returned from your `T`'s `len()`
+	pub fn load_len(&self) -> usize {
+		self.len.load(Ordering::Relaxed)
+	}
+
+	pub fn lock(&self) -> Result<Guard<T>, PoisonError<MutexGuard<T>>> {
+		Ok( Guard {
+			mutex_guard: self.data.lock()?,
+			len: &self.len,
+		})
+	}
+
+	pub fn try_lock(&self) -> Result<Guard<T>, PoisonError<MutexGuard<T>>> {
+		Ok( Guard {
+			mutex_guard: self.data.lock()?,
+			len: &self.len,
+		})
+	}
+}
+
+pub struct Guard<'a, T: Len + 'a> {
+	mutex_guard: MutexGuard<'a, T>,
+	len: &'a AtomicUsize,
+}
+
+impl<'a, T: Len> Drop for Guard<'a, T> {
+	fn drop(&mut self) {
+		self.len.store(self.mutex_guard.len(), Ordering::Relaxed);
+	}
+}
+
+impl<'a, T: Len> Deref for Guard<'a, T> {
+	type Target = T;
+	fn deref(&self)	-> &T {
+		self.mutex_guard.deref()
+	}
+}
+
+impl<'a, T: Len> DerefMut for Guard<'a, T> {
+	fn deref_mut(&mut self)	-> &mut T {
+		self.mutex_guard.deref_mut()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+    #[test]
+    fn caches_len() {
+		let v = vec![1,2,3];
+		let lcm = LenCachingMutex::new(v);
+        assert_eq!(lcm.load_len(), 3);
+		lcm.lock().unwrap().push(4);
+        assert_eq!(lcm.load_len(), 4);
+    }
+}


### PR DESCRIPTION
While working on another issue I developed a way to query the size of a collection held in a ```Mutex``` without requiring a lock. Ultimately I found a a different way to solve the issue without needing this, but it may be useful anyway. I've included a commit to show it used in ```Verification```. If another thread has the lock while ```load_len()``` is called, the cached value may not be accurate. However this is often not too different to normal operation - stored len() may be stale at any point after the Guard is dropped. 