### PR TITLE
Fix daemonize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,8 +444,8 @@ dependencies = [
 
 [[package]]
 name = "daemonize"
-version = "0.2.3"
-source = "git+https://github.com/paritytech/daemonize#df00295f03450326613f2d616059fd44434a0d74"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2280,7 +2280,7 @@ dependencies = [
  "blooms-db 0.1.0",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)",
- "daemonize 0.2.3 (git+https://github.com/paritytech/daemonize)",
+ "daemonize 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dir 0.1.2",
  "docopt 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4241,7 +4241,7 @@ dependencies = [
 "checksum csv-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dd8e6d86f7ba48b4276ef1317edc8cc36167546d8972feb4a2b5fec0b374105"
 "checksum ct-logs 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "95a4bf5107667e12bf6ce31a3a5066d67acc88942b6742117a41198734aaccaa"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum daemonize 0.2.3 (git+https://github.com/paritytech/daemonize)" = "<none>"
+"checksum daemonize 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4093d27eb267d617f03c2ee25d4c3ca525b89a76154001954a11984508ffbde5"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum docopt 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db2906c2579b5b7207fc1e328796a9a8835dc44e22dbe8e460b1d636f9a7b225"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ fake-fetch = { path = "util/fake-fetch" }
 winapi = { version = "0.3.4", features = ["winsock2", "winuser", "shellapi"] }
 
 [target.'cfg(not(windows))'.dependencies]
-daemonize = { git = "https://github.com/paritytech/daemonize" }
+daemonize = "0.3"
 
 [features]
 miner-debug = ["ethcore/miner-debug"]

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -544,6 +544,12 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 	// set network path.
 	net_conf.net_config_path = Some(db_dirs.network_path().to_string_lossy().into_owned());
 
+	// run in daemon mode
+	if let Some(pid_file) = cmd.daemon {
+		info!("Running as a daemon process!");
+		daemonize(pid_file)?;
+	}
+
 	let restoration_db_handler = db::restoration_db_handler(&client_path, &client_config);
 	let client_db = restoration_db_handler.open(&client_path)
 		.map_err(|e| format!("Failed to open database {:?}", e))?;
@@ -808,12 +814,6 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 
 	client.set_exit_handler(on_client_rq);
 	updater.set_exit_handler(on_updater_rq);
-
-	// run in daemon mode
-	if let Some(pid_file) = cmd.daemon {
-		info!("Running as a daemon process!");
-		daemonize(pid_file)?;
-	}
 
 	Ok(RunningClient {
 		inner: RunningClientInner::Full {


### PR DESCRIPTION
Closes #9991. (Sorry, I screwed up in https://github.com/paritytech/parity-ethereum/pull/9946#pullrequestreview-176800230, but it didn't segfault for me)

Nice find by @andresilva:
> I don't know how rust handles file descriptors and forks
they're probably closed before forking?
https://github.com/rust-lang/rust/pull/24034
so this means any file descriptor is closed before forking/exec I think

The first commit moves fork instruction just before we open the db (so #9367 remains fixed).
The second commit switches `daemonize` to crates.io version (@tomaka is https://github.com/paritytech/daemonize/pull/1 no longer relevant (cf. https://github.com/knsd/daemonize/commit/4c5f9d0dccc17715ff847257c3b732406ef911c7#diff-49a4b4d69f811d5619c481802227b86e)?), it's somewhat unrelated, happy to revert if needed.