### PR TITLE
Skip locking in statedb for non-canon blocks

### DIFF
--- a/ethcore/src/state_db.rs
+++ b/ethcore/src/state_db.rs
@@ -379,14 +379,7 @@ impl StateDB {
 
 	/// Check if the account can be returned from cache by matching current block parent hash against canonical
 	/// state and filtering out account modified in later blocks.
-	fn is_allowed(addr: &Address, parent_hash: &Option<H256>, modifications: &VecDeque<BlockChanges>) -> bool {
-		let mut parent = match *parent_hash {
-			None => {
-				trace!("Cache lookup skipped for {:?}: no parent hash", addr);
-				return false;
-			}
-			Some(ref parent) => parent,
-		};
+	fn is_allowed(addr: &Address, parent_hash: &H256, modifications: &VecDeque<BlockChanges>) -> bool {
 		if modifications.is_empty() {
 			return true;
 		}
@@ -395,6 +388,7 @@ impl StateDB {
 		// We search for our parent in that list first and then for
 		// all its parent until we hit the canonical block,
 		// checking against all the intermediate modifications.
+		let mut parent = parent_hash;
 		for m in modifications {
 			if &m.hash == parent {
 				if m.is_canon {
@@ -434,20 +428,25 @@ impl state::Backend for StateDB {
 	}
 
 	fn get_cached_account(&self, addr: &Address) -> Option<Option<Account>> {
-		let mut cache = self.account_cache.lock();
-		if !Self::is_allowed(addr, &self.parent_hash, &cache.modifications) {
-			return None;
-		}
-		cache.accounts.get_mut(addr).map(|a| a.as_ref().map(|a| a.clone_basic()))
+		self.parent_hash.as_ref().and_then(|parent_hash| {
+			let mut cache = self.account_cache.lock();
+			if !Self::is_allowed(addr, parent_hash, &cache.modifications) {
+				return None;
+			}
+			cache.accounts.get_mut(addr).map(|a| a.as_ref().map(|a| a.clone_basic()))
+		})
 	}
 
 	fn get_cached<F, U>(&self, a: &Address, f: F) -> Option<U>
-		where F: FnOnce(Option<&mut Account>) -> U {
-		let mut cache = self.account_cache.lock();
-		if !Self::is_allowed(a, &self.parent_hash, &cache.modifications) {
-			return None;
-		}
-		cache.accounts.get_mut(a).map(|c| f(c.as_mut()))
+		where F: FnOnce(Option<&mut Account>) -> U
+	{
+		self.parent_hash.as_ref().and_then(|parent_hash| {
+			let mut cache = self.account_cache.lock();
+			if !Self::is_allowed(a, parent_hash, &cache.modifications) {
+				return None;
+			}
+			cache.accounts.get_mut(a).map(|c| f(c.as_mut()))
+		})
 	}
 
 	fn get_cached_code(&self, hash: &H256) -> Option<Arc<Vec<u8>>> {


### PR DESCRIPTION
For non-canon blocks, we still clone `StateDB` and lock cache when get accounts, while the account cache is not usable at all. This PR makes it to early return to skip the lock. The change may be helpful for situations like a archive node under heavy load for `eth_call` (because canon sync and RPC won't compete for locks of cache anymore).

cc @insipx 