### PR TITLE
Trivial journal for private transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,7 @@ dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time-utils 0.1.0",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-pool 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethcore/private-tx/Cargo.toml
+++ b/ethcore/private-tx/Cargo.toml
@@ -35,6 +35,7 @@ rustc-hex = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+time-utils = { path = "../../util/time-utils" }
 tiny-keccak = "1.4"
 transaction-pool = "2.0"
 url = "1"

--- a/ethcore/private-tx/src/error.rs
+++ b/ethcore/private-tx/src/error.rs
@@ -99,6 +99,8 @@ pub enum Error {
 	/// Key server URL is not set.
 	#[display(fmt = "Key server URL is not set.")]
 	KeyServerNotSet,
+	#[display(fmt = "Private transaction not found in logs.")]
+	TxNotFoundInLog,
 	/// VM execution error.
 	#[display(fmt = "VM execution error {}", _0)]
 	Execution(ExecutionError),

--- a/ethcore/private-tx/src/error.rs
+++ b/ethcore/private-tx/src/error.rs
@@ -106,6 +106,9 @@ pub enum Error {
 	/// Transaction not found in logs.
 	#[display(fmt = "Private transaction not found in logs.")]
 	TxNotFoundInLog,
+	/// Path for logging not set.
+	#[display(fmt = "Path for logging not set.")]
+	LoggingPathNotSet,
 	/// Timestamp overflow error.
 	#[display(fmt = "Timestamp overflow error.")]
 	TimestampOverflow,

--- a/ethcore/private-tx/src/error.rs
+++ b/ethcore/private-tx/src/error.rs
@@ -25,6 +25,7 @@ use ethkey::Error as KeyError;
 use ethkey::crypto::Error as CryptoError;
 use txpool::VerifiedTransaction;
 use private_transactions::VerifiedPrivateTransaction;
+use serde_json::{Error as SerdeError};
 
 type TxPoolError = txpool::Error<<VerifiedPrivateTransaction as VerifiedTransaction>::Hash>;
 
@@ -45,6 +46,9 @@ pub enum Error {
 	/// Crypto error.
 	#[display(fmt = "Crypto Error {}", _0)]
 	Crypto(CryptoError),
+	/// Serialization error.
+	#[display(fmt = "Serialization Error {}", _0)]
+	Json(SerdeError),
 	/// Encryption error.
 	#[display(fmt = "Encryption error. ({})", _0)]
 	Encrypt(String),
@@ -99,6 +103,7 @@ pub enum Error {
 	/// Key server URL is not set.
 	#[display(fmt = "Key server URL is not set.")]
 	KeyServerNotSet,
+	/// Transaction not found in logs.
 	#[display(fmt = "Private transaction not found in logs.")]
 	TxNotFoundInLog,
 	/// VM execution error.
@@ -125,6 +130,7 @@ impl error::Error for Error {
 			Error::Decoder(e) => Some(e),
 			Error::Trie(e) => Some(e),
 			Error::TxPool(e) => Some(e),
+			Error::Json(e) => Some(e),
 			Error::Crypto(e) => Some(e),
 			Error::Execution(e) => Some(e),
 			Error::Key(e) => Some(e),
@@ -186,6 +192,12 @@ impl From<TrieError> for Error {
 impl From<TxPoolError> for Error {
 	fn from(err: TxPoolError) -> Self {
 		Error::TxPool(err).into()
+	}
+}
+
+impl From<SerdeError> for Error {
+	fn from(err: SerdeError) -> Self {
+		Error::Json(err).into()
 	}
 }
 

--- a/ethcore/private-tx/src/error.rs
+++ b/ethcore/private-tx/src/error.rs
@@ -106,6 +106,9 @@ pub enum Error {
 	/// Transaction not found in logs.
 	#[display(fmt = "Private transaction not found in logs.")]
 	TxNotFoundInLog,
+	/// Timestamp overflow error.
+	#[display(fmt = "Timestamp overflow error.")]
+	TimestampOverflow,
 	/// VM execution error.
 	#[display(fmt = "VM execution error {}", _0)]
 	Execution(ExecutionError),

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -25,6 +25,7 @@ mod key_server_keys;
 mod private_transactions;
 mod messages;
 mod error;
+mod log;
 
 extern crate common_types as types;
 extern crate ethabi;
@@ -45,11 +46,15 @@ extern crate parking_lot;
 extern crate trie_db as trie;
 extern crate patricia_trie_ethereum as ethtrie;
 extern crate rlp;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
+extern crate serde_json;
 extern crate rustc_hex;
 extern crate transaction_pool as txpool;
 extern crate url;
 #[macro_use]
-extern crate log;
+extern crate log as ethlog;
 #[macro_use]
 extern crate ethabi_derive;
 #[macro_use]
@@ -67,7 +72,8 @@ pub use encryptor::{Encryptor, SecretStoreEncryptor, EncryptorConfig, NoopEncryp
 pub use key_server_keys::{KeyProvider, SecretStoreKeys, StoringKeyProvider};
 pub use private_transactions::{VerifiedPrivateTransaction, VerificationStore, PrivateTransactionSigningDesc, SigningStore};
 pub use messages::{PrivateTransaction, SignedPrivateTransaction};
-pub use error::Error;
+pub use error::{Error, ErrorKind};
+use log::{Logging};
 
 use std::sync::{Arc, Weak};
 use std::collections::{HashMap, HashSet, BTreeMap};
@@ -117,6 +123,8 @@ pub struct ProviderConfig {
 	pub validator_accounts: Vec<Address>,
 	/// Account used for signing public transactions created from private transactions
 	pub signer_account: Option<Address>,
+	/// Path to private tx logs
+	pub logs_path: Option<String>,
 }
 
 #[derive(Debug)]
@@ -177,6 +185,7 @@ pub struct Provider {
 	accounts: Arc<Signer>,
 	channel: IoChannel<ClientIoMessage>,
 	keys_provider: Arc<KeyProvider>,
+	logging: Logging,
 }
 
 #[derive(Debug)]
@@ -211,6 +220,7 @@ impl Provider {
 			accounts,
 			channel,
 			keys_provider,
+			logging: Logging::new(config.logs_path),
 		}
 	}
 
@@ -257,8 +267,9 @@ impl Provider {
 		trace!(target: "privatetx", "Required validators: {:?}", contract_validators);
 		let private_state_hash = self.calculate_state_hash(&private_state, contract_nonce);
 		trace!(target: "privatetx", "Hashed effective private state for sender: {:?}", private_state_hash);
-		self.transactions_for_signing.write().add_transaction(private.hash(), signed_transaction, contract_validators, private_state, contract_nonce)?;
+		self.transactions_for_signing.write().add_transaction(private.hash(), signed_transaction, &contract_validators, private_state, contract_nonce)?;
 		self.broadcast_private_transaction(private.hash(), private.rlp_bytes());
+		self.logging.private_tx_created(tx_hash, &contract_validators);
 		Ok(Receipt {
 			hash: tx_hash,
 			contract_address: contract,
@@ -354,8 +365,9 @@ impl Provider {
 			Some(desc) => desc,
 		};
 		let last = self.last_required_signature(&desc, signed_tx.signature())?;
+		let original_tx_hash = desc.original_transaction.hash();
 
-		if last {
+		if last.0 {
 			let mut signatures = desc.received_signatures.clone();
 			signatures.push(signed_tx.signature());
 			let rsv: Vec<Signature> = signatures.into_iter().map(|sign| sign.into_electrum().into()).collect();
@@ -373,7 +385,7 @@ impl Provider {
 			trace!(target: "privatetx", "Last required signature received, public transaction created: {:?}", public_tx);
 			// Sign and add it to the queue
 			let chain_id = desc.original_transaction.chain_id();
-			let hash = public_tx.hash(chain_id);
+			let public_tx_hash = public_tx.hash(chain_id);
 			let signature = self.accounts.sign(signer_account, hash)?;
 			let signed = SignedTransaction::new(public_tx.with_signature(signature, chain_id))?;
 			match self.miner.import_own_transaction(&*self.client, signed.into()) {
@@ -392,6 +404,9 @@ impl Provider {
 					Err(err) => warn!(target: "privatetx", "Failed to send private state changed notification, error: {:?}", err),
 				}
 			}
+			// Store logs
+			self.logging.signature_added(original_tx_hash, last.1);
+			self.logging.tx_deployed(original_tx_hash, public_tx_hash);
 			// Remove from store for signing
 			if let Err(err) = self.transactions_for_signing.write().remove(&private_hash) {
 				warn!(target: "privatetx", "Failed to remove transaction from signing store, error: {:?}", err);
@@ -400,7 +415,10 @@ impl Provider {
 		} else {
 			// Add signature to the store
 			match self.transactions_for_signing.write().add_signature(&private_hash, signed_tx.signature()) {
-				Ok(_) => trace!(target: "privatetx", "Signature stored for private transaction"),
+				Ok(_) => {
+					trace!(target: "privatetx", "Signature stored for private transaction");
+					self.logging.signature_added(original_tx_hash, last.1);
+				}
 				Err(err) => {
 					warn!(target: "privatetx", "Failed to add signature to signing store, error: {:?}", err);
 					return Err(err);
@@ -420,17 +438,14 @@ impl Provider {
 		}
 	}
 
-	fn last_required_signature(&self, desc: &PrivateTransactionSigningDesc, sign: Signature) -> Result<bool, Error>  {
-		if desc.received_signatures.contains(&sign) {
-			return Ok(false);
-		}
+	fn last_required_signature(&self, desc: &PrivateTransactionSigningDesc, sign: Signature) -> Result<(bool, Address), Error>  {
 		let state_hash = self.calculate_state_hash(&desc.state, desc.contract_nonce);
 		match recover(&sign, &state_hash) {
 			Ok(public) => {
 				let sender = public_to_address(&public);
 				match desc.validators.contains(&sender) {
 					true => {
-						Ok(desc.received_signatures.len() + 1 == desc.validators.len())
+						Ok((desc.received_signatures.len() + 1 == desc.validators.len(), sender))
 					}
 					false => {
 						warn!(target: "privatetx", "Sender's state doesn't correspond to validator's");

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -73,9 +73,10 @@ pub use key_server_keys::{KeyProvider, SecretStoreKeys, StoringKeyProvider};
 pub use private_transactions::{VerifiedPrivateTransaction, VerificationStore, PrivateTransactionSigningDesc, SigningStore};
 pub use messages::{PrivateTransaction, SignedPrivateTransaction};
 pub use error::Error;
-pub use log::{Logging, TransactionLog, ValidatorLog, PrivateTxStatus, FileLogsSerializer, SystemTimestamp};
+pub use log::{Logging, TransactionLog, ValidatorLog, PrivateTxStatus, FileLogsSerializer};
 
 use std::sync::{Arc, Weak};
+use std::time::SystemTime;
 use std::collections::{HashMap, HashSet, BTreeMap};
 use ethereum_types::{H128, H256, U256, Address};
 use hash::keccak;
@@ -220,7 +221,7 @@ impl Provider {
 			accounts,
 			channel,
 			keys_provider,
-			logging: Logging::new(Arc::new(FileLogsSerializer::with_path(config.logs_path)), Box::new(SystemTimestamp {})),
+			logging: Logging::new(Arc::new(FileLogsSerializer::with_path(config.logs_path)), Box::new(SystemTime::now())),
 		}
 	}
 

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -63,6 +63,9 @@ extern crate derive_more;
 #[macro_use]
 extern crate rlp_derive;
 
+#[cfg(not(time_checked_add))]
+extern crate time_utils;
+
 #[cfg(test)]
 extern crate rand;
 #[cfg(test)]

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -701,7 +701,7 @@ impl Provider {
 	/// Retrieves log information about private transaction
 	pub fn private_log(&self, tx_hash: H256) -> Result<TransactionLog, Error> {
 		match self.logging {
-			Some(ref logging) => logging.tx_log(&tx_hash).ok_or_else(|| Error::TxNotFoundInLog.into()),
+			Some(ref logging) => logging.tx_log(&tx_hash).ok_or(Error::TxNotFoundInLog.into()),
 			None => Err(Error::LoggingPathNotSet),
 		}
 	}

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -73,7 +73,7 @@ pub use key_server_keys::{KeyProvider, SecretStoreKeys, StoringKeyProvider};
 pub use private_transactions::{VerifiedPrivateTransaction, VerificationStore, PrivateTransactionSigningDesc, SigningStore};
 pub use messages::{PrivateTransaction, SignedPrivateTransaction};
 pub use error::{Error, ErrorKind};
-use log::{Logging};
+pub use log::{Logging, TransactionLog, ValidatorLog, PrivateTxStatus};
 
 use std::sync::{Arc, Weak};
 use std::collections::{HashMap, HashSet, BTreeMap};
@@ -687,6 +687,11 @@ impl Provider {
 	pub fn private_call(&self, block: BlockId, transaction: &SignedTransaction) -> Result<Executed, Error> {
 		let result = self.execute_private(transaction, TransactOptions::with_no_tracing(), block)?;
 		Ok(result.result)
+	}
+
+	/// Retrieves log information about private transaction
+	pub fn private_log(&self, tx_hash: H256) -> Result<TransactionLog, Error> {
+		self.logging.tx_log(tx_hash).ok_or(ErrorKind::TxNotFoundInLog.into())
 	}
 
 	/// Returns private validators for a contract.

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -701,7 +701,7 @@ impl Provider {
 	/// Retrieves log information about private transaction
 	pub fn private_log(&self, tx_hash: H256) -> Result<TransactionLog, Error> {
 		match self.logging {
-			Some(ref logging) => logging.tx_log(&tx_hash).ok_or(Error::TxNotFoundInLog.into()),
+			Some(ref logging) => logging.tx_log(&tx_hash).ok_or(Error::TxNotFoundInLog),
 			None => Err(Error::LoggingPathNotSet),
 		}
 	}

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -269,7 +269,7 @@ impl Provider {
 		trace!(target: "privatetx", "Hashed effective private state for sender: {:?}", private_state_hash);
 		self.transactions_for_signing.write().add_transaction(private.hash(), signed_transaction, &contract_validators, private_state, contract_nonce)?;
 		self.broadcast_private_transaction(private.hash(), private.rlp_bytes());
-		self.logging.private_tx_created(tx_hash, &contract_validators);
+		self.logging.private_tx_created(&tx_hash, &contract_validators);
 		Ok(Receipt {
 			hash: tx_hash,
 			contract_address: contract,
@@ -405,8 +405,8 @@ impl Provider {
 				}
 			}
 			// Store logs
-			self.logging.signature_added(original_tx_hash, last.1);
-			self.logging.tx_deployed(original_tx_hash, public_tx_hash);
+			self.logging.signature_added(&original_tx_hash, &last.1);
+			self.logging.tx_deployed(&original_tx_hash, &public_tx_hash);
 			// Remove from store for signing
 			if let Err(err) = self.transactions_for_signing.write().remove(&private_hash) {
 				warn!(target: "privatetx", "Failed to remove transaction from signing store, error: {:?}", err);
@@ -417,7 +417,7 @@ impl Provider {
 			match self.transactions_for_signing.write().add_signature(&private_hash, signed_tx.signature()) {
 				Ok(_) => {
 					trace!(target: "privatetx", "Signature stored for private transaction");
-					self.logging.signature_added(original_tx_hash, last.1);
+					self.logging.signature_added(&original_tx_hash, &last.1);
 				}
 				Err(err) => {
 					warn!(target: "privatetx", "Failed to add signature to signing store, error: {:?}", err);
@@ -691,7 +691,7 @@ impl Provider {
 
 	/// Retrieves log information about private transaction
 	pub fn private_log(&self, tx_hash: H256) -> Result<TransactionLog, Error> {
-		self.logging.tx_log(tx_hash).ok_or(ErrorKind::TxNotFoundInLog.into())
+		self.logging.tx_log(&tx_hash).ok_or(ErrorKind::TxNotFoundInLog.into())
 	}
 
 	/// Returns private validators for a contract.

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -73,7 +73,7 @@ pub use key_server_keys::{KeyProvider, SecretStoreKeys, StoringKeyProvider};
 pub use private_transactions::{VerifiedPrivateTransaction, VerificationStore, PrivateTransactionSigningDesc, SigningStore};
 pub use messages::{PrivateTransaction, SignedPrivateTransaction};
 pub use error::{Error, ErrorKind};
-pub use log::{Logging, TransactionLog, ValidatorLog, PrivateTxStatus, FileLogsSerializer};
+pub use log::{Logging, TransactionLog, ValidatorLog, PrivateTxStatus, FileLogsSerializer, SystemTimestamp};
 
 use std::sync::{Arc, Weak};
 use std::collections::{HashMap, HashSet, BTreeMap};
@@ -220,7 +220,7 @@ impl Provider {
 			accounts,
 			channel,
 			keys_provider,
-			logging: Logging::new(Box::new(FileLogsSerializer::new(config.logs_path))),
+			logging: Logging::new(Arc::new(FileLogsSerializer::new(config.logs_path)), Box::new(SystemTimestamp {})),
 		}
 	}
 

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -188,7 +188,7 @@ pub struct Provider {
 	accounts: Arc<Signer>,
 	channel: IoChannel<ClientIoMessage>,
 	keys_provider: Arc<KeyProvider>,
-	logging: Logging,
+	logging: Option<Logging>,
 }
 
 #[derive(Debug)]
@@ -223,7 +223,7 @@ impl Provider {
 			accounts,
 			channel,
 			keys_provider,
-			logging: Logging::new(Arc::new(FileLogsSerializer::with_path(config.logs_path))),
+			logging: config.logs_path.map(|path| Logging::new(Arc::new(FileLogsSerializer::with_path(path)))),
 		}
 	}
 
@@ -272,7 +272,9 @@ impl Provider {
 		trace!(target: "privatetx", "Hashed effective private state for sender: {:?}", private_state_hash);
 		self.transactions_for_signing.write().add_transaction(private.hash(), signed_transaction, &contract_validators, private_state, contract_nonce)?;
 		self.broadcast_private_transaction(private.hash(), private.rlp_bytes());
-		self.logging.private_tx_created(&tx_hash, &contract_validators);
+		if let Some(ref logging) = self.logging {
+			logging.private_tx_created(&tx_hash, &contract_validators);
+		}
 		Ok(Receipt {
 			hash: tx_hash,
 			contract_address: contract,
@@ -408,8 +410,10 @@ impl Provider {
 				}
 			}
 			// Store logs
-			self.logging.signature_added(&original_tx_hash, &last.1);
-			self.logging.tx_deployed(&original_tx_hash, &public_tx_hash);
+			if let Some(ref logging) = self.logging {
+				logging.signature_added(&original_tx_hash, &last.1);
+				logging.tx_deployed(&original_tx_hash, &public_tx_hash);
+			}
 			// Remove from store for signing
 			if let Err(err) = self.transactions_for_signing.write().remove(&private_hash) {
 				warn!(target: "privatetx", "Failed to remove transaction from signing store, error: {:?}", err);
@@ -420,7 +424,9 @@ impl Provider {
 			match self.transactions_for_signing.write().add_signature(&private_hash, signed_tx.signature()) {
 				Ok(_) => {
 					trace!(target: "privatetx", "Signature stored for private transaction");
-					self.logging.signature_added(&original_tx_hash, &last.1);
+					if let Some(ref logging) = self.logging {
+						logging.signature_added(&original_tx_hash, &last.1);
+					}
 				}
 				Err(err) => {
 					warn!(target: "privatetx", "Failed to add signature to signing store, error: {:?}", err);
@@ -694,7 +700,10 @@ impl Provider {
 
 	/// Retrieves log information about private transaction
 	pub fn private_log(&self, tx_hash: H256) -> Result<TransactionLog, Error> {
-		self.logging.tx_log(&tx_hash).ok_or_else(|| Error::TxNotFoundInLog.into())
+		match self.logging {
+			Some(ref logging) => logging.tx_log(&tx_hash).ok_or_else(|| Error::TxNotFoundInLog.into()),
+			None => Err(Error::LoggingPathNotSet),
+		}
 	}
 
 	/// Returns private validators for a contract.

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -72,7 +72,7 @@ pub use encryptor::{Encryptor, SecretStoreEncryptor, EncryptorConfig, NoopEncryp
 pub use key_server_keys::{KeyProvider, SecretStoreKeys, StoringKeyProvider};
 pub use private_transactions::{VerifiedPrivateTransaction, VerificationStore, PrivateTransactionSigningDesc, SigningStore};
 pub use messages::{PrivateTransaction, SignedPrivateTransaction};
-pub use error::{Error, ErrorKind};
+pub use error::Error;
 pub use log::{Logging, TransactionLog, ValidatorLog, PrivateTxStatus, FileLogsSerializer, SystemTimestamp};
 
 use std::sync::{Arc, Weak};
@@ -691,7 +691,7 @@ impl Provider {
 
 	/// Retrieves log information about private transaction
 	pub fn private_log(&self, tx_hash: H256) -> Result<TransactionLog, Error> {
-		self.logging.tx_log(&tx_hash).ok_or_else(|| ErrorKind::TxNotFoundInLog.into())
+		self.logging.tx_log(&tx_hash).ok_or_else(|| Error::TxNotFoundInLog.into())
 	}
 
 	/// Returns private validators for a contract.

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -220,7 +220,7 @@ impl Provider {
 			accounts,
 			channel,
 			keys_provider,
-			logging: Logging::new(Arc::new(FileLogsSerializer::new(config.logs_path)), Box::new(SystemTimestamp {})),
+			logging: Logging::new(Arc::new(FileLogsSerializer::with_path(config.logs_path)), Box::new(SystemTimestamp {})),
 		}
 	}
 
@@ -691,7 +691,7 @@ impl Provider {
 
 	/// Retrieves log information about private transaction
 	pub fn private_log(&self, tx_hash: H256) -> Result<TransactionLog, Error> {
-		self.logging.tx_log(&tx_hash).ok_or(ErrorKind::TxNotFoundInLog.into())
+		self.logging.tx_log(&tx_hash).ok_or_else(|| ErrorKind::TxNotFoundInLog.into())
 	}
 
 	/// Returns private validators for a contract.

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -386,7 +386,7 @@ impl Provider {
 			// Sign and add it to the queue
 			let chain_id = desc.original_transaction.chain_id();
 			let public_tx_hash = public_tx.hash(chain_id);
-			let signature = self.accounts.sign(signer_account, hash)?;
+			let signature = self.accounts.sign(signer_account, public_tx_hash)?;
 			let signed = SignedTransaction::new(public_tx.with_signature(signature, chain_id))?;
 			match self.miner.import_own_transaction(&*self.client, signed.into()) {
 				Ok(_) => trace!(target: "privatetx", "Public transaction added to queue"),

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -73,7 +73,7 @@ pub use key_server_keys::{KeyProvider, SecretStoreKeys, StoringKeyProvider};
 pub use private_transactions::{VerifiedPrivateTransaction, VerificationStore, PrivateTransactionSigningDesc, SigningStore};
 pub use messages::{PrivateTransaction, SignedPrivateTransaction};
 pub use error::{Error, ErrorKind};
-pub use log::{Logging, TransactionLog, ValidatorLog, PrivateTxStatus};
+pub use log::{Logging, TransactionLog, ValidatorLog, PrivateTxStatus, FileLogsSerializer};
 
 use std::sync::{Arc, Weak};
 use std::collections::{HashMap, HashSet, BTreeMap};
@@ -220,7 +220,7 @@ impl Provider {
 			accounts,
 			channel,
 			keys_provider,
-			logging: Logging::new(config.logs_path),
+			logging: Logging::new(Box::new(FileLogsSerializer::new(config.logs_path))),
 		}
 	}
 

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -76,7 +76,6 @@ pub use error::Error;
 pub use log::{Logging, TransactionLog, ValidatorLog, PrivateTxStatus, FileLogsSerializer};
 
 use std::sync::{Arc, Weak};
-use std::time::SystemTime;
 use std::collections::{HashMap, HashSet, BTreeMap};
 use ethereum_types::{H128, H256, U256, Address};
 use hash::keccak;
@@ -221,7 +220,7 @@ impl Provider {
 			accounts,
 			channel,
 			keys_provider,
-			logging: Logging::new(Arc::new(FileLogsSerializer::with_path(config.logs_path)), Box::new(SystemTime::now())),
+			logging: Logging::new(Arc::new(FileLogsSerializer::with_path(config.logs_path))),
 		}
 	}
 

--- a/ethcore/private-tx/src/log.rs
+++ b/ethcore/private-tx/src/log.rs
@@ -20,6 +20,7 @@ use ethereum_types::{H256, Address};
 use std::collections::{HashMap};
 use std::fs::{File};
 use std::path::{PathBuf};
+use std::sync::{Arc};
 use std::time::{SystemTime, UNIX_EPOCH};
 use parking_lot::{RwLock};
 use serde::ser::{Serializer, SerializeSeq};
@@ -152,18 +153,35 @@ impl LogsSerializer for FileLogsSerializer {
 	}
 }
 
+/// Timestamp source for logs
+pub trait TimestampSource: Send + Sync + 'static {
+	/// Returns current timestamp in seconds
+	fn current_timestamp(&self) -> u64;
+}
+
+/// Timesource on the base of system time
+pub struct SystemTimestamp {}
+
+impl TimestampSource for SystemTimestamp {
+	fn current_timestamp(&self) -> u64 {
+		SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+	}
+}
+
 /// Private transactions logging
 pub struct Logging {
 	logs: RwLock<HashMap<H256, TransactionLog>>,
-	logs_serializer: Box<LogsSerializer>,
+	logs_serializer: Arc<LogsSerializer>,
+	timestamp_source: Box<TimestampSource>,
 }
 
 impl Logging {
 	/// Creates the logging object
-	pub fn new(logs_serializer: Box<LogsSerializer>) -> Self {
+	pub fn new(logs_serializer: Arc<LogsSerializer>, timestamp_source: Box<TimestampSource>) -> Self {
 		let logging = Logging {
 			logs: RwLock::new(HashMap::new()),
 			logs_serializer,
+			timestamp_source,
 		};
 		if let Err(err) = logging.read_logs() {
 			warn!(target: "privatetx", "Cannot read logs: {:?}", err);
@@ -199,7 +217,7 @@ impl Logging {
 		logs.insert(*tx_hash, TransactionLog {
 			tx_hash: *tx_hash,
 			status: PrivateTxStatus::Created,
-			creation_timestamp: SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs(),
+			creation_timestamp: self.timestamp_source.current_timestamp(),
 			validators: validator_logs,
 			deployment_timestamp: None,
 			public_tx_hash: None,
@@ -213,7 +231,7 @@ impl Logging {
 			transaction_log.status = PrivateTxStatus::Validating;
 			if let Some(ref mut validator_log) = transaction_log.validators.iter_mut().find(|log| log.account == *validator) {
 				validator_log.validated = true;
-				validator_log.validation_timestamp = Some(SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs());
+				validator_log.validation_timestamp = Some(self.timestamp_source.current_timestamp());
 			}
 		}
 	}
@@ -223,7 +241,7 @@ impl Logging {
 		let mut logs = self.logs.write();
 		if let Some(log) = logs.get_mut(&tx_hash) {
 			log.status = PrivateTxStatus::Deployed;
-			log.deployment_timestamp = Some(SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs());
+			log.deployment_timestamp = Some(self.timestamp_source.current_timestamp());
 			log.public_tx_hash = Some(*public_tx_hash);
 		}
 	}
@@ -231,7 +249,7 @@ impl Logging {
 	fn read_logs(&self) -> Result<(), Error> {
 		let mut transaction_logs = self.logs_serializer.read_logs()?;
 		// Drop old logs
-		let current_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+		let current_timestamp = self.timestamp_source.current_timestamp();
 		transaction_logs.retain(|tx_log| current_timestamp - tx_log.creation_timestamp < MAX_STORING_TIME);
 		let mut logs = self.logs.write();
 		for log in transaction_logs {
@@ -260,10 +278,11 @@ mod tests {
 	use serde_json;
 	use error::{Error};
 	use ethereum_types::{H256};
-	use std::collections::{HashMap};
+	use std::collections::{HashMap, BTreeMap};
+	use std::sync::{Arc};
 	use transaction::{Transaction};
 	use parking_lot::{RwLock};
-	use super::{TransactionLog, Logging, PrivateTxStatus, LogsSerializer};
+	use super::{TransactionLog, Logging, PrivateTxStatus, LogsSerializer, TimestampSource};
 
 	struct StringLogSerializer {
 		string_log: RwLock<String>,
@@ -274,6 +293,11 @@ mod tests {
 			StringLogSerializer {
 				string_log: RwLock::new(source),
 			}
+		}
+
+		fn log(&self) -> String {
+			let log = self.string_log.read();
+			log.clone()
 		}
 	}
 
@@ -288,8 +312,22 @@ mod tests {
 		}
 
 		fn flush_logs(&self, logs: &HashMap<H256, TransactionLog>) -> Result<(), Error> {
-			*self.string_log.write() = serde_json::to_string(logs)?;
+			// Sort logs in order to have the same order
+			let sorted_logs: BTreeMap<&H256, &TransactionLog> = logs.iter().collect();
+			*self.string_log.write() = serde_json::to_string(&sorted_logs.values().collect::<Vec<&&TransactionLog>>())?;
 			Ok(())
+		}
+	}
+
+	struct CounterTimestamp {
+		counter: RwLock<u64>,
+	}
+
+	impl TimestampSource for CounterTimestamp {
+		fn current_timestamp(&self) -> u64 {
+			let current = *self.counter.read();
+			*self.counter.write() = current + 1;
+			current
 		}
 	}
 
@@ -313,7 +351,7 @@ mod tests {
 
 	#[test]
 	fn private_log_status() {
-		let logger = Logging::new(Box::new(StringLogSerializer::new("".into())));
+		let logger = Logging::new(Arc::new(StringLogSerializer::new("".into())), Box::new(CounterTimestamp { counter: RwLock::new(0), }));
 		let private_tx = Transaction::default();
 		let hash = private_tx.hash(None);
 		logger.private_tx_created(&hash, &vec!["0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1".into()]);
@@ -321,5 +359,54 @@ mod tests {
 		logger.tx_deployed(&hash, &hash);
 		let tx_log = logger.tx_log(&hash).unwrap();
 		assert_eq!(tx_log.status, PrivateTxStatus::Deployed);
+	}
+
+	#[test]
+	fn serialization() {
+		let initial = r#"[{
+			"tx_hash":"0x64f648ca7ae7f4138014f860ae56164d8d5732969b1cea54d8be9d144d8aa6f6",
+			"status":"Deployed",
+			"creation_timestamp":0,
+			"validators":[{
+				"account":"0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1",
+				"validated":true,
+				"validation_timestamp":1
+			}],
+			"deployment_timestamp":2,
+			"public_tx_hash":"0x69b9c691ede7993effbcc88911c309af1c82be67b04b3882dd446b808ae146da"
+		}]"#;
+		let serializer = Arc::new(StringLogSerializer::new(initial.into()));
+		let logger = Logging::new(serializer.clone(), Box::new(CounterTimestamp { counter: RwLock::new(5) }));
+		let hash: H256 = "0x63c715e88f7291e66069302f6fcbb4f28a19ef5d7cbd1832d0c01e221c0061c6".into();
+		logger.private_tx_created(&hash, &vec!["0x7ffbe3512782069be388f41be4d8eb350672d3a5".into()]);
+		logger.signature_added(&hash, &"0x7ffbe3512782069be388f41be4d8eb350672d3a5".into());
+		logger.tx_deployed(&hash, &"0xde2209a8635b9cab9eceb67928b217c70ab53f6498e5144492ec01e6f43547d7".into());
+		drop(logger);
+		let should_be_final = r#"[
+			{
+				"tx_hash":"0x63c715e88f7291e66069302f6fcbb4f28a19ef5d7cbd1832d0c01e221c0061c6",
+				"status":"Deployed",
+				"creation_timestamp":6,
+				"validators":[{
+					"account":"0x7ffbe3512782069be388f41be4d8eb350672d3a5",
+					"validated":true,
+					"validation_timestamp":7
+				}],
+				"deployment_timestamp":8,
+				"public_tx_hash":"0xde2209a8635b9cab9eceb67928b217c70ab53f6498e5144492ec01e6f43547d7"},
+			{
+				"tx_hash":"0x64f648ca7ae7f4138014f860ae56164d8d5732969b1cea54d8be9d144d8aa6f6",
+				"status":"Deployed",
+				"creation_timestamp":0,
+				"validators":[{
+					"account":"0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1",
+					"validated":true,
+					"validation_timestamp":1
+				}],
+				"deployment_timestamp":2,
+				"public_tx_hash":"0x69b9c691ede7993effbcc88911c309af1c82be67b04b3882dd446b808ae146da"
+		}]"#;
+		let should_be_final = &should_be_final.replace("\t", "").replace("\n", "");
+		assert_eq!(serializer.log(), *should_be_final);
 	}
 }

--- a/ethcore/private-tx/src/log.rs
+++ b/ethcore/private-tx/src/log.rs
@@ -280,7 +280,7 @@ mod tests {
 	use ethereum_types::{H256};
 	use std::collections::{HashMap, BTreeMap};
 	use std::sync::{Arc};
-	use transaction::{Transaction};
+	use types::transaction::{Transaction};
 	use parking_lot::{RwLock};
 	use super::{TransactionLog, Logging, PrivateTxStatus, LogsSerializer, TimestampSource};
 

--- a/ethcore/private-tx/src/log.rs
+++ b/ethcore/private-tx/src/log.rs
@@ -100,7 +100,7 @@ impl FileLogsSerializer {
 					Ok(file) => file,
 					Err(err) => {
 						trace!(target: "privatetx", "Cannot open logs file: {}", err);
-						bail!("Cannot open logs file: {:?}", err);
+						return Err(format!("Cannot open logs file: {:?}", err).into());
 					}
 				}
 			}
@@ -122,7 +122,7 @@ impl LogsSerializer for FileLogsSerializer {
 					Ok(logs) => logs,
 					Err(err) => {
 						error!(target: "privatetx", "Cannot deserialize logs from file: {}", err);
-						bail!("Cannot deserialize logs from file: {:?}", err);
+						return Err(format!("Cannot deserialize logs from file: {:?}", err).into());
 					}
 				};
 				Ok(transaction_logs)

--- a/ethcore/private-tx/src/log.rs
+++ b/ethcore/private-tx/src/log.rs
@@ -116,7 +116,7 @@ impl Logging {
 				}
 			}
 			None => {
-				error!(target: "privatetx", "Logs path is not defined");
+				warn!(target: "privatetx", "Logs path is not defined");
 				return;
 			}
 		};
@@ -134,6 +134,10 @@ impl Logging {
 	}
 
 	fn flush_logs(&self) {
+		if self.logs.read().is_empty() {
+			// Do not create empty file
+			return;
+		}
 		let log_file = match self.logs_dir {
 			Some(ref path) => {
 				let mut file_path = path.clone();

--- a/ethcore/private-tx/src/log.rs
+++ b/ethcore/private-tx/src/log.rs
@@ -164,15 +164,6 @@ impl CurrentTime for SystemTime {
 	}
 }
 
-/*/// Timesource on the base of system time
-pub struct SystemTimestamp {}
-
-impl CurrentTime for SystemTimestamp {
-	fn timestamp(&self) -> u64 {
-		SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
-	}
-}*/
-
 /// Private transactions logging
 pub struct Logging {
 	logs: RwLock<HashMap<H256, TransactionLog>>,

--- a/ethcore/private-tx/src/log.rs
+++ b/ethcore/private-tx/src/log.rs
@@ -1,0 +1,166 @@
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Private transactions logs.
+
+use ethereum_types::{H256, Address};
+use std::collections::{HashMap};
+use std::fs::{File};
+use std::time::{SystemTime, UNIX_EPOCH};
+use parking_lot::{RwLock};
+
+#[derive(Clone, Serialize, Deserialize)]
+enum Status {
+	Created,
+	Validating,
+	Deployed,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct ValidatorLog {
+	account: Address,
+	validated: bool,
+	validation_timestamp: Option<u64>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct TransactionLog {
+	tx_hash: H256,
+	status: Status,
+	creation_timestamp: u64,
+	validators: Vec<ValidatorLog>,
+	deployment_timestamp: Option<u64>,
+	public_tx_hash: Option<H256>,
+}
+
+/// Private transactions logging
+pub struct Logging {
+	logs: RwLock<HashMap<H256, TransactionLog>>,
+	logs_dir: Option<String>,
+}
+
+impl Logging {
+	pub fn new(logs_dir: Option<String>) -> Self {
+		let logging = Logging {
+			logs: RwLock::new(HashMap::new()),
+			logs_dir,
+		};
+		logging.read_logs();
+		logging
+	}
+
+	pub fn private_tx_created(&self, tx_hash: H256, validators: &Vec<Address>) {
+		let mut validator_logs = Vec::new();
+		for account in validators {
+			validator_logs.push(ValidatorLog {
+				account: *account,
+				validated: false,
+				validation_timestamp: None,
+			});
+		}
+		let mut logs = self.logs.write();
+		logs.insert(tx_hash, TransactionLog {
+			tx_hash,
+			status: Status::Created,
+			creation_timestamp: SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs(),
+			validators: validator_logs,
+			deployment_timestamp: None,
+			public_tx_hash: None,
+		});
+	}
+
+	pub fn signature_added(&self, tx_hash: H256, validator: Address) {
+		let mut logs = self.logs.write();
+		if let Some(transaction_log) = logs.get_mut(&tx_hash) {
+			transaction_log.status = Status::Validating;
+			if let Some(ref mut validator_log) = transaction_log.validators.iter_mut().find(|log| log.account == validator) {
+				validator_log.validated = true;
+				validator_log.validation_timestamp = Some(SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs());
+			}
+		}
+	}
+
+	pub fn tx_deployed(&self, tx_hash: H256, public_tx_hash: H256) {
+		let mut logs = self.logs.write();
+		if let Some(log) = logs.get_mut(&tx_hash) {
+			log.status = Status::Deployed;
+			log.deployment_timestamp = Some(SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs());
+			log.public_tx_hash = Some(public_tx_hash);
+		}
+	}
+
+	fn read_logs(&self) {
+		let log_file = match self.logs_dir {
+			Some(ref path) => {
+				let mut file_path = path.clone();
+				file_path.push_str("private_tx.log");
+				match File::open(&file_path) {
+					Ok(file) => file,
+					Err(err) => {
+						trace!(target: "privatetx", "Cannot open logs file: {}", err);
+						return;
+					}
+				}
+			}
+			None => {
+				error!(target: "privatetx", "Logs path is not defined");
+				return;
+			}
+		};
+		let transaction_logs: Vec<TransactionLog> = match serde_json::from_reader(log_file) {
+			Ok(logs) => logs,
+			Err(err) => {
+				error!(target: "privatetx", "Cannot deserialize logs from file: {}", err);
+				return;
+			}
+		};
+		let mut logs = self.logs.write();
+		for log in transaction_logs {
+			logs.insert(log.tx_hash, log);
+		}
+	}
+
+	fn flush_logs(&self) {
+		let log_file = match self.logs_dir {
+			Some(ref path) => {
+				let mut file_path = path.clone();
+				file_path.push_str("private_tx.log");
+				match File::open(&file_path) {
+					Ok(file) => Some(file),
+					Err(_) => File::create(&file_path).ok()
+				}
+			}
+			None => None,
+		};
+		let log_file = match log_file {
+			Some(file) => file,
+			None => {
+				error!(target: "privatetx", "Cannot open logs file");
+				return;
+			}
+		};
+		if let Err(err) = serde_json::to_writer(log_file, &self.logs.read().values().cloned().collect::<Vec<TransactionLog>>()) {
+			error!(target: "privatetx", "Error during logs serialisation: {}", err);
+		}
+	}
+}
+
+// Flush all logs on drop
+impl Drop for Logging {
+	fn drop(&mut self) {
+		self.flush_logs();
+	}
+}

--- a/ethcore/private-tx/src/log.rs
+++ b/ethcore/private-tx/src/log.rs
@@ -54,7 +54,7 @@ impl MonoTime {
 		self.start_inst.elapsed()
 	}
 
-	fn into_system_time(&self) -> SystemTime {
+	fn to_system_time(&self) -> SystemTime {
 		self.start_time + self.elapsed()
 	}
 }
@@ -221,7 +221,7 @@ impl Logging {
 		logs.insert(*tx_hash, TransactionLog {
 			tx_hash: *tx_hash,
 			status: PrivateTxStatus::Created,
-			creation_timestamp: self.mono_time.lock().into_system_time(),
+			creation_timestamp: self.mono_time.lock().to_system_time(),
 			validators: validator_logs,
 			deployment_timestamp: None,
 			public_tx_hash: None,
@@ -234,7 +234,7 @@ impl Logging {
 		if let Some(transaction_log) = logs.get_mut(&tx_hash) {
 			if let Some(ref mut validator_log) = transaction_log.validators.iter_mut().find(|log| log.account == *validator) {
 				transaction_log.status = PrivateTxStatus::Validating;
-				validator_log.validation_timestamp = Some(self.mono_time.lock().into_system_time());
+				validator_log.validation_timestamp = Some(self.mono_time.lock().to_system_time());
 			}
 		}
 	}
@@ -244,7 +244,7 @@ impl Logging {
 		let mut logs = self.logs.write();
 		if let Some(log) = logs.get_mut(&tx_hash) {
 			log.status = PrivateTxStatus::Deployed;
-			log.deployment_timestamp = Some(self.mono_time.lock().into_system_time());
+			log.deployment_timestamp = Some(self.mono_time.lock().to_system_time());
 			log.public_tx_hash = Some(*public_tx_hash);
 		}
 	}

--- a/ethcore/private-tx/src/log.rs
+++ b/ethcore/private-tx/src/log.rs
@@ -158,13 +158,20 @@ pub trait CurrentTime: Send + Sync + 'static {
 }
 
 /// Timesource on the base of system time
+impl CurrentTime for SystemTime {
+	fn timestamp(&self) -> u64 {
+		self.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+	}
+}
+
+/*/// Timesource on the base of system time
 pub struct SystemTimestamp {}
 
 impl CurrentTime for SystemTimestamp {
 	fn timestamp(&self) -> u64 {
 		SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
 	}
-}
+}*/
 
 /// Private transactions logging
 pub struct Logging {

--- a/ethcore/private-tx/src/private_transactions.rs
+++ b/ethcore/private-tx/src/private_transactions.rs
@@ -224,7 +224,7 @@ impl SigningStore {
 		&mut self,
 		private_hash: H256,
 		transaction: SignedTransaction,
-		validators: Vec<Address>,
+		validators: &Vec<Address>,
 		state: Bytes,
 		contract_nonce: U256,
 	) -> Result<(), Error> {

--- a/ethcore/private-tx/tests/private_contract.rs
+++ b/ethcore/private-tx/tests/private_contract.rs
@@ -194,6 +194,7 @@ fn call_other_private_contract() {
 	let config = ProviderConfig{
 		validator_accounts: vec![key3.address(), key4.address()],
 		signer_account: None,
+		logs_path: None,
 	};
 
 	let io = ethcore_io::IoChannel::disconnected();

--- a/ethcore/private-tx/tests/private_contract.rs
+++ b/ethcore/private-tx/tests/private_contract.rs
@@ -59,6 +59,7 @@ fn private_contract() {
 	let config = ProviderConfig{
 		validator_accounts: vec![key3.address(), key4.address()],
 		signer_account: None,
+		logs_path: None,
 	};
 
 	let io = ethcore_io::IoChannel::disconnected();

--- a/ethcore/sync/src/tests/private.rs
+++ b/ethcore/sync/src/tests/private.rs
@@ -69,11 +69,13 @@ fn send_private_transaction() {
 	let validator_config = ProviderConfig{
 		validator_accounts: vec![s1.address()],
 		signer_account: None,
+		logs_path: None,
 	};
 
 	let signer_config = ProviderConfig{
 		validator_accounts: Vec::new(),
 		signer_account: Some(s0.address()),
+		logs_path: None,
 	};
 
 	let private_keys = Arc::new(StoringKeyProvider::default());

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -1458,7 +1458,6 @@ mod tests {
 			private_provider_conf: ProviderConfig {
 				validator_accounts: Default::default(),
 				signer_account: Default::default(),
-				passwords: Default::default(),
 				logs_path: Some(Directories::default().base),
 			},
 			private_encryptor_conf: Default::default(),

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -1455,7 +1455,12 @@ mod tests {
 			net_settings: Default::default(),
 			ipfs_conf: Default::default(),
 			secretstore_conf: Default::default(),
-			private_provider_conf: Default::default(),
+			private_provider_conf: ProviderConfig {
+				validator_accounts: Default::default(),
+				signer_account: Default::default(),
+				passwords: Default::default(),
+				logs_path: Some(Directories::default().base),
+			},
 			private_encryptor_conf: Default::default(),
 			private_tx_enabled: false,
 			name: "".into(),

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -913,9 +913,11 @@ impl Configuration {
 	}
 
 	fn private_provider_config(&self) -> Result<(ProviderConfig, EncryptorConfig, bool), String> {
+		let dirs = self.directories();
 		let provider_conf = ProviderConfig {
 			validator_accounts: to_addresses(&self.args.arg_private_validators)?,
 			signer_account: self.args.arg_private_signer.clone().and_then(|account| to_address(Some(account)).ok()),
+			logs_path: Some(dirs.base),
 		};
 
 		let encryptor_conf = EncryptorConfig {

--- a/rpc/src/v1/impls/private.rs
+++ b/rpc/src/v1/impls/private.rs
@@ -26,7 +26,7 @@ use types::transaction::SignedTransaction;
 
 use jsonrpc_core::{Error};
 use v1::types::{Bytes, PrivateTransactionReceipt, TransactionRequest,
-	BlockNumber, PrivateTransactionReceiptAndTransaction, CallRequest, 
+	BlockNumber, PrivateTransactionReceiptAndTransaction, CallRequest,
 	block_number_to_id, PrivateTransactionLog};
 use v1::traits::Private;
 use v1::metadata::Metadata;
@@ -122,8 +122,9 @@ impl Private for PrivateClient {
 	}
 
 	fn private_log(&self, tx_hash: H256) -> Result<PrivateTransactionLog, Error> {
-		let client = self.unwrap_manager()?;
-		let log = client.private_log(tx_hash.into()).map_err(|e| errors::private_message(e))?;
-		Ok(log.into())
+		self.unwrap_manager()?
+			.private_log(tx_hash)
+			.map_err(errors::private_message)
+			.map(Into::into)
 	}
 }

--- a/rpc/src/v1/impls/private.rs
+++ b/rpc/src/v1/impls/private.rs
@@ -26,7 +26,8 @@ use types::transaction::SignedTransaction;
 
 use jsonrpc_core::{Error};
 use v1::types::{Bytes, PrivateTransactionReceipt, TransactionRequest,
-	BlockNumber, PrivateTransactionReceiptAndTransaction, CallRequest, block_number_to_id};
+	BlockNumber, PrivateTransactionReceiptAndTransaction, CallRequest, 
+	block_number_to_id, PrivateTransactionLog};
 use v1::traits::Private;
 use v1::metadata::Metadata;
 use v1::helpers::{errors, fake_sign};
@@ -118,5 +119,11 @@ impl Private for PrivateClient {
 		let client = self.unwrap_manager()?;
 		let key = client.contract_key_id(&contract_address).map_err(errors::private_message)?;
 		Ok(key)
+	}
+
+	fn private_log(&self, tx_hash: H256) -> Result<PrivateTransactionLog, Error> {
+		let client = self.unwrap_manager()?;
+		let log = client.private_log(tx_hash.into()).map_err(|e| errors::private_message(e))?;
+		Ok(log.into())
 	}
 }

--- a/rpc/src/v1/traits/private.rs
+++ b/rpc/src/v1/traits/private.rs
@@ -21,7 +21,7 @@ use jsonrpc_core::Error;
 use jsonrpc_derive::rpc;
 
 use v1::types::{Bytes, PrivateTransactionReceipt, BlockNumber,
-	PrivateTransactionReceiptAndTransaction, CallRequest};
+	PrivateTransactionReceiptAndTransaction, CallRequest, PrivateTransactionLog};
 
 /// Private transaction management RPC interface.
 #[rpc]
@@ -44,4 +44,8 @@ pub trait Private {
 	/// Retrieve the id of the key associated with the contract
 	#[rpc(name = "private_contractKey")]
 	fn private_contract_key(&self, H160) -> Result<H256, Error>;
+
+	/// Retrieve log information about private transaction
+	#[rpc(name = "private_log")]
+	fn private_log(&self, H256) -> Result<PrivateTransactionLog, Error>;
 }

--- a/rpc/src/v1/types/mod.rs
+++ b/rpc/src/v1/types/mod.rs
@@ -32,6 +32,8 @@ mod histogram;
 mod index;
 mod log;
 mod node_kind;
+mod private_receipt;
+mod private_log;
 mod provenance;
 mod receipt;
 mod rpc_settings;
@@ -43,7 +45,6 @@ mod transaction;
 mod transaction_request;
 mod transaction_condition;
 mod work;
-mod private_receipt;
 mod eip191;
 
 pub mod pubsub;
@@ -65,6 +66,8 @@ pub use self::histogram::Histogram;
 pub use self::index::Index;
 pub use self::log::Log;
 pub use self::node_kind::{NodeKind, Availability, Capability};
+pub use self::private_receipt::{PrivateTransactionReceipt, PrivateTransactionReceiptAndTransaction};
+pub use self::private_log::PrivateTransactionLog;
 pub use self::provenance::Origin;
 pub use self::receipt::Receipt;
 pub use self::rpc_settings::RpcSettings;
@@ -79,7 +82,6 @@ pub use self::transaction::{Transaction, RichRawTransaction, LocalTransactionSta
 pub use self::transaction_request::TransactionRequest;
 pub use self::transaction_condition::TransactionCondition;
 pub use self::work::Work;
-pub use self::private_receipt::{PrivateTransactionReceipt, PrivateTransactionReceiptAndTransaction};
 
 // TODO [ToDr] Refactor to a proper type Vec of enums?
 /// Expected tracing type.

--- a/rpc/src/v1/types/private_log.rs
+++ b/rpc/src/v1/types/private_log.rs
@@ -54,7 +54,7 @@ pub struct ValidatorLog {
 impl From<EthValidatorLog> for ValidatorLog {
 	fn from(r: EthValidatorLog) -> Self {
 		ValidatorLog {
-			account: r.account.into(),
+			account: r.account,
 			validation_timestamp: r.validation_timestamp.map(|t| t.duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs()),
 		}
 	}
@@ -81,12 +81,12 @@ pub struct PrivateTransactionLog {
 impl From<EthTransactionLog> for PrivateTransactionLog {
 	fn from(r: EthTransactionLog) -> Self {
 		PrivateTransactionLog {
-			tx_hash: r.tx_hash.into(),
+			tx_hash: r.tx_hash,
 			status: r.status.into(),
 			creation_timestamp: r.creation_timestamp.duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs(),
 			validators: r.validators.into_iter().map(Into::into).collect(),
 			deployment_timestamp: r.deployment_timestamp.map(|t| t.duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs()),
-			public_tx_hash: r.public_tx_hash.map(Into::into),
+			public_tx_hash: r.public_tx_hash,
 		}
 	}
 }

--- a/rpc/src/v1/types/private_log.rs
+++ b/rpc/src/v1/types/private_log.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::time::SystemTime;
 use ethereum_types::{H160, H256};
 use ethcore_private_tx::{TransactionLog as EthTransactionLog, ValidatorLog as EthValidatorLog, PrivateTxStatus as EthStatus};
 
@@ -54,7 +55,7 @@ impl From<EthValidatorLog> for ValidatorLog {
 	fn from(r: EthValidatorLog) -> Self {
 		ValidatorLog {
 			account: r.account.into(),
-			validation_timestamp: r.validation_timestamp.into(),
+			validation_timestamp: r.validation_timestamp.map(|t| t.duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs()),
 		}
 	}
 }
@@ -82,9 +83,9 @@ impl From<EthTransactionLog> for PrivateTransactionLog {
 		PrivateTransactionLog {
 			tx_hash: r.tx_hash.into(),
 			status: r.status.into(),
-			creation_timestamp: r.creation_timestamp.into(),
+			creation_timestamp: r.creation_timestamp.duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs(),
 			validators: r.validators.into_iter().map(Into::into).collect(),
-			deployment_timestamp: r.deployment_timestamp.into(),
+			deployment_timestamp: r.deployment_timestamp.map(|t| t.duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs()),
 			public_tx_hash: r.public_tx_hash.map(Into::into),
 		}
 	}

--- a/rpc/src/v1/types/private_log.rs
+++ b/rpc/src/v1/types/private_log.rs
@@ -46,9 +46,7 @@ impl From<EthStatus> for Status {
 pub struct ValidatorLog {
 	/// Account of the validator
 	pub account: H160,
-	/// Validation flag
-	pub validated: bool,
-	/// Validation timestamp
+	/// Validation timestamp, None, if the transaction is not validated yet
 	pub validation_timestamp: Option<u64>,
 }
 
@@ -56,7 +54,6 @@ impl From<EthValidatorLog> for ValidatorLog {
 	fn from(r: EthValidatorLog) -> Self {
 		ValidatorLog {
 			account: r.account.into(),
-			validated: r.validated.into(),
 			validation_timestamp: r.validation_timestamp.into(),
 		}
 	}

--- a/rpc/src/v1/types/private_log.rs
+++ b/rpc/src/v1/types/private_log.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use v1::types::{H160, H256};
+use ethereum_types::{H160, H256};
 use ethcore_private_tx::{TransactionLog as EthTransactionLog, ValidatorLog as EthValidatorLog, PrivateTxStatus as EthStatus};
 
 /// Current status of the private transaction

--- a/rpc/src/v1/types/private_log.rs
+++ b/rpc/src/v1/types/private_log.rs
@@ -1,0 +1,95 @@
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+use v1::types::{H160, H256};
+use ethcore_private_tx::{TransactionLog as EthTransactionLog, ValidatorLog as EthValidatorLog, PrivateTxStatus as EthStatus};
+
+/// Current status of the private transaction
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum Status {
+	/// Private tx was created but no validation received yet
+	Created,
+	/// Several validators (but not all) validated the transaction
+	Validating,
+	/// All validators validated the private tx
+	/// Corresponding public tx was created and added into the pool
+	Deployed,
+}
+
+impl From<EthStatus> for Status {
+	fn from(c: EthStatus) -> Self {
+		match c {
+			EthStatus::Created => Status::Created,
+			EthStatus::Validating => Status::Validating,
+			EthStatus::Deployed => Status::Deployed,
+		}
+	}
+}
+
+/// Information about private tx validation
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidatorLog {
+	/// Account of the validator
+	pub account: H160,
+	/// Validation flag
+	pub validated: bool,
+	/// Validation timestamp
+	pub validation_timestamp: Option<u64>,
+}
+
+impl From<EthValidatorLog> for ValidatorLog {
+	fn from(r: EthValidatorLog) -> Self {
+		ValidatorLog {
+			account: r.account.into(),
+			validated: r.validated.into(),
+			validation_timestamp: r.validation_timestamp.into(),
+		}
+	}
+}
+
+/// Information about the private transaction
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivateTransactionLog {
+	/// Original signed transaction hash (used as a source for private tx)
+	pub tx_hash: H256,
+	/// Current status of the private transaction
+	pub status: Status,
+	/// Creation timestamp
+	pub creation_timestamp: u64,
+	/// List of validations
+	pub validators: Vec<ValidatorLog>,
+	/// Timestamp of the resulting public tx deployment
+	pub deployment_timestamp: Option<u64>,
+	/// Hash of the resulting public tx
+	pub public_tx_hash: Option<H256>,
+}
+
+impl From<EthTransactionLog> for PrivateTransactionLog {
+	fn from(r: EthTransactionLog) -> Self {
+		PrivateTransactionLog {
+			tx_hash: r.tx_hash.into(),
+			status: r.status.into(),
+			creation_timestamp: r.creation_timestamp.into(),
+			validators: r.validators.into_iter().map(Into::into).collect(),
+			deployment_timestamp: r.deployment_timestamp.into(),
+			public_tx_hash: r.public_tx_hash.map(Into::into),
+		}
+	}
+}
+


### PR DESCRIPTION
For private tx diagnostic purposes trivial journal implemented.
Details of the solution:
- All logs are put into the local json file, created in client's root directory (with name private_tx.log)
- So only the node created the private transaction can provide information about its status
- The following information is stored for every private transaction created on the node:
	/// Original signed transaction hash (used as a source for private tx)
	pub tx_hash: H256,
	/// Current status of the private transaction
	pub status: PrivateTxStatus,
	/// Creation timestamp
	pub creation_timestamp: u64,
	/// List of validations
	pub validators: Vec<ValidatorLog>,
	/// Timestamp of the resulting public tx deployment
	pub deployment_timestamp: Option<u64>,
	/// Hash of the resulting public tx
	pub public_tx_hash: Option<H256>,
- Status has one of the following values:
        /// Private tx was created but no validation received yet
	Created,
	/// Several validators (but not all) validated the transaction
	Validating,
	/// All validators validated the private tx
	/// Corresponding public tx was created and added into the pool
	Deployed, 
- Example of the log:
[{"tx_hash":"0x957251b3acfa1cabaed21234afa40cdb0c51952c6ac426d538f8b559bc50c271","status":"Created","creation_timestamp":1544627108,"validators":[{"account":"0x7ffbe3512782069be388f41be4d8eb350672d3a5","validated":false,"validation_timestamp":null}],"deployment_timestamp":null,"public_tx_hash":null},{"tx_hash":"0xc868b873b74259935f74b8b858bf44f692ad0ead3339844aaad1e6df6a29c982","status":"Deployed","creation_timestamp":1544626975,"validators":[{"account":"0x7ffbe3512782069be388f41be4d8eb350672d3a5","validated":true,"validation_timestamp":1544626975}],"deployment_timestamp":1544626975,"public_tx_hash":"0xe56b48fd040e14e38d6f6dae7846fec10ec20a7edc903b31ba87d3b1bd9413f0"}]
- Corresponding RPC method private_log added in order to access the information
- In order to preserve sensible size of the logs the following limitations implemented:
-- Amount of logs available (currently hardcoded 1000)
-- Lifetime of the logs (currently 20 days hardcoded), the older logs will be dropped with the next processing

Closes #9641 