### PR TITLE
WIP: Add Gangnam testnet support

### DIFF
--- a/ethcore/res/ethereum/gangnam.json
+++ b/ethcore/res/ethereum/gangnam.json
@@ -1,0 +1,65 @@
+{
+	"name": "Gangnam",
+	"dataDir": "gangnam",
+	"engine": {
+		"Ethash": {
+			"params": {
+				"minimumDifficulty": "0x020000",
+				"difficultyBoundDivisor": "0x0800",
+				"durationLimit": "0x0d",
+				"blockReward": "0x29A2241AF62C0000",
+				"homesteadTransition": 0,
+				"eip100bTransition": 0,
+				"difficultyBombDelays": {
+					"30000": 3000000
+				}
+			}
+		}
+	},
+	"params": {
+		"gasLimitBoundDivisor": "0x0400",
+		"accountStartNonce": "0x0",
+		"maximumExtraDataSize": "0x20",
+		"minGasLimit": "0x1388",
+		"networkID" : "0x4b4",
+		"chainID":"0x4b4",
+		"maxCodeSize": 24576,
+		"maxCodeSizeTransition": 0,
+		"eip150Transition": 0,
+		"eip160Transition": 0,
+		"eip161abcTransition": 0,
+		"eip161dTransition": 0,
+		"eip155Transition": 0,
+		"eip140Transition": 0,
+		"eip211Transition": 0,
+		"eip214Transition": 0,
+		"eip658Transition": 0
+	},
+	"genesis": {
+		"seal": {
+			"ethereum": {
+				"nonce": "0x0000000000000042",
+				"mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+			}
+		},
+		"difficulty": "0x20000",
+		"author": "0x0000000000000000000000000000000000000000",
+		"timestamp": "0x5c063400",
+		"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"extraData": "0x476f6c64656e20457468657265756d20546573746e657420303031",
+		"gasLimit": "0x7a1200"
+	},
+	"nodes": [
+		"enode://0db62aeb5a7c7516dc562cbceff318cf1a28a139367c5a3e0fba100948b815e41cbcbc593bfa7ee0c473f644c8845ce676af9e99a2d48e8c31fd306c47573462@115.68.99.108:30403"
+	],
+	"accounts": {
+		"0000000000000000000000000000000000000001": { "builtin": { "name": "ecrecover", "pricing": { "linear": { "base": 3000, "word": 0 } } } },
+		"0000000000000000000000000000000000000002": { "builtin": { "name": "sha256", "pricing": { "linear": { "base": 60, "word": 12 } } } },
+		"0000000000000000000000000000000000000003": { "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
+		"0000000000000000000000000000000000000004": { "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } },
+		"0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "pricing": { "modexp": { "divisor": 20 } } } },
+		"0000000000000000000000000000000000000006": { "builtin": { "name": "alt_bn128_add", "pricing": { "linear": { "base": 500, "word": 0 } } } },
+		"0000000000000000000000000000000000000007": { "builtin": { "name": "alt_bn128_mul", "pricing": { "linear": { "base": 40000, "word": 0 } } } },
+		"0000000000000000000000000000000000000008": { "builtin": { "name": "alt_bn128_pairing", "pricing": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 } } } }
+	}
+}

--- a/ethcore/src/ethereum/mod.rs
+++ b/ethcore/src/ethereum/mod.rs
@@ -89,6 +89,11 @@ pub fn new_social<'a, T: Into<SpecParams<'a>>>(params: T) -> Spec {
 	load(params.into(), include_bytes!("../../res/ethereum/social.json"))
 }
 
+/// Create a new Callisto mainnet chain spec
+pub fn new_callisto<'a, T: Into<SpecParams<'a>>>(params: T) -> Spec {
+	load(params.into(), include_bytes!("../../res/ethereum/callisto.json"))
+}
+
 /// Create a new MIX mainnet chain spec.
 pub fn new_mix<'a, T: Into<SpecParams<'a>>>(params: T) -> Spec {
 	load(params.into(), include_bytes!("../../res/ethereum/mix.json"))
@@ -114,9 +119,9 @@ pub fn new_sokol<'a, T: Into<SpecParams<'a>>>(params: T) -> Spec {
 	load(params.into(), include_bytes!("../../res/ethereum/poasokol.json"))
 }
 
-/// Create a new Callisto chaun spec
-pub fn new_callisto<'a, T: Into<SpecParams<'a>>>(params: T) -> Spec {
-	load(params.into(), include_bytes!("../../res/ethereum/callisto.json"))
+/// Create a new Gangnam testnet chain spec.
+pub fn new_gangnam<'a, T: Into<SpecParams<'a>>>(params: T) -> Spec {
+	load(params.into(), include_bytes!("../../res/ethereum/gangnam.json"))
 }
 
 // For tests

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -288,7 +288,7 @@ usage! {
 
 			ARG arg_chain: (String) = "foundation", or |c: &Config| c.parity.as_ref()?.chain.clone(),
 			"--chain=[CHAIN]",
-			"Specify the blockchain type. CHAIN may be either a JSON chain specification file or ethereum, classic, poacore, tobalaba, expanse, musicoin, ellaism, easthub, social, mix, callisto, morden, ropsten, kovan, poasokol, testnet, or dev.",
+			"Specify the blockchain type. CHAIN may be either a JSON chain specification file or ethereum, classic, poacore, tobalaba, expanse, musicoin, ellaism, easthub, social, callisto, mix, morden, ropsten, kovan, poasokol, gangnam, testnet, or dev.",
 
 			ARG arg_keys_path: (String) = "$BASE/keys", or |c: &Config| c.parity.as_ref()?.keys_path.clone(),
 			"--keys-path=[PATH]",

--- a/parity/params.rs
+++ b/parity/params.rs
@@ -40,12 +40,13 @@ pub enum SpecType {
 	Ellaism,
 	Easthub,
 	Social,
-	Mix,
 	Callisto,
+	Mix,
 	Morden,
 	Ropsten,
 	Kovan,
 	Sokol,
+	Gangnam,
 	Dev,
 	Custom(String),
 }
@@ -70,12 +71,13 @@ impl str::FromStr for SpecType {
 			"ellaism" => SpecType::Ellaism,
 			"easthub" => SpecType::Easthub,
 			"social" => SpecType::Social,
-			"mix" => SpecType::Mix,
 			"callisto" => SpecType::Callisto,
+			"mix" => SpecType::Mix,
 			"morden" | "classic-testnet" => SpecType::Morden,
 			"ropsten" => SpecType::Ropsten,
 			"kovan" | "testnet" => SpecType::Kovan,
 			"sokol" | "poasokol" => SpecType::Sokol,
+			"gangnam" => SpecType::Gangnam,
 			"dev" => SpecType::Dev,
 			other => SpecType::Custom(other.into()),
 		};
@@ -95,12 +97,13 @@ impl fmt::Display for SpecType {
 			SpecType::Ellaism => "ellaism",
 			SpecType::Easthub => "easthub",
 			SpecType::Social => "social",
-			SpecType::Mix => "mix",
 			SpecType::Callisto => "callisto",
+			SpecType::Mix => "mix",
 			SpecType::Morden => "morden",
 			SpecType::Ropsten => "ropsten",
 			SpecType::Kovan => "kovan",
 			SpecType::Sokol => "sokol",
+			SpecType::Gangnam => "gangnam",
 			SpecType::Dev => "dev",
 			SpecType::Custom(ref custom) => custom,
 		})
@@ -120,12 +123,13 @@ impl SpecType {
 			SpecType::Ellaism => Ok(ethereum::new_ellaism(params)),
 			SpecType::Easthub => Ok(ethereum::new_easthub(params)),
 			SpecType::Social => Ok(ethereum::new_social(params)),
-			SpecType::Mix => Ok(ethereum::new_mix(params)),
 			SpecType::Callisto => Ok(ethereum::new_callisto(params)),
+			SpecType::Mix => Ok(ethereum::new_mix(params)),
 			SpecType::Morden => Ok(ethereum::new_morden(params)),
 			SpecType::Ropsten => Ok(ethereum::new_ropsten(params)),
 			SpecType::Kovan => Ok(ethereum::new_kovan(params)),
 			SpecType::Sokol => Ok(ethereum::new_sokol(params)),
+			SpecType::Gangnam => Ok(ethereum::new_gangnam(params)),
 			SpecType::Dev => Ok(Spec::new_instant()),
 			SpecType::Custom(ref filename) => {
 				let file = fs::File::open(filename).map_err(|e| format!("Could not load specification file at {}: {}", filename, e))?;
@@ -374,8 +378,8 @@ mod tests {
 		assert_eq!(SpecType::Ellaism, "ellaism".parse().unwrap());
 		assert_eq!(SpecType::Easthub, "easthub".parse().unwrap());
 		assert_eq!(SpecType::Social, "social".parse().unwrap());
-		assert_eq!(SpecType::Mix, "mix".parse().unwrap());
 		assert_eq!(SpecType::Callisto, "callisto".parse().unwrap());
+		assert_eq!(SpecType::Mix, "mix".parse().unwrap());
 		assert_eq!(SpecType::Morden, "morden".parse().unwrap());
 		assert_eq!(SpecType::Morden, "classic-testnet".parse().unwrap());
 		assert_eq!(SpecType::Ropsten, "ropsten".parse().unwrap());
@@ -383,6 +387,7 @@ mod tests {
 		assert_eq!(SpecType::Kovan, "testnet".parse().unwrap());
 		assert_eq!(SpecType::Sokol, "sokol".parse().unwrap());
 		assert_eq!(SpecType::Sokol, "poasokol".parse().unwrap());
+		assert_eq!(SpecType::Gangnam, "gangnam".parse().unwrap());
 	}
 
 	#[test]
@@ -401,12 +406,13 @@ mod tests {
 		assert_eq!(format!("{}", SpecType::Ellaism), "ellaism");
 		assert_eq!(format!("{}", SpecType::Easthub), "easthub");
 		assert_eq!(format!("{}", SpecType::Social), "social");
-		assert_eq!(format!("{}", SpecType::Mix), "mix");
 		assert_eq!(format!("{}", SpecType::Callisto), "callisto");
+		assert_eq!(format!("{}", SpecType::Mix), "mix");
 		assert_eq!(format!("{}", SpecType::Morden), "morden");
 		assert_eq!(format!("{}", SpecType::Ropsten), "ropsten");
 		assert_eq!(format!("{}", SpecType::Kovan), "kovan");
 		assert_eq!(format!("{}", SpecType::Sokol), "sokol");
+		assert_eq!(format!("{}", SpecType::Gangnam), "gangnam");
 		assert_eq!(format!("{}", SpecType::Dev), "dev");
 		assert_eq!(format!("{}", SpecType::Custom("foo/bar".into())), "foo/bar");
 	}


### PR DESCRIPTION
_**Please do not merge or close this PR yet, this is for WIP only!!**_

See also: https://github.com/ethereum/go-ethereum/pull/18245

### What is Gangnam Testnet?
Gangnam testnet is a proof of work testnet to test **alternative proof-of-work algorithms** like [progpow](https://eips.ethereum.org/EIPS/eip-1057) or [tethashv1](https://github.com/ethereum/EIPs/blob/7336cceac6c997252299a463ffe896a3414c479b/EIPS/eip-1485.md), [eip-1355](https://eips.ethereum.org/EIPS/eip-1355), it is supposed to provide a public testnet environment to test pow softwares like nodes, miners, or pool implementations.

### Proposed specification for Gangnam Testnet
+ Spec for Geth: goldenethereum/golden-ethereum@ee97595

+ Spec for Parity-Ethereum: goldenethereum/parity-ethereum@9b79304

### List any resources for gangnam testnet here
+ Discord community: http://discord.gg/HvpucP7

+ Block Explorer and Pool WIP