### PR TITLE
Align personal_unlockAccount behaviour when permanent unlock is disabled

### DIFF
--- a/rpc/src/v1/impls/personal.rs
+++ b/rpc/src/v1/impls/personal.rs
@@ -128,10 +128,7 @@ impl<D: Dispatcher + 'static> Personal for PersonalClient<D> {
 
 		let r = match (self.allow_perm_unlock, duration) {
 			(false, None) => store.unlock_account_temporarily(account, account_pass.into()),
-			(false, _) => return Err(errors::unsupported(
-				"Time-unlocking is only supported in --geth compatibility mode.",
-				Some("Restart your client with --geth flag or use personal_sendTransaction instead."),
-			)),
+			(false, _) => store.unlock_account_temporarily(account, account_pass.into()),
 			(true, Some(0)) => store.unlock_account_permanently(account, account_pass.into()),
 			(true, Some(d)) => store.unlock_account_timed(account, account_pass.into(), Duration::from_secs(d.into())),
 			(true, None) => store.unlock_account_timed(account, account_pass.into(), Duration::from_secs(300)),

--- a/rpc/src/v1/impls/personal.rs
+++ b/rpc/src/v1/impls/personal.rs
@@ -128,7 +128,10 @@ impl<D: Dispatcher + 'static> Personal for PersonalClient<D> {
 
 		let r = match (self.allow_perm_unlock, duration) {
 			(false, None) => store.unlock_account_temporarily(account, account_pass.into()),
-			(false, _) => store.unlock_account_temporarily(account, account_pass.into()),
+			(false, _) => return Err(errors::unsupported(				(false, _) => store.unlock_account_temporarily(account, account_pass.into()),
+				"Time-unlocking is not supported when permanent unlock is disabled.",	
+				Some("Use personal_sendTransaction or enable permanent unlocking, instead."),	
+			)),
 			(true, Some(0)) => store.unlock_account_permanently(account, account_pass.into()),
 			(true, Some(d)) => store.unlock_account_timed(account, account_pass.into(), Duration::from_secs(d.into())),
 			(true, None) => store.unlock_account_timed(account, account_pass.into(), Duration::from_secs(300)),

--- a/rpc/src/v1/impls/personal.rs
+++ b/rpc/src/v1/impls/personal.rs
@@ -128,7 +128,7 @@ impl<D: Dispatcher + 'static> Personal for PersonalClient<D> {
 
 		let r = match (self.allow_perm_unlock, duration) {
 			(false, None) => store.unlock_account_temporarily(account, account_pass.into()),
-			(false, _) => return Err(errors::unsupported(				(false, _) => store.unlock_account_temporarily(account, account_pass.into()),
+			(false, _) => return Err(errors::unsupported(
 				"Time-unlocking is not supported when permanent unlock is disabled.",	
 				Some("Use personal_sendTransaction or enable permanent unlocking, instead."),	
 			)),

--- a/rpc/src/v1/impls/personal.rs
+++ b/rpc/src/v1/impls/personal.rs
@@ -129,8 +129,8 @@ impl<D: Dispatcher + 'static> Personal for PersonalClient<D> {
 		let r = match (self.allow_perm_unlock, duration) {
 			(false, None) => store.unlock_account_temporarily(account, account_pass.into()),
 			(false, _) => return Err(errors::unsupported(
-				"Time-unlocking is not supported when permanent unlock is disabled.",	
-				Some("Use personal_sendTransaction or enable permanent unlocking, instead."),	
+				"Time-unlocking is not supported when permanent unlock is disabled.",
+				Some("Use personal_sendTransaction or enable permanent unlocking, instead."),
 			)),
 			(true, Some(0)) => store.unlock_account_permanently(account, account_pass.into()),
 			(true, Some(d)) => store.unlock_account_timed(account, account_pass.into(), Duration::from_secs(d.into())),

--- a/rpc/src/v1/tests/mocked/personal.rs
+++ b/rpc/src/v1/tests/mocked/personal.rs
@@ -303,7 +303,7 @@ fn ec_recover_invalid_signature() {
 }
 
 #[test]
-fn should_unlock_account_temporarily_if_allow_perm_is_disabled() {
+fn should_not_unlock_account_temporarily_if_allow_perm_is_disabled() {
 	let tester = setup();
 	let address = tester.accounts.new_account(&"password123".into()).unwrap();
 
@@ -318,10 +318,9 @@ fn should_unlock_account_temporarily_if_allow_perm_is_disabled() {
 		"id": 1
 	}"#;
 
-	let response = r#"{"jsonrpc":"2.0","result":true,"id":1}"#;
-	assert_eq!(tester.io.handle_request_sync(&request), Some(response.into()));
-	assert!(tester.accounts.sign(address, None, Default::default()).is_ok(), "Should unlock account.");
-	assert!(tester.accounts.sign(address, None, Default::default()).is_err(), "Should only sign once.");
+	let response = r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"Time-unlocking is not supported when permanent unlock is disabled.","data":"Use personal_sendTransaction or enable permanent unlocking, instead."},"id":1}"#;	
+	assert_eq!(tester.io.handle_request_sync(&request), Some(response.into()));	
+ 	assert!(tester.accounts.sign(address, None, Default::default()).is_err(), "Should not unlock account.");
 }
 
 #[test]

--- a/rpc/src/v1/tests/mocked/personal.rs
+++ b/rpc/src/v1/tests/mocked/personal.rs
@@ -317,10 +317,10 @@ fn should_not_unlock_account_temporarily_if_allow_perm_is_disabled() {
 		],
 		"id": 1
 	}"#;
-	let response = r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"Time-unlocking is not supported when permanent unlock is disabled.","data":"Use personal_sendTransaction or enable permanent unlocking, instead."},"id":1}"#;	
-	assert_eq!(tester.io.handle_request_sync(&request), Some(response.into()));	
-	
- 	assert!(tester.accounts.sign(address, None, Default::default()).is_err(), "Should not unlock account.");
+	let response = r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"Time-unlocking is not supported when permanent unlock is disabled.","data":"Use personal_sendTransaction or enable permanent unlocking, instead."},"id":1}"#;
+	assert_eq!(tester.io.handle_request_sync(&request), Some(response.into()));
+
+	assert!(tester.accounts.sign(address, None, Default::default()).is_err(), "Should not unlock account.");
 }
 
 #[test]

--- a/rpc/src/v1/tests/mocked/personal.rs
+++ b/rpc/src/v1/tests/mocked/personal.rs
@@ -317,9 +317,9 @@ fn should_not_unlock_account_temporarily_if_allow_perm_is_disabled() {
 		],
 		"id": 1
 	}"#;
-
 	let response = r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"Time-unlocking is not supported when permanent unlock is disabled.","data":"Use personal_sendTransaction or enable permanent unlocking, instead."},"id":1}"#;	
 	assert_eq!(tester.io.handle_request_sync(&request), Some(response.into()));	
+	
  	assert!(tester.accounts.sign(address, None, Default::default()).is_err(), "Should not unlock account.");
 }
 

--- a/rpc/src/v1/tests/mocked/personal.rs
+++ b/rpc/src/v1/tests/mocked/personal.rs
@@ -303,7 +303,7 @@ fn ec_recover_invalid_signature() {
 }
 
 #[test]
-fn should_unlock_not_account_temporarily_if_allow_perm_is_disabled() {
+fn should_unlock_account_temporarily_if_allow_perm_is_disabled() {
 	let tester = setup();
 	let address = tester.accounts.new_account(&"password123".into()).unwrap();
 
@@ -317,10 +317,11 @@ fn should_unlock_not_account_temporarily_if_allow_perm_is_disabled() {
 		],
 		"id": 1
 	}"#;
-	let response = r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"Time-unlocking is only supported in --geth compatibility mode.","data":"Restart your client with --geth flag or use personal_sendTransaction instead."},"id":1}"#;
-	assert_eq!(tester.io.handle_request_sync(&request), Some(response.into()));
 
-	assert!(tester.accounts.sign(address, None, Default::default()).is_err(), "Should not unlock account.");
+	let response = r#"{"jsonrpc":"2.0","result":true,"id":1}"#;
+	assert_eq!(tester.io.handle_request_sync(&request), Some(response.into()));
+	assert!(tester.accounts.sign(address, None, Default::default()).is_ok(), "Should unlock account.");
+	assert!(tester.accounts.sign(address, None, Default::default()).is_err(), "Should only sign once.");
 }
 
 #[test]


### PR DESCRIPTION
> If permanent unlocking is disabled (the default) then the duration argument will be **ignored**, and the account will be unlocked for a single signing.

Current behaviour throws an error.