### PR TITLE
Revert "Add --frozen when running cargo (#10081)"

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -35,9 +35,9 @@ validate () {
   if [ "$VALIDATE" -eq "1" ]
   then
     echo "________Validate build________"
-    time cargo check $@ --frozen --no-default-features
-    time cargo check $@ --frozen --manifest-path util/io/Cargo.toml --no-default-features
-    time cargo check $@ --frozen --manifest-path util/io/Cargo.toml --features "mio"
+    time cargo check $@ --no-default-features
+    time cargo check $@ --manifest-path util/io/Cargo.toml --no-default-features
+    time cargo check $@ --manifest-path util/io/Cargo.toml --features "mio"
 
     # Validate chainspecs
     echo "________Validate chainspecs________"
@@ -71,7 +71,7 @@ cpp_test () {
 cargo_test () {
   echo "________Running Parity Full Test Suite________"
   git submodule update --init --recursive
-  time cargo test $OPTIONS --features "$FEATURES" --frozen --all $@ -- --test-threads $THREADS
+  time cargo test $OPTIONS --features "$FEATURES" --all $@ -- --test-threads $THREADS
 }
 
 

--- a/test.sh
+++ b/test.sh
@@ -39,6 +39,13 @@ validate () {
     time cargo check $@ --manifest-path util/io/Cargo.toml --no-default-features
     time cargo check $@ --manifest-path util/io/Cargo.toml --features "mio"
 
+    MODIFIED=$(git ls-files -m | grep Cargo.lock | wc -l)
+    if [ "$MODIFIED" -eq "1" ]
+    then
+      echo "Detected Cargo.lock modification. Exitting."
+      exit 1
+    fi
+
     # Validate chainspecs
     echo "________Validate chainspecs________"
     time ./scripts/validate_chainspecs.sh


### PR DESCRIPTION
This reverts commit c90e279ab5c76787dccb8da35b90aacab33aca6e.

Seems that `--frozen` is more about making network requests than modifying `Cargo.lock`.
It works correctly when all required dependencies are in cargo cache, but fails otherwise.

Added a simple detection of `Cargo.lock` modification based on `git ls-files`

