### PR TITLE
Backports for beta 2.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,7 +2162,7 @@ version = "1.12.0"
 dependencies = [
  "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic_hook 0.1.0",
- "parity-ethereum 2.2.4",
+ "parity-ethereum 2.2.5",
 ]
 
 [[package]]
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "parity-ethereum"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2227,7 +2227,7 @@ dependencies = [
  "parity-rpc-client 1.4.0",
  "parity-runtime 0.1.0",
  "parity-updater 1.12.0",
- "parity-version 2.2.4",
+ "parity-version 2.2.5",
  "parity-whisper 0.1.0",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2382,7 +2382,7 @@ dependencies = [
  "parity-crypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-runtime 0.1.0",
  "parity-updater 1.12.0",
- "parity-version 2.2.4",
+ "parity-version 2.2.5",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "patricia-trie 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2479,7 +2479,7 @@ dependencies = [
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-hash-fetch 1.12.0",
  "parity-path 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-version 2.2.4",
+ "parity-version 2.2.5",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2489,7 +2489,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,8 +286,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -296,6 +314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -335,6 +362,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +386,14 @@ dependencies = [
 name = "crossbeam-utils"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "crunchy"
@@ -566,7 +614,7 @@ dependencies = [
  "bn 0.4.4 (git+https://github.com/paritytech/bn)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "common-types 0.1.0",
- "crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4067,13 +4115,17 @@ dependencies = [
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "6ec65ee4f9c9d16f335091d23693457ed4928657ba4982289d7fafee03bc614a"
 "checksum combine 3.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fc1d011beeed29187b8db2ac3925c8dd4d3e87db463dc9d2d2833985388fc5bc"
-"checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"
+"checksum crossbeam 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d7408247b1b87f480890f28b670c5f8d9a8a4274833433fe74dc0dfd46d33650"
+"checksum crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7b85741761b7f160bc5e7e0c14986ef685b7f8bf9b7ad081c60c604bb4649827"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
+"checksum crossbeam-deque 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7792c4a9b5a4222f654e3728a3dd945aacc24d2c3a1a096ed265d80e4929cb9a"
 "checksum crossbeam-deque 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3486aefc4c0487b9cb52372c97df0a48b8c249514af1ee99703bf70d2f2ceda1"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30fecfcac6abfef8771151f8be4abc9e4edc112c2bcb233314cafde2680536e9"
+"checksum crossbeam-epoch 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2449aaa4ec7ef96e5fb24db16024b935df718e9ae1cec0a1e68feeca2efca7b8"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
+"checksum crossbeam-utils 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e07fc155212827475223f0bcfae57e945e694fc90950ddf3f6695bbfd5555c72"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum crunchy 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c240f247c278fa08a6d4820a6a222bfc6e0d999e51ba67be94f44c905b2161f2"
 "checksum ct-logs 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "95a4bf5107667e12bf6ce31a3a5066d67acc88942b6742117a41198734aaccaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Parity Ethereum client"
 name = "parity-ethereum"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "2.2.4"
+version = "2.2.5"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -12,7 +12,7 @@ blooms-db = { path = "../util/blooms-db" }
 bn = { git = "https://github.com/paritytech/bn", default-features = false }
 byteorder = "1.0"
 common-types = { path = "types" }
-crossbeam = "0.3"
+crossbeam = "0.4"
 ethash = { path = "../ethash" }
 ethcore-bloom-journal = { path = "../util/bloom" }
 parity-bytes = "0.1"

--- a/ethcore/light/src/cache.rs
+++ b/ethcore/light/src/cache.rs
@@ -179,14 +179,15 @@ mod tests {
 
 	#[test]
 	fn corpus_inaccessible() {
-		let mut cache = Cache::new(Default::default(), Duration::from_secs(5 * 3600));
+		let duration = Duration::from_secs(20);
+		let mut cache = Cache::new(Default::default(), duration.clone());
 
 		cache.set_gas_price_corpus(vec![].into());
 		assert_eq!(cache.gas_price_corpus(), Some(vec![].into()));
 
 		{
 			let corpus_time = &mut cache.corpus.as_mut().unwrap().1;
-			*corpus_time = *corpus_time - Duration::from_secs(6 * 3600);
+			*corpus_time = *corpus_time - duration;
 		}
 		assert!(cache.gas_price_corpus().is_none());
 	}

--- a/ethcore/res/ethereum/foundation.json
+++ b/ethcore/res/ethereum/foundation.json
@@ -9,7 +9,8 @@
 				"durationLimit": "0x0d",
 				"blockReward": {
 					"0": "0x4563918244F40000",
-					"4370000": "0x29A2241AF62C0000"
+					"4370000": "0x29A2241AF62C0000",
+					"7080000": "0x1BC16D674EC80000"
 				},
 				"homesteadTransition": "0x118c30",
 				"daoHardforkTransition": "0x1d4c00",
@@ -134,7 +135,8 @@
 				],
 				"eip100bTransition": 4370000,
 				"difficultyBombDelays": {
-					"4370000": 3000000
+					"4370000": 3000000,
+					"7080000": 2000000
 				}
 			}
 		}
@@ -159,7 +161,11 @@
 		"eip140Transition": 4370000,
 		"eip211Transition": 4370000,
 		"eip214Transition": 4370000,
-		"eip658Transition": 4370000
+		"eip658Transition": 4370000,
+		"eip145Transition": 7080000,
+		"eip1014Transition": 7080000,
+		"eip1052Transition": 7080000,
+		"eip1283Transition": 7080000
 	},
 	"genesis": {
 		"seal": {

--- a/ethcore/src/engines/validator_set/test.rs
+++ b/ethcore/src/engines/validator_set/test.rs
@@ -34,12 +34,18 @@ pub struct TestSet {
 	last_benign: Arc<AtomicUsize>,
 }
 
+impl Default for TestSet {
+	fn default() -> Self {
+		TestSet::new(Default::default(), Default::default())
+	}
+}
+
 impl TestSet {
 	pub fn new(last_malicious: Arc<AtomicUsize>, last_benign: Arc<AtomicUsize>) -> Self {
 		TestSet {
 			validator: SimpleList::new(vec![Address::from_str("7d577a597b2742b498cb5cf0c26cdcd726d39e6e").unwrap()]),
-			last_malicious: last_malicious,
-			last_benign: last_benign,
+			last_malicious,
+			last_benign,
 		}
 	}
 }

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -979,7 +979,7 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 				scope.builder().stack_size(::std::cmp::max(self.schedule.max_depth.saturating_sub(depth_threshold) * STACK_SIZE_PER_DEPTH, local_stack_size)).spawn(move || {
 					self.call_with_stack_depth(params, substate, stack_depth, tracer, vm_tracer)
 				}).expect("Sub-thread creation cannot fail; the host might run out of resources; qed")
-			}).join()
+			}).join().expect("Sub-thread never panics; qed")
 		}
 	}
 
@@ -1063,7 +1063,7 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 				scope.builder().stack_size(::std::cmp::max(self.schedule.max_depth.saturating_sub(depth_threshold) * STACK_SIZE_PER_DEPTH, local_stack_size)).spawn(move || {
 					self.create_with_stack_depth(params, substate, stack_depth, tracer, vm_tracer)
 				}).expect("Sub-thread creation cannot fail; the host might run out of resources; qed")
-			}).join()
+			}).join().expect("Sub-thread never panics; qed")
 		}
 	}
 

--- a/ethcore/src/snapshot/mod.rs
+++ b/ethcore/src/snapshot/mod.rs
@@ -192,11 +192,11 @@ pub fn take_snapshot<W: SnapshotWriter + Send>(
 			state_guards.push(state_guard);
 		}
 
-		let block_hashes = block_guard.join()?;
+		let block_hashes = block_guard.join().expect("Sub-thread never panics; qed")?;
 		let mut state_hashes = Vec::new();
 
 		for guard in state_guards {
-			let part_state_hashes = guard.join()?;
+			let part_state_hashes = guard.join().expect("Sub-thread never panics; qed")?;
 			state_hashes.extend(part_state_hashes);
 		}
 

--- a/json/src/spec/authority_round.rs
+++ b/json/src/spec/authority_round.rs
@@ -68,6 +68,8 @@ pub struct AuthorityRoundParams {
 	/// Maximum number of accepted empty steps.
 	#[serde(rename="maximumEmptySteps")]
 	pub maximum_empty_steps: Option<Uint>,
+	/// Strict validation of empty steps transition block.
+	pub strict_empty_steps_transition: Option<Uint>,
 }
 
 /// Authority engine deserialization.

--- a/miner/src/pool/tests/mod.rs
+++ b/miner/src/pool/tests/mod.rs
@@ -26,12 +26,18 @@ pub mod client;
 use self::tx::{Tx, TxExt, PairExt};
 use self::client::TestClient;
 
+// max mem for 3 transaction, this is relative
+// to the global use allocator, the value is currently
+// set to reflect malloc usage.
+// 50 was enough when using jmalloc.
+const TEST_QUEUE_MAX_MEM: usize = 80;
+
 fn new_queue() -> TransactionQueue {
 	TransactionQueue::new(
 		txpool::Options {
 			max_count: 3,
 			max_per_sender: 3,
-			max_mem_usage: 50
+			max_mem_usage: TEST_QUEUE_MAX_MEM
 		},
 		verifier::Options {
 			minimal_gas_price: 1.into(),
@@ -49,7 +55,7 @@ fn should_return_correct_nonces_when_dropped_because_of_limit() {
 		txpool::Options {
 			max_count: 3,
 			max_per_sender: 1,
-			max_mem_usage: 50
+			max_mem_usage: TEST_QUEUE_MAX_MEM
 		},
 		verifier::Options {
 			minimal_gas_price: 1.into(),
@@ -103,7 +109,7 @@ fn should_never_drop_local_transactions_from_different_senders() {
 		txpool::Options {
 			max_count: 3,
 			max_per_sender: 1,
-			max_mem_usage: 50
+			max_mem_usage: TEST_QUEUE_MAX_MEM
 		},
 		verifier::Options {
 			minimal_gas_price: 1.into(),
@@ -477,7 +483,7 @@ fn should_prefer_current_transactions_when_hitting_the_limit() {
 		txpool::Options {
 			max_count: 1,
 			max_per_sender: 2,
-			max_mem_usage: 50
+			max_mem_usage: TEST_QUEUE_MAX_MEM
 		},
 		verifier::Options {
 			minimal_gas_price: 1.into(),
@@ -707,7 +713,7 @@ fn should_accept_local_transactions_below_min_gas_price() {
 		txpool::Options {
 			max_count: 3,
 			max_per_sender: 3,
-			max_mem_usage: 50
+			max_mem_usage: TEST_QUEUE_MAX_MEM
 		},
 		verifier::Options {
 			minimal_gas_price: 10.into(),
@@ -890,7 +896,7 @@ fn should_include_local_transaction_to_a_full_pool() {
 		txpool::Options {
 			max_count: 1,
 			max_per_sender: 2,
-			max_mem_usage: 50
+			max_mem_usage: TEST_QUEUE_MAX_MEM
 		},
 		verifier::Options {
 			minimal_gas_price: 1.into(),
@@ -922,7 +928,7 @@ fn should_avoid_verifying_transaction_already_in_pool() {
 		txpool::Options {
 			max_count: 1,
 			max_per_sender: 2,
-			max_mem_usage: 50
+			max_mem_usage: TEST_QUEUE_MAX_MEM
 		},
 		verifier::Options {
 			minimal_gas_price: 1.into(),
@@ -957,7 +963,7 @@ fn should_avoid_reverifying_recently_rejected_transactions() {
 		txpool::Options {
 			max_count: 1,
 			max_per_sender: 2,
-			max_mem_usage: 50
+			max_mem_usage: TEST_QUEUE_MAX_MEM
 		},
 		verifier::Options {
 			minimal_gas_price: 1.into(),
@@ -999,7 +1005,7 @@ fn should_reject_early_in_case_gas_price_is_less_than_min_effective() {
 		txpool::Options {
 			max_count: 1,
 			max_per_sender: 2,
-			max_mem_usage: 50
+			max_mem_usage: TEST_QUEUE_MAX_MEM
 		},
 		verifier::Options {
 			minimal_gas_price: 1.into(),
@@ -1039,7 +1045,7 @@ fn should_not_reject_early_in_case_gas_price_is_less_than_min_effective() {
 		txpool::Options {
 			max_count: 1,
 			max_per_sender: 2,
-			max_mem_usage: 50
+			max_mem_usage: TEST_QUEUE_MAX_MEM
 		},
 		verifier::Options {
 			minimal_gas_price: 1.into(),

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for Parity Ethereum version string (via env CARGO_PKG_VERSION)
-version = "2.2.4"
+version = "2.2.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 


### PR DESCRIPTION
- [x] Bump beta to 2.2.5
- [x] Fix empty steps #9939
- [x] Strict empty steps validation #10041
- [x] enable constantinople on ethereum #10031
- [x] Change test miner max memory to support malloc allocator #10024
- [x] Fix test: corpus_inaccessible (panic) #10019