### PR TITLE
move daemonize before creating account provider

### DIFF
--- a/parity/run.rs
+++ b/parity/run.rs
@@ -464,6 +464,12 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 
 	let passwords = passwords_from_files(&cmd.acc_conf.password_files)?;
 
+	// run in daemon mode
+	if let Some(pid_file) = cmd.daemon {
+		info!("Running as a daemon process!");
+		daemonize(pid_file)?;
+	}
+
 	// prepare account provider
 	let account_provider = Arc::new(prepare_account_provider(&cmd.spec, &cmd.dirs, &spec.data_dir, cmd.acc_conf, &passwords)?);
 
@@ -543,12 +549,6 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 
 	// set network path.
 	net_conf.net_config_path = Some(db_dirs.network_path().to_string_lossy().into_owned());
-
-	// run in daemon mode
-	if let Some(pid_file) = cmd.daemon {
-		info!("Running as a daemon process!");
-		daemonize(pid_file)?;
-	}
 
 	let restoration_db_handler = db::restoration_db_handler(&client_path, &client_config);
 	let client_db = restoration_db_handler.open(&client_path)

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -464,7 +464,9 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 
 	let passwords = passwords_from_files(&cmd.acc_conf.password_files)?;
 
-	// run in daemon mode
+	// Run in daemon mode.
+	// Note, that it should be called before we leave any file descriptor open,
+	// since `daemonize` will close them.
 	if let Some(pid_file) = cmd.daemon {
 		info!("Running as a daemon process!");
 		daemonize(pid_file)?;


### PR DESCRIPTION
Follow-up for #10000, thanks @andresilva for spotting the issue.

The fetch service didn't work in #10000, since daemonize closed its open fds. We could've moved `daemonize` at the beginning, but we're trying to print as much errors (cf. #9367) as possible before starting a daemon.
