### PR TITLE
Fix test: corpus_inaccessible (panic)

### DIFF
--- a/ethcore/light/src/cache.rs
+++ b/ethcore/light/src/cache.rs
@@ -179,14 +179,15 @@ mod tests {
 
 	#[test]
 	fn corpus_inaccessible() {
-		let mut cache = Cache::new(Default::default(), Duration::from_secs(5 * 3600));
+		let duration = Duration::from_secs(20);
+		let mut cache = Cache::new(Default::default(), duration.clone());
 
 		cache.set_gas_price_corpus(vec![].into());
 		assert_eq!(cache.gas_price_corpus(), Some(vec![].into()));
 
 		{
 			let corpus_time = &mut cache.corpus.as_mut().unwrap().1;
-			*corpus_time = *corpus_time - Duration::from_secs(5 * 3600);
+			*corpus_time = *corpus_time - duration;
 		}
 		assert!(cache.gas_price_corpus().is_none());
 	}


### PR DESCRIPTION
If system uptime is less than the duration in the test, thread will panic:

```thread 'cache::tests::corpus_inaccessible' panicked at 'overflow when subtracting duration from instant'```

Reduced duration to 20 seconds (from 5 hours) to make it unlikely the test will fail due to this condition.

Since no operations on Instant in this module carry a similar risk (outside of the tests), it doesn't seem warranted to depend on an external crate to fix the test.

Closes: [9957](https://github.com/paritytech/parity-ethereum/issues/9957)