### PR TITLE
Handle the case for contract creation on an empty but exist account with storage items

### DIFF
--- a/ethcore/res/ethereum/tests-issues/currents.json
+++ b/ethcore/res/ethereum/tests-issues/currents.json
@@ -1,42 +1,4 @@
-{ "block":
-	[
-		{
-			"reference": "None",
-			"comment": "This failing test is deemed skippable. Could not happen on a mainnet.",
-			"failing": "GeneralStateTest_stCreate2",
-			"subtests": ["RevertInCreateInInitCreate2_d0g0v0_Constantinople"]
-		},
-		{
-			"reference": "None",
-			"comment": "This failing test is deemed skippable. Could not happen on a mainnet.",
-			"failing": "GeneralStateTest_stRevertTest",
-			"subtests": ["RevertInCreateInInit_d0g0v0_Constantinople"]
-		}
-	],
-	"state":
-	[
-		{
-			"reference": "None",
-			"comment": "This failing test is deemed skippable. Could not happen on a mainnet.",
-			"failing": "stCreate2Test",
-			"subtests": {
-				"RevertInCreateInInitCreate2": {
-					"subnumbers": ["1"],
-					"chain": "Constantinople (test)"
-				}
-			}
-		},
-		{
-			"reference": "None",
-			"comment": "This failing test is deemed skippable. Could not happen on a mainnet.",
-			"failing": "stRevertTest",
-			"subtests": {
-				"RevertInCreateInInit": {
-					"subnumbers": ["1"],
-					"chain": "Constantinople (test)"
-				}
-			}
-		}
-		
-	]
+{
+	"block": [],
+	"state": []
 }

--- a/ethcore/src/externalities.rs
+++ b/ethcore/src/externalities.rs
@@ -119,7 +119,7 @@ impl<'a, T: 'a, V: 'a, B: 'a> Ext for Externalities<'a, T, V, B>
 		if self.state.is_base_storage_root_unchanged(&self.origin_info.address)? {
 			self.state.checkpoint_storage_at(0, &self.origin_info.address, key).map(|v| v.unwrap_or(H256::zero())).map_err(Into::into)
 		} else {
-			warn!(target: "externalities", "Detected existing account 0x{:x} where a forced contract creation happened.", self.origin_info.address);
+			warn!(target: "externalities", "Detected existing account {:#x} where a forced contract creation happened.", self.origin_info.address);
 			Ok(H256::zero())
 		}
 	}

--- a/ethcore/src/externalities.rs
+++ b/ethcore/src/externalities.rs
@@ -116,7 +116,11 @@ impl<'a, T: 'a, V: 'a, B: 'a> Ext for Externalities<'a, T, V, B>
 	where T: Tracer, V: VMTracer, B: StateBackend
 {
 	fn initial_storage_at(&self, key: &H256) -> vm::Result<H256> {
-		self.state.checkpoint_storage_at(0, &self.origin_info.address, key).map(|v| v.unwrap_or(H256::zero())).map_err(Into::into)
+		if self.state.is_base_storage_root_unchanged(&self.origin_info.address)? {
+			self.state.checkpoint_storage_at(0, &self.origin_info.address, key).map(|v| v.unwrap_or(H256::zero())).map_err(Into::into)
+		} else {
+			Ok(H256::zero())
+		}
 	}
 
 	fn storage_at(&self, key: &H256) -> vm::Result<H256> {

--- a/ethcore/src/externalities.rs
+++ b/ethcore/src/externalities.rs
@@ -119,6 +119,7 @@ impl<'a, T: 'a, V: 'a, B: 'a> Ext for Externalities<'a, T, V, B>
 		if self.state.is_base_storage_root_unchanged(&self.origin_info.address)? {
 			self.state.checkpoint_storage_at(0, &self.origin_info.address, key).map(|v| v.unwrap_or(H256::zero())).map_err(Into::into)
 		} else {
+			warn!(target: "externalities", "Detected existing account 0x{:x} where a forced contract creation happened.", self.origin_info.address);
 			Ok(H256::zero())
 		}
 	}

--- a/ethcore/src/state/account.rs
+++ b/ethcore/src/state/account.rs
@@ -451,6 +451,11 @@ impl Account {
 		}
 	}
 
+	/// Whether the base storage root of this account is unchanged.
+	pub fn is_base_storage_root_unchanged(&self) -> bool {
+		self.original_storage_cache.is_none()
+	}
+
 	/// Storage root where the account changes are based upon.
 	pub fn base_storage_root(&self) -> H256 {
 		self.storage_root

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -539,6 +539,13 @@ impl<B: Backend> State<B> {
 			|a| a.as_ref().map_or(self.account_start_nonce, |account| *account.nonce()))
 	}
 
+	/// Whether the base storage root of an account remains unchanged.
+	pub fn is_base_storage_root_unchanged(&self, a: &Address) -> TrieResult<bool> {
+		self.ensure_cached(a, RequireCache::None, true,
+			|a| a.as_ref().and_then(|account| account.base_storage_root() == account.original_storage_root))?
+			.unwrap_or(true)
+	}
+
 	/// Get the storage root of account `a`.
 	pub fn storage_root(&self, a: &Address) -> TrieResult<Option<H256>> {
 		self.ensure_cached(a, RequireCache::None, true,

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -541,9 +541,9 @@ impl<B: Backend> State<B> {
 
 	/// Whether the base storage root of an account remains unchanged.
 	pub fn is_base_storage_root_unchanged(&self, a: &Address) -> TrieResult<bool> {
-		self.ensure_cached(a, RequireCache::None, true,
-			|a| a.as_ref().and_then(|account| account.base_storage_root() == account.original_storage_root))?
-			.unwrap_or(true)
+		Ok(self.ensure_cached(a, RequireCache::None, true,
+			|a| a.as_ref().map(|account| account.is_base_storage_root_unchanged()))?
+			.unwrap_or(true))
 	}
 
 	/// Get the storage root of account `a`.


### PR DESCRIPTION
In spec it's technically possible to create empty account with existing storage items, thus break the net metering model. This PR creates `is_base_storage_root_unchanged` function in state. However, any **sane person** wouldn't do that so practically `is_base_storage_root_unchanged` should always be `true` with the only exception of tests.

For any items in the checkpoint, once we set `original_storage_cache`, we carry it on for any further items in the checkpoint. So we can check the newest items in the checkpoint list to determine whether there's any changes of the `base_storage_root` value. It works for current model because the value of `base_storage_root` can only ever be changed once.