### PR TITLE
Allow sealing when bugfix hardforks activate later than block 0

### DIFF
--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -1095,13 +1095,12 @@ impl miner::MinerService for Miner {
 			None => return,
 		};
 
-		// refuse to seal the first block of the chain if it contains hard forks
+		// warn if the first block of the chain contains hard forks
 		// which should be on by default.
 		if block.block().header().number() == 1 {
 			if let Some(name) = self.engine.params().nonzero_bugfix_hard_fork() {
 				warn!("Your chain specification contains one or more hard forks which are required to be \
 					   on by default. Please remove these forks and start your chain again: {}.", name);
-				return;
 			}
 		}
 

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -1099,7 +1099,7 @@ impl miner::MinerService for Miner {
 		// which should be on by default.
 		if block.block().header().number() == 1 {
 			if let Some(name) = self.engine.params().nonzero_bugfix_hard_fork() {
-				warn!("Your chain specification contains one or more hard forks which are required to be \
+				trace!(target: "miner", "Your chain specification contains one or more hard forks which are required to be \
 					   on by default. Please remove these forks and start your chain again: {}.", name);
 			}
 		}


### PR DESCRIPTION
Some networks (like Rinkeby) rely on this.