### PR TITLE
ci: move future releases to ethereum subdir on s3

### DIFF
--- a/scripts/gitlab/publish-awss3.sh
+++ b/scripts/gitlab/publish-awss3.sh
@@ -43,10 +43,10 @@ aws configure set aws_secret_access_key $s3_secret
 
 case "${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}" in
   (beta|stable|nightly)
-    export S3_BUCKET=ethereum/public;
+    export S3_BUCKET=public/ethereum;
     ;;
   (*)
-    export S3_BUCKET=ethereum/builds;
+    export S3_BUCKET=builds/ethereum;
     ;;
 esac
 

--- a/scripts/gitlab/publish-awss3.sh
+++ b/scripts/gitlab/publish-awss3.sh
@@ -43,10 +43,10 @@ aws configure set aws_secret_access_key $s3_secret
 
 case "${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}" in
   (beta|stable|nightly)
-    export S3_BUCKET=public/ethereum;
+    export S3_BUCKET=releases.parity.io/ethereum;
     ;;
   (*)
-    export S3_BUCKET=builds/ethereum;
+    export S3_BUCKET=builds-parity;
     ;;
 esac
 

--- a/scripts/gitlab/publish-awss3.sh
+++ b/scripts/gitlab/publish-awss3.sh
@@ -43,10 +43,10 @@ aws configure set aws_secret_access_key $s3_secret
 
 case "${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}" in
   (beta|stable|nightly)
-    export S3_BUCKET=builds-parity-published;
+    export S3_BUCKET=ethereum/public;
     ;;
   (*)
-    export S3_BUCKET=builds-parity;
+    export S3_BUCKET=ethereum/builds;
     ;;
 esac
 


### PR DESCRIPTION
- move binaries from releases.parity.io to releases.parity.io/ethereum
- allow for future products to be released on same domain, e.g. releases.parity.io/substrate
- ~~only affects future binaries~~ will sync over old releases manually
- on ice: vanity service needs a patch before we release this