### PR TITLE
Call private contract methods from another private contract (read-only) 

### DIFF
--- a/ethcore/private-tx/res/keys_acl.json
+++ b/ethcore/private-tx/res/keys_acl.json
@@ -1,0 +1,43 @@
+[
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name":"user",
+				"type":"address"
+			}
+		],
+		"name": "availableKeys",
+		"outputs": [
+			{
+				"name": "",
+				"type": "bytes32[]"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant":true,
+		"inputs": [
+			{
+				"name":"user",
+				"type":"address"
+			},
+			{
+				"name":"document",
+				"type":"bytes32"
+			}
+		],
+		"name":"checkPermissions",
+		"outputs": [
+			{
+				"name":"",
+				"type":"bool"
+			}
+		],
+		"payable":false,
+		"type":"function"
+	}
+]

--- a/ethcore/private-tx/src/encryptor.rs
+++ b/ethcore/private-tx/src/encryptor.rs
@@ -34,6 +34,7 @@ use bytes::{Bytes, ToPretty};
 use error::{Error, ErrorKind};
 use url::Url;
 use super::find_account_password;
+use super::key_server_keys::address_to_key;
 
 /// Initialization vector length.
 const INIT_VEC_LEN: usize = 16;
@@ -190,7 +191,7 @@ impl SecretStoreEncryptor {
 	fn sign_contract_address(&self, contract_address: &Address, accounts: &AccountProvider) -> Result<Signature, Error> {
 		let key_server_account = self.config.key_server_account.ok_or_else(|| ErrorKind::KeyServerAccountNotSet)?;
 		let password = find_account_password(&self.config.passwords, accounts, &key_server_account);
-		Ok(accounts.sign(key_server_account, password, key_server_keys::address_to_key(contract_address))?)
+		Ok(accounts.sign(key_server_account, password, address_to_key(contract_address))?)
 	}
 }
 

--- a/ethcore/private-tx/src/encryptor.rs
+++ b/ethcore/private-tx/src/encryptor.rs
@@ -34,7 +34,6 @@ use bytes::{Bytes, ToPretty};
 use error::{Error, ErrorKind};
 use url::Url;
 use super::find_account_password;
-use super::key_server_keys::address_to_key;
 
 /// Initialization vector length.
 const INIT_VEC_LEN: usize = 16;
@@ -191,7 +190,7 @@ impl SecretStoreEncryptor {
 	fn sign_contract_address(&self, contract_address: &Address, accounts: &AccountProvider) -> Result<Signature, Error> {
 		let key_server_account = self.config.key_server_account.ok_or_else(|| ErrorKind::KeyServerAccountNotSet)?;
 		let password = find_account_password(&self.config.passwords, accounts, &key_server_account);
-		Ok(accounts.sign(key_server_account, password, address_to_key(contract_address))?)
+		Ok(accounts.sign(key_server_account, password, key_server_keys::address_to_key(contract_address))?)
 	}
 }
 

--- a/ethcore/private-tx/src/encryptor.rs
+++ b/ethcore/private-tx/src/encryptor.rs
@@ -59,6 +59,11 @@ pub trait Encryptor: Send + Sync + 'static {
 		accounts: &AccountProvider,
 		cypher: &[u8],
 	) -> Result<Bytes, Error>;
+
+	/// Account, that is used for communication with key server
+	fn key_server_account(
+		&self,
+	) -> Option<Address>;
 }
 
 /// Configurtion for key server encryptor
@@ -248,6 +253,10 @@ impl Encryptor for SecretStoreEncryptor {
 			.map_err(|e| ErrorKind::Decrypt(e.to_string()))?;
 		Ok(plain_data)
 	}
+
+	fn key_server_account(&self) -> Option<Address> {
+		self.config.key_server_account
+	}
 }
 
 /// Dummy encryptor.
@@ -273,4 +282,9 @@ impl Encryptor for NoopEncryptor {
 	) -> Result<Bytes, Error> {
 		Ok(data.to_vec())
 	}
+
+	fn key_server_account(&self) -> Option<Address> {
+		None
+	}
+
 }

--- a/ethcore/private-tx/src/key_server_keys.rs
+++ b/ethcore/private-tx/src/key_server_keys.rs
@@ -1,0 +1,135 @@
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Wrapper around key server responsible for access keys processing.
+
+use std::sync::Arc;
+use parking_lot::RwLock;
+use ethereum_types::{H256, Address};
+use ethcore::client::{BlockId, CallContract, Client, RegistryInfo};
+use ethabi::FunctionOutputDecoder;
+
+const ACL_CHECKER_CONTRACT_REGISTRY_NAME: &'static str = "secretstore_acl_checker";
+
+use_contract!(keys_acl_contract, "res/keys_acl.json");
+
+/// Returns the address (of the contract), that corresponds to the key
+pub fn key_to_address(key: &H256) -> Address {
+	Address::from_slice(&key.to_vec()[..10])
+}
+
+/// Returns the key from the key server associated with the contract
+pub fn address_to_key(contract_address: &Address) -> H256 {
+	// Current solution uses contract address extended with 0 as id
+	let contract_address_extended: H256 = contract_address.into();
+
+	H256::from_slice(&contract_address_extended)
+}
+
+/// Trait for keys server keys provider.
+pub trait KeyProvider: Send + Sync + 'static {
+	/// Account, that is used for communication with key server
+	fn key_server_account(&self) -> Option<Address>;
+
+	/// List of keys available for the account
+	fn available_keys(&self, block: BlockId, account: &Address) -> Option<Vec<Address>>;
+
+	/// Update permissioning contract
+	fn update_acl_contract(&self);
+}
+
+/// Secret Store keys provider
+pub struct SecretStoreKeys {
+	client: Arc<Client>,
+	key_server_account: Option<Address>,
+	keys_acl_contract: RwLock<Option<Address>>,
+}
+
+impl SecretStoreKeys {
+	/// Create provider
+	pub fn new(client: Arc<Client>, key_server_account: Option<Address>) -> Self {
+		SecretStoreKeys {
+			client,
+			key_server_account,
+			keys_acl_contract: RwLock::new(None),
+		}
+	}
+
+	fn keys_to_addresses(&self, keys: Option<Vec<H256>>) -> Option<Vec<Address>> {
+		keys.map(|key_values| {
+			let mut addresses: Vec<Address> = Vec::new();
+			for key in key_values {
+				addresses.push(key_to_address(&key));
+			}
+			addresses
+		})
+	}
+}
+
+impl KeyProvider for SecretStoreKeys {
+	fn key_server_account(&self) -> Option<Address> {
+		self.key_server_account
+	}
+
+	fn available_keys(&self, block: BlockId, account: &Address) -> Option<Vec<Address>> {
+		match *self.keys_acl_contract.read() {
+			Some(acl_contract_address) => {
+				let (data, decoder) = keys_acl_contract::functions::available_keys::call(*account);
+				if let Ok(value) = self.client.call_contract(block, acl_contract_address, data) {
+					self.keys_to_addresses(decoder.decode(&value).ok())
+				} else {
+					None
+				}
+			}
+			None => None,
+		}
+	}
+
+	fn update_acl_contract(&self) {
+		let contract_address = self.client.registry_address(ACL_CHECKER_CONTRACT_REGISTRY_NAME.into(), BlockId::Latest);
+		let current_address = self.keys_acl_contract.read();
+
+		if *current_address != contract_address {
+			trace!(target: "privatetx", "Configuring for ACL checker contract from address {:?}",
+				contract_address);
+
+			let keys_acl_contract = self.keys_acl_contract.write();
+			keys_acl_contract.and(contract_address);
+		}
+	}
+}
+
+/// Dummy keys provider.
+#[derive(Default)]
+pub struct StoringKeyProvider {
+	available_keys: Option<Vec<Address>>,
+}
+
+impl StoringKeyProvider {
+	fn set_available_keys(&mut self, keys: &Vec<Address>) {
+		self.available_keys.replace(keys.to_vec());
+	}
+}
+
+impl KeyProvider for StoringKeyProvider {
+	fn key_server_account(&self) -> Option<Address> { None }
+
+	fn available_keys(&self, _block: BlockId, _account: &Address) -> Option<Vec<Address>> {
+		self.available_keys.clone()
+	}
+
+	fn update_acl_contract(&self) {}
+}

--- a/ethcore/private-tx/src/key_server_keys.rs
+++ b/ethcore/private-tx/src/key_server_keys.rs
@@ -113,14 +113,23 @@ impl KeyProvider for SecretStoreKeys {
 }
 
 /// Dummy keys provider.
-#[derive(Default)]
 pub struct StoringKeyProvider {
-	available_keys: Option<Vec<Address>>,
+	available_keys: RwLock<Option<Vec<Address>>>,
 }
 
 impl StoringKeyProvider {
-	fn set_available_keys(&mut self, keys: &Vec<Address>) {
-		self.available_keys.replace(keys.to_vec());
+	/// Store available keys
+	pub fn set_available_keys(&self, keys: &Vec<Address>) {
+		let mut current = self.available_keys.write();
+		current.replace(keys.to_vec());
+	}
+}
+
+impl Default for StoringKeyProvider {
+	fn default() -> Self {
+		StoringKeyProvider {
+			available_keys: RwLock::new(None),
+		}
 	}
 }
 
@@ -128,7 +137,7 @@ impl KeyProvider for StoringKeyProvider {
 	fn key_server_account(&self) -> Option<Address> { None }
 
 	fn available_keys(&self, _block: BlockId, _account: &Address) -> Option<Vec<Address>> {
-		self.available_keys.clone()
+		self.available_keys.read().clone()
 	}
 
 	fn update_acl_contract(&self) {}

--- a/ethcore/private-tx/src/key_server_keys.rs
+++ b/ethcore/private-tx/src/key_server_keys.rs
@@ -19,7 +19,8 @@
 use std::sync::Arc;
 use parking_lot::RwLock;
 use ethereum_types::{H256, Address};
-use ethcore::client::{BlockId, CallContract, RegistryInfo};
+use call_contract::{CallContract, RegistryInfo};
+use ethcore::client::BlockId;
 use ethabi::FunctionOutputDecoder;
 
 const ACL_CHECKER_CONTRACT_REGISTRY_NAME: &'static str = "secretstore_acl_checker";

--- a/ethcore/private-tx/src/key_server_keys.rs
+++ b/ethcore/private-tx/src/key_server_keys.rs
@@ -115,6 +115,7 @@ impl KeyProvider for SecretStoreKeys {
 /// Dummy keys provider.
 pub struct StoringKeyProvider {
 	available_keys: RwLock<Option<Vec<Address>>>,
+	key_server_account: Option<Address>,
 }
 
 impl StoringKeyProvider {
@@ -129,12 +130,15 @@ impl Default for StoringKeyProvider {
 	fn default() -> Self {
 		StoringKeyProvider {
 			available_keys: RwLock::new(None),
+			key_server_account: Some(Address::default()),
 		}
 	}
 }
 
 impl KeyProvider for StoringKeyProvider {
-	fn key_server_account(&self) -> Option<Address> { None }
+	fn key_server_account(&self) -> Option<Address> {
+		self.key_server_account
+	}
 
 	fn available_keys(&self, _block: BlockId, _account: &Address) -> Option<Vec<Address>> {
 		self.available_keys.read().clone()

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -85,7 +85,7 @@ use types::transaction::{SignedTransaction, Transaction, Action, UnverifiedTrans
 use ethcore::{contract_address as ethcore_contract_address};
 use ethcore::client::{
 	Client, ChainNotify, NewBlocks, ChainMessageType, ClientIoMessage, BlockId,
-	Call, BlockInfo, CallContract
+	Call, BlockInfo
 };
 use ethcore::account_provider::AccountProvider;
 use ethcore::miner::{self, Miner, MinerService, pool_client::NonceCache};

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -519,14 +519,12 @@ impl Provider where {
 		};
 
 		let engine = self.client.engine();
-		let contract_address = contract_address.or({
-			let sender = transaction.sender();
-			let nonce = state.nonce(&sender)?;
+		let sender = transaction.sender();
+		let nonce = state.nonce(&sender)?;
+		let contract_address = contract_address.unwrap_or_else(|| {
 			let (new_address, _) = ethcore_contract_address(engine.create_address_scheme(env_info.number), &sender, &nonce, &transaction.data);
-			Some(new_address)
+			new_address
 		});
-		let contract_address = contract_address.expect("Private contract address is non zero by this point, \
-			it was either non zero (if it's Action::Call) or created (for Action::Create); qed");
 		// Patch other available private contracts' states as well
 		// TODO: #10133 patch only required for the contract states
 		if let Some(key_server_account) = self.keys_provider.key_server_account() {

--- a/ethcore/private-tx/src/lib.rs
+++ b/ethcore/private-tx/src/lib.rs
@@ -527,6 +527,7 @@ impl Provider where {
 		});
 		let contract_address = contract_address.expect("Private contract address should be non zero by this moment; qed");
 		// Patch other available private contracts' states as well
+		// TODO: #10133 patch only required for the contract states
 		if let Some(key_server_account) = self.keys_provider.key_server_account() {
 			if let Some(available_contracts) = self.keys_provider.available_keys(block, &key_server_account) {
 				for private_contract in available_contracts {

--- a/ethcore/private-tx/tests/private_contract.rs
+++ b/ethcore/private-tx/tests/private_contract.rs
@@ -157,3 +157,126 @@ fn private_contract() {
 	let result = pm.private_call(BlockId::Latest, &query_tx).unwrap();
 	assert_eq!(result.output, "2a00000000000000000000000000000000000000000000000000000000000000".from_hex().unwrap());
 }
+
+#[test]
+fn call_other_private_contract() {
+	// This test verifies calls private contract methods from another one
+	// Two contract will be deployed
+	// The same contract A:
+	// contract Test1 {
+	//	bytes32 public x;
+	//	function setX(bytes32 _x) {
+	//		 x = _x;
+	//	}
+	// }
+	// And the following contract B:
+	// contract Deployed {
+	//	function setX(uint) {}
+	//	function x() returns (uint) {}
+	//}
+	// contract Existing {
+	//	Deployed dc;
+	//	function Existing(address t) {
+	//		dc = Deployed(t);
+	//	}
+	//	function getX() returns (uint) {
+	//		return dc.x();
+	//	}
+	//	function setX(uint val) {
+	//		dc.setX(val);
+	//	}
+	// }
+	ethcore_logger::init_log();
+
+	// Create client and provider
+	let client = generate_dummy_client(0);
+	let chain_id = client.signing_chain_id();
+	let key1 = KeyPair::from_secret(Secret::from("0000000000000000000000000000000000000000000000000000000000000011")).unwrap();
+	let _key2 = KeyPair::from_secret(Secret::from("0000000000000000000000000000000000000000000000000000000000000012")).unwrap();
+	let key3 = KeyPair::from_secret(Secret::from("0000000000000000000000000000000000000000000000000000000000000013")).unwrap();
+	let key4 = KeyPair::from_secret(Secret::from("0000000000000000000000000000000000000000000000000000000000000014")).unwrap();
+	let ap = Arc::new(AccountProvider::transient_provider());
+	ap.insert_account(key1.secret().clone(), &"".into()).unwrap();
+	ap.insert_account(key3.secret().clone(), &"".into()).unwrap();
+	ap.insert_account(key4.secret().clone(), &"".into()).unwrap();
+
+	let config = ProviderConfig{
+		validator_accounts: vec![key3.address(), key4.address()],
+		signer_account: None,
+		passwords: vec!["".into()],
+	};
+
+	let io = ethcore_io::IoChannel::disconnected();
+	let miner = Arc::new(Miner::new_for_tests(&::ethcore::spec::Spec::new_test(), None));
+	let private_keys = Arc::new(StoringKeyProvider::default());
+	let pm = Arc::new(Provider::new(
+			client.clone(),
+			miner,
+			ap.clone(),
+			Box::new(NoopEncryptor::default()),
+			config,
+			io,
+			private_keys.clone(),
+	));
+
+	// Deploy contract A
+	let (address_a, _) = contract_address(CreateContractAddress::FromSenderAndNonce, &key1.address(), &0.into(), &[]);
+	trace!("Creating private contract A");
+	let private_contract_a_test = "6060604052341561000f57600080fd5b60d88061001d6000396000f30060606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630c55699c146046578063bc64b76d14607457600080fd5b3415605057600080fd5b60566098565b60405180826000191660001916815260200191505060405180910390f35b3415607e57600080fd5b6096600480803560001916906020019091905050609e565b005b60005481565b8060008160001916905550505600a165627a7a723058206acbdf4b15ca4c2d43e1b1879b830451a34f1e9d02ff1f2f394d8d857e79d2080029".from_hex().unwrap();
+	let mut private_create_tx = Transaction::default();
+	private_create_tx.action = Action::Create;
+	private_create_tx.data = private_contract_a_test;
+	private_create_tx.gas = 200000.into();
+	let private_create_tx_signed = private_create_tx.sign(&key1.secret(), None);
+	let validators = vec![key3.address(), key4.address()];
+	let (public_tx, _) = pm.public_creation_transaction(BlockId::Latest, &private_create_tx_signed, &validators, 0.into()).unwrap();
+	let public_tx = public_tx.sign(&key1.secret(), chain_id);
+	trace!("Transaction created. Pushing block");
+	push_block_with_transactions(&client, &[public_tx]);
+
+	// Deploy contract B
+	let (address_b, _) = contract_address(CreateContractAddress::FromSenderAndNonce, &key1.address(), &1.into(), &[]);
+	trace!("Creating private contract B");
+	// Build constructor data
+	let private_contract_b_test = "6060604052341561000f57600080fd5b60d88061001d6000396000f30060606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630c55699c146046578063bc64b76d14607457600080fd5b3415605057600080fd5b60566098565b60405180826000191660001916815260200191505060405180910390f35b3415607e57600080fd5b6096600480803560001916906020019091905050609e565b005b60005481565b8060008160001916905550505600a165627a7a723058206acbdf4b15ca4c2d43e1b1879b830451a34f1e9d02ff1f2f394d8d857e79d2080029".from_hex().unwrap();
+	let mut private_create_tx = Transaction::default();
+	private_create_tx.action = Action::Create;
+	private_create_tx.data = private_contract_b_test;
+	private_create_tx.gas = 200000.into();
+	let private_create_tx_signed = private_create_tx.sign(&key1.secret(), None);
+	let (public_tx, _) = pm.public_creation_transaction(BlockId::Latest, &private_create_tx_signed, &validators, 0.into()).unwrap();
+	let public_tx = public_tx.sign(&key1.secret(), chain_id);
+	trace!("Transaction created. Pushing block");
+	push_block_with_transactions(&client, &[public_tx]);
+
+	// Let provider know, that it has access to both keys for A and B
+	private_keys.set_available_keys(&vec![address_a, address_b]);
+
+	// Call B.setx(42)
+	trace!("Modifying private state");
+	let mut private_tx = Transaction::default();
+	private_tx.action = Action::Call(address_b.clone());
+	private_tx.data = "bc64b76d2a00000000000000000000000000000000000000000000000000000000000000".from_hex().unwrap(); //setX(42)
+	private_tx.gas = 120000.into();
+	private_tx.nonce = 2.into();
+	let private_tx = private_tx.sign(&key1.secret(), None);
+	let private_contract_nonce = pm.get_contract_nonce(&address_b, BlockId::Latest).unwrap();
+	let private_state = pm.execute_private_transaction(BlockId::Latest, &private_tx).unwrap();
+	let nonced_state_hash = pm.calculate_state_hash(&private_state, private_contract_nonce);
+	let signatures: Vec<_> = [&key3, &key4].iter().map(|k|
+		Signature::from(::ethkey::sign(&k.secret(), &nonced_state_hash).unwrap().into_electrum())).collect();
+	let public_tx = pm.public_transaction(private_state, &private_tx, &signatures, 2.into(), 0.into()).unwrap();
+	let public_tx = public_tx.sign(&key1.secret(), chain_id);
+	push_block_with_transactions(&client, &[public_tx]);
+
+	// Call B.getX()
+	trace!("Querying private state");
+	let mut query_tx = Transaction::default();
+	query_tx.action = Action::Call(address_b.clone());
+	query_tx.data = "0c55699c".from_hex().unwrap();  // getX
+	query_tx.gas = 50000.into();
+	query_tx.nonce = 3.into();
+	let query_tx = query_tx.sign(&key1.secret(), chain_id);
+	let result = pm.private_call(BlockId::Latest, &query_tx).unwrap();
+	assert_eq!(&result.output[..], &("2a00000000000000000000000000000000000000000000000000000000000000".from_hex().unwrap()[..]));
+}

--- a/ethcore/private-tx/tests/private_contract.rs
+++ b/ethcore/private-tx/tests/private_contract.rs
@@ -42,7 +42,7 @@ use ethcore::test_helpers::{generate_dummy_client, push_block_with_transactions}
 use ethkey::{Secret, KeyPair, Signature};
 use hash::keccak;
 
-use ethcore_private_tx::{NoopEncryptor, Provider, ProviderConfig};
+use ethcore_private_tx::{NoopEncryptor, Provider, ProviderConfig, StoringKeyProvider};
 
 #[test]
 fn private_contract() {
@@ -67,6 +67,7 @@ fn private_contract() {
 
 	let io = ethcore_io::IoChannel::disconnected();
 	let miner = Arc::new(Miner::new_for_tests(&::ethcore::spec::Spec::new_test(), None));
+	let private_keys = Arc::new(StoringKeyProvider::default());
 	let pm = Arc::new(Provider::new(
 			client.clone(),
 			miner,
@@ -74,6 +75,7 @@ fn private_contract() {
 			Box::new(NoopEncryptor::default()),
 			config,
 			io,
+			private_keys,
 	));
 
 	let (address, _) = contract_address(CreateContractAddress::FromSenderAndNonce, &key1.address(), &0.into(), &[]);

--- a/ethcore/private-tx/tests/private_contract.rs
+++ b/ethcore/private-tx/tests/private_contract.rs
@@ -29,7 +29,7 @@ extern crate rustc_hex;
 extern crate log;
 
 use std::sync::Arc;
-use rustc_hex::FromHex;
+use rustc_hex::{FromHex, ToHex};
 
 use types::ids::BlockId;
 use types::transaction::{Transaction, Action};
@@ -182,11 +182,8 @@ fn call_other_private_contract() {
 	//	function getX() returns (uint) {
 	//		return dc.x();
 	//	}
-	//	function setX(uint val) {
-	//		dc.setX(val);
-	//	}
 	// }
-	ethcore_logger::init_log();
+	//ethcore_logger::init_log();
 
 	// Create client and provider
 	let client = generate_dummy_client(0);
@@ -223,39 +220,43 @@ fn call_other_private_contract() {
 	let (address_a, _) = contract_address(CreateContractAddress::FromSenderAndNonce, &key1.address(), &0.into(), &[]);
 	trace!("Creating private contract A");
 	let private_contract_a_test = "6060604052341561000f57600080fd5b60d88061001d6000396000f30060606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630c55699c146046578063bc64b76d14607457600080fd5b3415605057600080fd5b60566098565b60405180826000191660001916815260200191505060405180910390f35b3415607e57600080fd5b6096600480803560001916906020019091905050609e565b005b60005481565b8060008160001916905550505600a165627a7a723058206acbdf4b15ca4c2d43e1b1879b830451a34f1e9d02ff1f2f394d8d857e79d2080029".from_hex().unwrap();
-	let mut private_create_tx = Transaction::default();
-	private_create_tx.action = Action::Create;
-	private_create_tx.data = private_contract_a_test;
-	private_create_tx.gas = 200000.into();
-	let private_create_tx_signed = private_create_tx.sign(&key1.secret(), None);
+	let mut private_create_tx1 = Transaction::default();
+	private_create_tx1.action = Action::Create;
+	private_create_tx1.data = private_contract_a_test;
+	private_create_tx1.gas = 200000.into();
+	private_create_tx1.nonce = 0.into();
+	let private_create_tx_signed = private_create_tx1.sign(&key1.secret(), None);
 	let validators = vec![key3.address(), key4.address()];
-	let (public_tx, _) = pm.public_creation_transaction(BlockId::Latest, &private_create_tx_signed, &validators, 0.into()).unwrap();
-	let public_tx = public_tx.sign(&key1.secret(), chain_id);
+	let (public_tx1, _) = pm.public_creation_transaction(BlockId::Latest, &private_create_tx_signed, &validators, 0.into()).unwrap();
+	let public_tx1 = public_tx1.sign(&key1.secret(), chain_id);
 	trace!("Transaction created. Pushing block");
-	push_block_with_transactions(&client, &[public_tx]);
+	push_block_with_transactions(&client, &[public_tx1]);
 
 	// Deploy contract B
 	let (address_b, _) = contract_address(CreateContractAddress::FromSenderAndNonce, &key1.address(), &1.into(), &[]);
 	trace!("Creating private contract B");
 	// Build constructor data
-	let private_contract_b_test = "6060604052341561000f57600080fd5b60d88061001d6000396000f30060606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630c55699c146046578063bc64b76d14607457600080fd5b3415605057600080fd5b60566098565b60405180826000191660001916815260200191505060405180910390f35b3415607e57600080fd5b6096600480803560001916906020019091905050609e565b005b60005481565b8060008160001916905550505600a165627a7a723058206acbdf4b15ca4c2d43e1b1879b830451a34f1e9d02ff1f2f394d8d857e79d2080029".from_hex().unwrap();
-	let mut private_create_tx = Transaction::default();
-	private_create_tx.action = Action::Create;
-	private_create_tx.data = private_contract_b_test;
-	private_create_tx.gas = 200000.into();
-	let private_create_tx_signed = private_create_tx.sign(&key1.secret(), None);
-	let (public_tx, _) = pm.public_creation_transaction(BlockId::Latest, &private_create_tx_signed, &validators, 0.into()).unwrap();
-	let public_tx = public_tx.sign(&key1.secret(), chain_id);
+	let mut deploy_data = "6060604052341561000f57600080fd5b6040516020806101c583398101604052808051906020019091905050806000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505061014a8061007b6000396000f300606060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680635197c7aa14610046575b600080fd5b341561005157600080fd5b61005961006f565b6040518082815260200191505060405180910390f35b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16630c55699c6000604051602001526040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401602060405180830381600087803b15156100fe57600080fd5b6102c65a03f1151561010f57600080fd5b505050604051805190509050905600a165627a7a723058207f8994e02725b47d76ec73e5c54a338d27b306dd1c830276bff2d75fcd1a5c920029000000000000000000000000".to_string();
+	deploy_data.push_str(&address_a.to_vec().to_hex());
+	let private_contract_b_test = deploy_data.from_hex().unwrap();
+	let mut private_create_tx2 = Transaction::default();
+	private_create_tx2.action = Action::Create;
+	private_create_tx2.data = private_contract_b_test;
+	private_create_tx2.gas = 200000.into();
+	private_create_tx2.nonce = 1.into();
+	let private_create_tx_signed = private_create_tx2.sign(&key1.secret(), None);
+	let (public_tx2, _) = pm.public_creation_transaction(BlockId::Latest, &private_create_tx_signed, &validators, 0.into()).unwrap();
+	let public_tx2 = public_tx2.sign(&key1.secret(), chain_id);
 	trace!("Transaction created. Pushing block");
-	push_block_with_transactions(&client, &[public_tx]);
+	push_block_with_transactions(&client, &[public_tx2]);
 
 	// Let provider know, that it has access to both keys for A and B
 	private_keys.set_available_keys(&vec![address_a, address_b]);
 
-	// Call B.setx(42)
+	// Call A.setx(42)
 	trace!("Modifying private state");
 	let mut private_tx = Transaction::default();
-	private_tx.action = Action::Call(address_b.clone());
+	private_tx.action = Action::Call(address_a.clone());
 	private_tx.data = "bc64b76d2a00000000000000000000000000000000000000000000000000000000000000".from_hex().unwrap(); //setX(42)
 	private_tx.gas = 120000.into();
 	private_tx.nonce = 2.into();
@@ -273,7 +274,7 @@ fn call_other_private_contract() {
 	trace!("Querying private state");
 	let mut query_tx = Transaction::default();
 	query_tx.action = Action::Call(address_b.clone());
-	query_tx.data = "0c55699c".from_hex().unwrap();  // getX
+	query_tx.data = "5197c7aa".from_hex().unwrap();  // getX
 	query_tx.gas = 50000.into();
 	query_tx.nonce = 3.into();
 	let query_tx = query_tx.sign(&key1.secret(), chain_id);

--- a/ethcore/service/src/service.rs
+++ b/ethcore/service/src/service.rs
@@ -99,6 +99,7 @@ impl ClientService {
 		account_provider: Arc<AccountProvider>,
 		encryptor: Box<ethcore_private_tx::Encryptor>,
 		private_tx_conf: ethcore_private_tx::ProviderConfig,
+		private_encryptor_conf: ethcore_private_tx::EncryptorConfig,
 		) -> Result<ClientService, Error>
 	{
 		let io_service = IoService::<ClientIoMessage>::start()?;
@@ -127,13 +128,18 @@ impl ClientService {
 		};
 		let snapshot = Arc::new(SnapshotService::new(snapshot_params)?);
 
+		let private_keys = Arc::new(ethcore_private_tx::SecretStoreKeys::new(
+			client.clone(),
+			private_encryptor_conf.key_server_account,
+		));
 		let provider = Arc::new(ethcore_private_tx::Provider::new(
-				client.clone(),
-				miner,
-				account_provider,
-				encryptor,
-				private_tx_conf,
-				io_service.channel(),
+			client.clone(),
+			miner,
+			account_provider,
+			encryptor,
+			private_tx_conf,
+			io_service.channel(),
+			private_keys,
 		));
 		let private_tx = Arc::new(PrivateTxService::new(provider));
 
@@ -313,6 +319,7 @@ mod tests {
 			Arc::new(Miner::new_for_tests(&spec, None)),
 			Arc::new(AccountProvider::transient_provider()),
 			Box::new(ethcore_private_tx::NoopEncryptor),
+			Default::default(),
 			Default::default(),
 		);
 		assert!(service.is_ok());

--- a/ethcore/sync/src/tests/private.rs
+++ b/ethcore/sync/src/tests/private.rs
@@ -17,17 +17,17 @@
 use std::sync::Arc;
 use hash::keccak;
 use io::{IoHandler, IoChannel};
-use ethcore::client::{Client as EthcoreClient, BlockChainClient, BlockId, ClientIoMessage};
+use ethcore::client::{BlockChainClient, BlockId, ClientIoMessage};
 use ethcore::spec::Spec;
 use ethcore::miner::MinerService;
 use ethcore::CreateContractAddress;
-use types::transaction::{Transaction, Action, SignedTransaction};
+use types::transaction::{Transaction, Action};
 use ethcore::executive::{contract_address};
 use ethcore::test_helpers::{push_block_with_transactions};
-use ethcore_private_tx::{Provider, ProviderConfig, NoopEncryptor, Importer, SignedPrivateTransaction, StoringKeyProvider};
+use ethcore_private_tx::{Provider, ProviderConfig, NoopEncryptor, Importer, SignedPrivateTransaction, StoringKeyProvider	};
 use ethcore::account_provider::AccountProvider;
 use ethkey::{KeyPair};
-use tests::helpers::{TestNet, TestIoHandler, EthPeer};
+use tests::helpers::{TestNet, TestIoHandler};
 use rustc_hex::FromHex;
 use rlp::Rlp;
 use SyncConfig;
@@ -37,124 +37,87 @@ fn seal_spec() -> Spec {
 	Spec::load(&::std::env::temp_dir(), spec_data.as_bytes()).unwrap()
 }
 
-struct PrivateNetworkWithTwoNodes {
-	s0: KeyPair,
-	s1: KeyPair,
-	chain_id: Option<u64>,
-	net: TestNet<EthPeer<EthcoreClient>>,
-	pm0: Arc<Provider>,
-	pm1: Arc<Provider>,
-	client0: Arc<EthcoreClient>,
-	client1: Arc<EthcoreClient>,
-	io_handler0: Arc<IoHandler<ClientIoMessage>>,
-	io_handler1: Arc<IoHandler<ClientIoMessage>>,
-}
-
-impl PrivateNetworkWithTwoNodes {
-	fn create() -> Self {
-		// Setup two clients
-		let s0 = KeyPair::from_secret_slice(&keccak("1")).unwrap();
-		let s1 = KeyPair::from_secret_slice(&keccak("0")).unwrap();
-		let ap = Arc::new(AccountProvider::transient_provider());
-		ap.insert_account(s0.secret().clone(), &"".into()).unwrap();
-		ap.insert_account(s1.secret().clone(), &"".into()).unwrap();
-
-		let mut net = TestNet::with_spec_and_accounts(2, SyncConfig::default(), seal_spec, Some(ap.clone()));
-		let client0 = net.peer(0).chain.clone();
-		let client1 = net.peer(1).chain.clone();
-		let io_handler0: Arc<IoHandler<ClientIoMessage>> = Arc::new(TestIoHandler::new(net.peer(0).chain.clone()));
-		let io_handler1: Arc<IoHandler<ClientIoMessage>> = Arc::new(TestIoHandler::new(net.peer(1).chain.clone()));
-
-		net.peer(0).miner.set_author(s0.address(), Some("".into())).unwrap();
-		net.peer(1).miner.set_author(s1.address(), Some("".into())).unwrap();
-		net.peer(0).chain.engine().register_client(Arc::downgrade(&net.peer(0).chain) as _);
-		net.peer(1).chain.engine().register_client(Arc::downgrade(&net.peer(1).chain) as _);
-		net.peer(0).chain.set_io_channel(IoChannel::to_handler(Arc::downgrade(&io_handler0)));
-		net.peer(1).chain.set_io_channel(IoChannel::to_handler(Arc::downgrade(&io_handler1)));
-
-		let chain_id = client0.signing_chain_id();
-
-		// Exhange statuses
-		net.sync();
-
-		// Setup private providers
-		let validator_config = ProviderConfig{
-			validator_accounts: vec![s1.address()],
-			signer_account: None,
-			passwords: vec!["".into()],
-		};
-
-		let signer_config = ProviderConfig{
-			validator_accounts: Vec::new(),
-			signer_account: Some(s0.address()),
-			passwords: vec!["".into()],
-		};
-
-		let private_keys = Arc::new(StoringKeyProvider::default());
-
-		let pm0 = Arc::new(Provider::new(
-				client0.clone(),
-				net.peer(0).miner.clone(),
-				ap.clone(),
-				Box::new(NoopEncryptor::default()),
-				signer_config,
-				IoChannel::to_handler(Arc::downgrade(&io_handler0)),
-				private_keys.clone(),
-		));
-		pm0.add_notify(net.peers[0].clone());
-
-		let pm1 = Arc::new(Provider::new(
-				client1.clone(),
-				net.peer(1).miner.clone(),
-				ap.clone(),
-				Box::new(NoopEncryptor::default()),
-				validator_config,
-				IoChannel::to_handler(Arc::downgrade(&io_handler1)),
-				private_keys.clone(),
-		));
-		pm1.add_notify(net.peers[1].clone());
-
-		PrivateNetworkWithTwoNodes {
-			s0,
-			s1,
-			chain_id,
-			net,
-			pm0,
-			pm1,
-			client0,
-			client1,
-			io_handler0,
-			io_handler1,
-		}
-	}
-
-	fn deploy_transaction(&self, transaction: SignedTransaction) {
-		let tx_copy = transaction.clone();
-		push_block_with_transactions(&self.client0, &[transaction]);
-		push_block_with_transactions(&self.client1, &[tx_copy]);
-	}
-}
-
 #[test]
 fn send_private_transaction() {
-	::env_logger::try_init().ok();
+	// Setup two clients
+	let s0 = KeyPair::from_secret_slice(&keccak("1")).unwrap();
+	let s1 = KeyPair::from_secret_slice(&keccak("0")).unwrap();
+	let ap = Arc::new(AccountProvider::transient_provider());
+	ap.insert_account(s0.secret().clone(), &"".into()).unwrap();
+	ap.insert_account(s1.secret().clone(), &"".into()).unwrap();
 
-	let mut test_network = PrivateNetworkWithTwoNodes::create();
+	let mut net = TestNet::with_spec_and_accounts(2, SyncConfig::default(), seal_spec, Some(ap.clone()));
+	let client0 = net.peer(0).chain.clone();
+	let client1 = net.peer(1).chain.clone();
+	let io_handler0: Arc<IoHandler<ClientIoMessage>> = Arc::new(TestIoHandler::new(net.peer(0).chain.clone()));
+	let io_handler1: Arc<IoHandler<ClientIoMessage>> = Arc::new(TestIoHandler::new(net.peer(1).chain.clone()));
+
+	net.peer(0).miner.set_author(s0.address(), Some("".into())).unwrap();
+	net.peer(1).miner.set_author(s1.address(), Some("".into())).unwrap();
+	net.peer(0).chain.engine().register_client(Arc::downgrade(&net.peer(0).chain) as _);
+	net.peer(1).chain.engine().register_client(Arc::downgrade(&net.peer(1).chain) as _);
+	net.peer(0).chain.set_io_channel(IoChannel::to_handler(Arc::downgrade(&io_handler0)));
+	net.peer(1).chain.set_io_channel(IoChannel::to_handler(Arc::downgrade(&io_handler1)));
+
+	let (address, _) = contract_address(CreateContractAddress::FromSenderAndNonce, &s0.address(), &0.into(), &[]);
+	let chain_id = client0.signing_chain_id();
+
+	// Exhange statuses
+	net.sync();
+
+	// Setup private providers
+	let validator_config = ProviderConfig{
+		validator_accounts: vec![s1.address()],
+		signer_account: None,
+		passwords: vec!["".into()],
+	};
+
+	let signer_config = ProviderConfig{
+		validator_accounts: Vec::new(),
+		signer_account: Some(s0.address()),
+		passwords: vec!["".into()],
+	};
+
+	let private_keys = Arc::new(StoringKeyProvider::default());
+
+	let pm0 = Arc::new(Provider::new(
+			client0.clone(),
+			net.peer(0).miner.clone(),
+			ap.clone(),
+			Box::new(NoopEncryptor::default()),
+			signer_config,
+			IoChannel::to_handler(Arc::downgrade(&io_handler0)),
+			private_keys.clone(),
+	));
+	pm0.add_notify(net.peers[0].clone());
+
+	let pm1 = Arc::new(Provider::new(
+			client1.clone(),
+			net.peer(1).miner.clone(),
+			ap.clone(),
+			Box::new(NoopEncryptor::default()),
+			validator_config,
+			IoChannel::to_handler(Arc::downgrade(&io_handler1)),
+			private_keys.clone(),
+	));
+	pm1.add_notify(net.peers[1].clone());
 
 	// Create and deploy contract
-	let (address, _) = contract_address(CreateContractAddress::FromSenderAndNonce, &test_network.s0.address(), &0.into(), &[]);
 	let private_contract_test = "6060604052341561000f57600080fd5b60d88061001d6000396000f30060606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630c55699c146046578063bc64b76d14607457600080fd5b3415605057600080fd5b60566098565b60405180826000191660001916815260200191505060405180910390f35b3415607e57600080fd5b6096600480803560001916906020019091905050609e565b005b60005481565b8060008160001916905550505600a165627a7a723058206acbdf4b15ca4c2d43e1b1879b830451a34f1e9d02ff1f2f394d8d857e79d2080029".from_hex().unwrap();
 	let mut private_create_tx = Transaction::default();
 	private_create_tx.action = Action::Create;
 	private_create_tx.data = private_contract_test;
 	private_create_tx.gas = 200000.into();
-	let private_create_tx_signed = private_create_tx.sign(&test_network.s0.secret(), None);
-	let validators = vec![test_network.s1.address()];
-	let (public_tx, _) = test_network.pm0.public_creation_transaction(BlockId::Latest, &private_create_tx_signed, &validators, 0.into()).unwrap();
-	let public_tx = public_tx.sign(&test_network.s0.secret(), test_network.chain_id);
+	let private_create_tx_signed = private_create_tx.sign(&s0.secret(), None);
+	let validators = vec![s1.address()];
+	let (public_tx, _) = pm0.public_creation_transaction(BlockId::Latest, &private_create_tx_signed, &validators, 0.into()).unwrap();
+	let public_tx = public_tx.sign(&s0.secret(), chain_id);
 
-	test_network.deploy_transaction(public_tx);
-	test_network.net.sync();
+	let public_tx_copy = public_tx.clone();
+	push_block_with_transactions(&client0, &[public_tx]);
+	push_block_with_transactions(&client1, &[public_tx_copy]);
+
+	net.sync();
 
 	//Create private transaction for modifying state
 	let mut private_tx = Transaction::default();
@@ -162,32 +125,32 @@ fn send_private_transaction() {
 	private_tx.data = "bc64b76d2a00000000000000000000000000000000000000000000000000000000000000".from_hex().unwrap(); //setX(42)
 	private_tx.gas = 120000.into();
 	private_tx.nonce = 1.into();
-	let private_tx = private_tx.sign(&test_network.s0.secret(), None);
-	assert!(test_network.pm0.create_private_transaction(private_tx).is_ok());
+	let private_tx = private_tx.sign(&s0.secret(), None);
+	assert!(pm0.create_private_transaction(private_tx).is_ok());
 
 	//send private transaction message to validator
-	test_network.net.sync();
+	net.sync();
 
-	let validator_handler = test_network.net.peer(1).private_tx_handler.clone();
+	let validator_handler = net.peer(1).private_tx_handler.clone();
 	let received_private_transactions = validator_handler.txs.lock().clone();
 	assert_eq!(received_private_transactions.len(), 1);
 
 	//process received private transaction message
 	let private_transaction = received_private_transactions[0].clone();
-	assert!(test_network.pm1.import_private_transaction(&private_transaction).is_ok());
+	assert!(pm1.import_private_transaction(&private_transaction).is_ok());
 
 	//send signed response
-	test_network.net.sync();
+	net.sync();
 
-	let sender_handler = test_network.net.peer(0).private_tx_handler.clone();
+	let sender_handler = net.peer(0).private_tx_handler.clone();
 	let received_signed_private_transactions = sender_handler.signed_txs.lock().clone();
 	assert_eq!(received_signed_private_transactions.len(), 1);
 
 	//process signed response
 	let signed_private_transaction = received_signed_private_transactions[0].clone();
-	assert!(test_network.pm0.import_signed_private_transaction(&signed_private_transaction).is_ok());
+	assert!(pm0.import_signed_private_transaction(&signed_private_transaction).is_ok());
 	let signature: SignedPrivateTransaction = Rlp::new(&signed_private_transaction).as_val().unwrap();
-	assert!(test_network.pm0.process_signature(&signature).is_ok());
-	let local_transactions = test_network.net.peer(0).miner.local_transactions();
+	assert!(pm0.process_signature(&signature).is_ok());
+	let local_transactions = net.peer(0).miner.local_transactions();
 	assert_eq!(local_transactions.len(), 1);
 }

--- a/ethcore/sync/src/tests/private.rs
+++ b/ethcore/sync/src/tests/private.rs
@@ -17,17 +17,17 @@
 use std::sync::Arc;
 use hash::keccak;
 use io::{IoHandler, IoChannel};
-use ethcore::client::{BlockChainClient, BlockId, ClientIoMessage};
+use ethcore::client::{Client as EthcoreClient, BlockChainClient, BlockId, ClientIoMessage};
 use ethcore::spec::Spec;
 use ethcore::miner::MinerService;
 use ethcore::CreateContractAddress;
-use types::transaction::{Transaction, Action};
+use types::transaction::{Transaction, Action, SignedTransaction};
 use ethcore::executive::{contract_address};
 use ethcore::test_helpers::{push_block_with_transactions};
-use ethcore_private_tx::{Provider, ProviderConfig, NoopEncryptor, Importer, SignedPrivateTransaction, StoringKeyProvider	};
+use ethcore_private_tx::{Provider, ProviderConfig, NoopEncryptor, Importer, SignedPrivateTransaction, StoringKeyProvider};
 use ethcore::account_provider::AccountProvider;
 use ethkey::{KeyPair};
-use tests::helpers::{TestNet, TestIoHandler};
+use tests::helpers::{TestNet, TestIoHandler, EthPeer};
 use rustc_hex::FromHex;
 use rlp::Rlp;
 use SyncConfig;
@@ -37,87 +37,124 @@ fn seal_spec() -> Spec {
 	Spec::load(&::std::env::temp_dir(), spec_data.as_bytes()).unwrap()
 }
 
+struct PrivateNetworkWithTwoNodes {
+	s0: KeyPair,
+	s1: KeyPair,
+	chain_id: Option<u64>,
+	net: TestNet<EthPeer<EthcoreClient>>,
+	pm0: Arc<Provider>,
+	pm1: Arc<Provider>,
+	client0: Arc<EthcoreClient>,
+	client1: Arc<EthcoreClient>,
+	io_handler0: Arc<IoHandler<ClientIoMessage>>,
+	io_handler1: Arc<IoHandler<ClientIoMessage>>,
+}
+
+impl PrivateNetworkWithTwoNodes {
+	fn create() -> Self {
+		// Setup two clients
+		let s0 = KeyPair::from_secret_slice(&keccak("1")).unwrap();
+		let s1 = KeyPair::from_secret_slice(&keccak("0")).unwrap();
+		let ap = Arc::new(AccountProvider::transient_provider());
+		ap.insert_account(s0.secret().clone(), &"".into()).unwrap();
+		ap.insert_account(s1.secret().clone(), &"".into()).unwrap();
+
+		let mut net = TestNet::with_spec_and_accounts(2, SyncConfig::default(), seal_spec, Some(ap.clone()));
+		let client0 = net.peer(0).chain.clone();
+		let client1 = net.peer(1).chain.clone();
+		let io_handler0: Arc<IoHandler<ClientIoMessage>> = Arc::new(TestIoHandler::new(net.peer(0).chain.clone()));
+		let io_handler1: Arc<IoHandler<ClientIoMessage>> = Arc::new(TestIoHandler::new(net.peer(1).chain.clone()));
+
+		net.peer(0).miner.set_author(s0.address(), Some("".into())).unwrap();
+		net.peer(1).miner.set_author(s1.address(), Some("".into())).unwrap();
+		net.peer(0).chain.engine().register_client(Arc::downgrade(&net.peer(0).chain) as _);
+		net.peer(1).chain.engine().register_client(Arc::downgrade(&net.peer(1).chain) as _);
+		net.peer(0).chain.set_io_channel(IoChannel::to_handler(Arc::downgrade(&io_handler0)));
+		net.peer(1).chain.set_io_channel(IoChannel::to_handler(Arc::downgrade(&io_handler1)));
+
+		let chain_id = client0.signing_chain_id();
+
+		// Exhange statuses
+		net.sync();
+
+		// Setup private providers
+		let validator_config = ProviderConfig{
+			validator_accounts: vec![s1.address()],
+			signer_account: None,
+			passwords: vec!["".into()],
+		};
+
+		let signer_config = ProviderConfig{
+			validator_accounts: Vec::new(),
+			signer_account: Some(s0.address()),
+			passwords: vec!["".into()],
+		};
+
+		let private_keys = Arc::new(StoringKeyProvider::default());
+
+		let pm0 = Arc::new(Provider::new(
+				client0.clone(),
+				net.peer(0).miner.clone(),
+				ap.clone(),
+				Box::new(NoopEncryptor::default()),
+				signer_config,
+				IoChannel::to_handler(Arc::downgrade(&io_handler0)),
+				private_keys.clone(),
+		));
+		pm0.add_notify(net.peers[0].clone());
+
+		let pm1 = Arc::new(Provider::new(
+				client1.clone(),
+				net.peer(1).miner.clone(),
+				ap.clone(),
+				Box::new(NoopEncryptor::default()),
+				validator_config,
+				IoChannel::to_handler(Arc::downgrade(&io_handler1)),
+				private_keys.clone(),
+		));
+		pm1.add_notify(net.peers[1].clone());
+
+		PrivateNetworkWithTwoNodes {
+			s0,
+			s1,
+			chain_id,
+			net,
+			pm0,
+			pm1,
+			client0,
+			client1,
+			io_handler0,
+			io_handler1,
+		}
+	}
+
+	fn deploy_transaction(&self, transaction: SignedTransaction) {
+		let tx_copy = transaction.clone();
+		push_block_with_transactions(&self.client0, &[transaction]);
+		push_block_with_transactions(&self.client1, &[tx_copy]);
+	}
+}
+
 #[test]
 fn send_private_transaction() {
-	// Setup two clients
-	let s0 = KeyPair::from_secret_slice(&keccak("1")).unwrap();
-	let s1 = KeyPair::from_secret_slice(&keccak("0")).unwrap();
-	let ap = Arc::new(AccountProvider::transient_provider());
-	ap.insert_account(s0.secret().clone(), &"".into()).unwrap();
-	ap.insert_account(s1.secret().clone(), &"".into()).unwrap();
+	::env_logger::try_init().ok();
 
-	let mut net = TestNet::with_spec_and_accounts(2, SyncConfig::default(), seal_spec, Some(ap.clone()));
-	let client0 = net.peer(0).chain.clone();
-	let client1 = net.peer(1).chain.clone();
-	let io_handler0: Arc<IoHandler<ClientIoMessage>> = Arc::new(TestIoHandler::new(net.peer(0).chain.clone()));
-	let io_handler1: Arc<IoHandler<ClientIoMessage>> = Arc::new(TestIoHandler::new(net.peer(1).chain.clone()));
-
-	net.peer(0).miner.set_author(s0.address(), Some("".into())).unwrap();
-	net.peer(1).miner.set_author(s1.address(), Some("".into())).unwrap();
-	net.peer(0).chain.engine().register_client(Arc::downgrade(&net.peer(0).chain) as _);
-	net.peer(1).chain.engine().register_client(Arc::downgrade(&net.peer(1).chain) as _);
-	net.peer(0).chain.set_io_channel(IoChannel::to_handler(Arc::downgrade(&io_handler0)));
-	net.peer(1).chain.set_io_channel(IoChannel::to_handler(Arc::downgrade(&io_handler1)));
-
-	let (address, _) = contract_address(CreateContractAddress::FromSenderAndNonce, &s0.address(), &0.into(), &[]);
-	let chain_id = client0.signing_chain_id();
-
-	// Exhange statuses
-	net.sync();
-
-	// Setup private providers
-	let validator_config = ProviderConfig{
-		validator_accounts: vec![s1.address()],
-		signer_account: None,
-		passwords: vec!["".into()],
-	};
-
-	let signer_config = ProviderConfig{
-		validator_accounts: Vec::new(),
-		signer_account: Some(s0.address()),
-		passwords: vec!["".into()],
-	};
-
-	let private_keys = Arc::new(StoringKeyProvider::default());
-
-	let pm0 = Arc::new(Provider::new(
-			client0.clone(),
-			net.peer(0).miner.clone(),
-			ap.clone(),
-			Box::new(NoopEncryptor::default()),
-			signer_config,
-			IoChannel::to_handler(Arc::downgrade(&io_handler0)),
-			private_keys.clone(),
-	));
-	pm0.add_notify(net.peers[0].clone());
-
-	let pm1 = Arc::new(Provider::new(
-			client1.clone(),
-			net.peer(1).miner.clone(),
-			ap.clone(),
-			Box::new(NoopEncryptor::default()),
-			validator_config,
-			IoChannel::to_handler(Arc::downgrade(&io_handler1)),
-			private_keys.clone(),
-	));
-	pm1.add_notify(net.peers[1].clone());
+	let mut test_network = PrivateNetworkWithTwoNodes::create();
 
 	// Create and deploy contract
+	let (address, _) = contract_address(CreateContractAddress::FromSenderAndNonce, &test_network.s0.address(), &0.into(), &[]);
 	let private_contract_test = "6060604052341561000f57600080fd5b60d88061001d6000396000f30060606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630c55699c146046578063bc64b76d14607457600080fd5b3415605057600080fd5b60566098565b60405180826000191660001916815260200191505060405180910390f35b3415607e57600080fd5b6096600480803560001916906020019091905050609e565b005b60005481565b8060008160001916905550505600a165627a7a723058206acbdf4b15ca4c2d43e1b1879b830451a34f1e9d02ff1f2f394d8d857e79d2080029".from_hex().unwrap();
 	let mut private_create_tx = Transaction::default();
 	private_create_tx.action = Action::Create;
 	private_create_tx.data = private_contract_test;
 	private_create_tx.gas = 200000.into();
-	let private_create_tx_signed = private_create_tx.sign(&s0.secret(), None);
-	let validators = vec![s1.address()];
-	let (public_tx, _) = pm0.public_creation_transaction(BlockId::Latest, &private_create_tx_signed, &validators, 0.into()).unwrap();
-	let public_tx = public_tx.sign(&s0.secret(), chain_id);
+	let private_create_tx_signed = private_create_tx.sign(&test_network.s0.secret(), None);
+	let validators = vec![test_network.s1.address()];
+	let (public_tx, _) = test_network.pm0.public_creation_transaction(BlockId::Latest, &private_create_tx_signed, &validators, 0.into()).unwrap();
+	let public_tx = public_tx.sign(&test_network.s0.secret(), test_network.chain_id);
 
-	let public_tx_copy = public_tx.clone();
-	push_block_with_transactions(&client0, &[public_tx]);
-	push_block_with_transactions(&client1, &[public_tx_copy]);
-
-	net.sync();
+	test_network.deploy_transaction(public_tx);
+	test_network.net.sync();
 
 	//Create private transaction for modifying state
 	let mut private_tx = Transaction::default();
@@ -125,32 +162,32 @@ fn send_private_transaction() {
 	private_tx.data = "bc64b76d2a00000000000000000000000000000000000000000000000000000000000000".from_hex().unwrap(); //setX(42)
 	private_tx.gas = 120000.into();
 	private_tx.nonce = 1.into();
-	let private_tx = private_tx.sign(&s0.secret(), None);
-	assert!(pm0.create_private_transaction(private_tx).is_ok());
+	let private_tx = private_tx.sign(&test_network.s0.secret(), None);
+	assert!(test_network.pm0.create_private_transaction(private_tx).is_ok());
 
 	//send private transaction message to validator
-	net.sync();
+	test_network.net.sync();
 
-	let validator_handler = net.peer(1).private_tx_handler.clone();
+	let validator_handler = test_network.net.peer(1).private_tx_handler.clone();
 	let received_private_transactions = validator_handler.txs.lock().clone();
 	assert_eq!(received_private_transactions.len(), 1);
 
 	//process received private transaction message
 	let private_transaction = received_private_transactions[0].clone();
-	assert!(pm1.import_private_transaction(&private_transaction).is_ok());
+	assert!(test_network.pm1.import_private_transaction(&private_transaction).is_ok());
 
 	//send signed response
-	net.sync();
+	test_network.net.sync();
 
-	let sender_handler = net.peer(0).private_tx_handler.clone();
+	let sender_handler = test_network.net.peer(0).private_tx_handler.clone();
 	let received_signed_private_transactions = sender_handler.signed_txs.lock().clone();
 	assert_eq!(received_signed_private_transactions.len(), 1);
 
 	//process signed response
 	let signed_private_transaction = received_signed_private_transactions[0].clone();
-	assert!(pm0.import_signed_private_transaction(&signed_private_transaction).is_ok());
+	assert!(test_network.pm0.import_signed_private_transaction(&signed_private_transaction).is_ok());
 	let signature: SignedPrivateTransaction = Rlp::new(&signed_private_transaction).as_val().unwrap();
-	assert!(pm0.process_signature(&signature).is_ok());
-	let local_transactions = net.peer(0).miner.local_transactions();
+	assert!(test_network.pm0.process_signature(&signature).is_ok());
+	let local_transactions = test_network.net.peer(0).miner.local_transactions();
 	assert_eq!(local_transactions.len(), 1);
 }

--- a/ethcore/sync/src/tests/private.rs
+++ b/ethcore/sync/src/tests/private.rs
@@ -24,7 +24,7 @@ use ethcore::CreateContractAddress;
 use types::transaction::{Transaction, Action};
 use ethcore::executive::{contract_address};
 use ethcore::test_helpers::{push_block_with_transactions};
-use ethcore_private_tx::{Provider, ProviderConfig, NoopEncryptor, Importer, SignedPrivateTransaction};
+use ethcore_private_tx::{Provider, ProviderConfig, NoopEncryptor, Importer, SignedPrivateTransaction, StoringKeyProvider	};
 use ethcore::account_provider::AccountProvider;
 use ethkey::{KeyPair};
 use tests::helpers::{TestNet, TestIoHandler};
@@ -78,6 +78,8 @@ fn send_private_transaction() {
 		passwords: vec!["".into()],
 	};
 
+	let private_keys = Arc::new(StoringKeyProvider::default());
+
 	let pm0 = Arc::new(Provider::new(
 			client0.clone(),
 			net.peer(0).miner.clone(),
@@ -85,6 +87,7 @@ fn send_private_transaction() {
 			Box::new(NoopEncryptor::default()),
 			signer_config,
 			IoChannel::to_handler(Arc::downgrade(&io_handler0)),
+			private_keys.clone(),
 	));
 	pm0.add_notify(net.peers[0].clone());
 
@@ -95,6 +98,7 @@ fn send_private_transaction() {
 			Box::new(NoopEncryptor::default()),
 			validator_config,
 			IoChannel::to_handler(Arc::downgrade(&io_handler1)),
+			private_keys.clone(),
 	));
 	pm1.add_notify(net.peers[1].clone());
 

--- a/ethcore/sync/src/tests/private.rs
+++ b/ethcore/sync/src/tests/private.rs
@@ -24,7 +24,7 @@ use ethcore::CreateContractAddress;
 use types::transaction::{Transaction, Action};
 use ethcore::executive::{contract_address};
 use ethcore::test_helpers::{push_block_with_transactions};
-use ethcore_private_tx::{Provider, ProviderConfig, NoopEncryptor, Importer, SignedPrivateTransaction, StoringKeyProvider	};
+use ethcore_private_tx::{Provider, ProviderConfig, NoopEncryptor, Importer, SignedPrivateTransaction, StoringKeyProvider};
 use ethcore::account_provider::AccountProvider;
 use ethkey::{KeyPair};
 use tests::helpers::{TestNet, TestIoHandler};

--- a/parity/blockchain.rs
+++ b/parity/blockchain.rs
@@ -398,6 +398,7 @@ fn execute_import(cmd: ImportBlockchain) -> Result<(), String> {
 		Arc::new(AccountProvider::transient_provider()),
 		Box::new(ethcore_private_tx::NoopEncryptor),
 		Default::default(),
+		Default::default(),
 	).map_err(|e| format!("Client service error: {:?}", e))?;
 
 	// free up the spec in memory.
@@ -588,6 +589,7 @@ fn start_client(
 		Arc::new(Miner::new_for_tests(&spec, None)),
 		Arc::new(AccountProvider::transient_provider()),
 		Box::new(ethcore_private_tx::NoopEncryptor),
+		Default::default(),
 		Default::default(),
 	).map_err(|e| format!("Client service error: {:?}", e))?;
 

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -582,8 +582,9 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 		&cmd.dirs.ipc_path(),
 		miner.clone(),
 		account_provider.clone(),
-		Box::new(SecretStoreEncryptor::new(cmd.private_encryptor_conf, fetch.clone()).map_err(|e| e.to_string())?),
+		Box::new(SecretStoreEncryptor::new(cmd.private_encryptor_conf.clone(), fetch.clone()).map_err(|e| e.to_string())?),
 		cmd.private_provider_conf,
+		cmd.private_encryptor_conf,
 	).map_err(|e| format!("Client service error: {:?}", e))?;
 
 	let connection_filter_address = spec.params().node_permission_contract;

--- a/parity/snapshot.rs
+++ b/parity/snapshot.rs
@@ -202,6 +202,7 @@ impl SnapshotCommand {
 			Arc::new(AccountProvider::transient_provider()),
 			Box::new(ethcore_private_tx::NoopEncryptor),
 			Default::default(),
+			Default::default(),
 		).map_err(|e| format!("Client service error: {:?}", e))?;
 
 		Ok(service)

--- a/rpc/src/v1/impls/private.rs
+++ b/rpc/src/v1/impls/private.rs
@@ -94,7 +94,7 @@ impl Private for PrivateClient {
 			transaction: request,
 			receipt: PrivateTransactionReceipt {
 				transaction_hash: tx_hash.into(),
-				contract_address: contract_address.map(|address| address.into()),
+				contract_address: contract_address.into(),
 				status_code: 0,
 			}
 		})

--- a/rpc/src/v1/types/private_receipt.rs
+++ b/rpc/src/v1/types/private_receipt.rs
@@ -24,7 +24,7 @@ pub struct PrivateTransactionReceipt {
 	/// Transaction Hash
 	pub transaction_hash: H256,
 	/// Private contract address
-	pub contract_address: Option<H160>,
+	pub contract_address: H160,
 	/// Status code
 	#[serde(rename = "status")]
 	pub status_code: u8,
@@ -34,7 +34,7 @@ impl From<EthPrivateReceipt> for PrivateTransactionReceipt {
 	fn from(r: EthPrivateReceipt) -> Self {
 		PrivateTransactionReceipt {
 			transaction_hash: r.hash.into(),
-			contract_address: r.contract_address.map(Into::into),
+			contract_address: r.contract_address.into(),
 			status_code: r.status_code.into(),
 		}
 	}


### PR DESCRIPTION
This PR adds possibility to make calls of private contract methods from another private contract (with condition, that caller has access to the keys for both private contracts).
In order to achieve this, ABI of permissioning contract of Secret Store was extended with availableKeys method, that returns all keys, available for the account.
The further solution is rather straightforward: after patching the state for the current private contract, we also patch states for all private contracts, available for the node, and execute the private transaction on this state.
Some details of the solution:
- Only read-only calls are supported. Client can modify the state of other private contracts during execution of the private transaction, but these changes won't be saved
- All code, responsible for work with Secret Store keys, moved to the separate module

Closes #9199 