### PR TITLE
light(on_demand): decrease default time window to 10 secs

### DIFF
--- a/ethcore/light/src/on_demand/mod.rs
+++ b/ethcore/light/src/on_demand/mod.rs
@@ -62,7 +62,7 @@ pub const DEFAULT_REQUEST_MIN_BACKOFF_DURATION: Duration = Duration::from_secs(1
 /// The maximum request interval for OnDemand queries
 pub const DEFAULT_REQUEST_MAX_BACKOFF_DURATION: Duration = Duration::from_secs(100);
 /// The default window length a response is evaluated
-pub const DEFAULT_RESPONSE_TIME_TO_LIVE: Duration = Duration::from_secs(60);
+pub const DEFAULT_RESPONSE_TIME_TO_LIVE: Duration = Duration::from_secs(10);
 /// The default number of maximum backoff iterations
 pub const DEFAULT_MAX_REQUEST_BACKOFF_ROUNDS: usize = 10;
 /// The default number failed request to be regarded as failure

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -1835,9 +1835,9 @@ mod tests {
 			arg_snapshot_threads: None,
 
 			// -- Light options.
-			arg_on_demand_response_time_window: Some(2000),
-			arg_on_demand_request_backoff_start: Some(9000),
-			arg_on_demand_request_backoff_max: Some(15000),
+			arg_on_demand_response_time_window: Some(2),
+			arg_on_demand_request_backoff_start: Some(9),
+			arg_on_demand_request_backoff_max: Some(15),
 			arg_on_demand_request_backoff_rounds_max: Some(100),
 			arg_on_demand_request_consecutive_failures: Some(1),
 
@@ -2093,9 +2093,9 @@ mod tests {
 				num_verifiers: None,
 			}),
 			light: Some(Light {
-				on_demand_response_time_window: Some(2000),
-				on_demand_request_backoff_start: Some(9000),
-				on_demand_request_backoff_max: Some(15000),
+				on_demand_response_time_window: Some(2),
+				on_demand_request_backoff_start: Some(9),
+				on_demand_request_backoff_max: Some(15),
 				on_demand_request_backoff_rounds_max: Some(10),
 				on_demand_request_consecutive_failures: Some(1),
 			}),

--- a/parity/cli/tests/config.full.toml
+++ b/parity/cli/tests/config.full.toml
@@ -157,9 +157,9 @@ scale_verifiers = true
 num_verifiers = 6
 
 [light]
-on_demand_response_time_window = 2000
-on_demand_request_backoff_start = 9000
-on_demand_request_backoff_max = 15000
+on_demand_response_time_window = 2
+on_demand_request_backoff_start = 9
+on_demand_request_backoff_max = 15
 on_demand_request_backoff_rounds_max = 100
 on_demand_request_consecutive_failures = 1
 

--- a/parity/cli/tests/config.toml
+++ b/parity/cli/tests/config.toml
@@ -71,9 +71,9 @@ fat_db = "off"
 scale_verifiers = false
 
 [light]
-on_demand_response_time_window = 2000
-on_demand_request_backoff_start = 9000
-on_demand_request_backoff_max = 15000
+on_demand_response_time_window = 2
+on_demand_request_backoff_start = 9
+on_demand_request_backoff_max = 15
 on_demand_request_backoff_rounds_max = 10
 on_demand_request_consecutive_failures = 1
 


### PR DESCRIPTION
Follow-up for #9790. Resolves https://github.com/paritytech/parity-ethereum/pull/9790#discussion_r239001822.