### PR TITLE
HF in POA Core (2019-01-18) - Constantinople

### DIFF
--- a/ethcore/res/ethereum/poacore.json
+++ b/ethcore/res/ethereum/poacore.json
@@ -34,7 +34,11 @@
 		"eip140Transition": "0x0",
 		"eip211Transition": "0x0",
 		"eip214Transition": "0x0",
-		"eip658Transition": "0x0"
+		"eip658Transition": "0x0",
+		"eip145Transition": 6843780,
+		"eip1014Transition": 6843780,
+		"eip1052Transition": 6843780,
+		"eip1283Transition": 6843780
 	},
 	"genesis": {
 		"seal": {


### PR DESCRIPTION
We're going to activate Constantinople in our `Core` network at block `6843780` (on 18 January 2019).

The proposed changes correspond to [the changes](https://github.com/poanetwork/poa-chain-spec/pull/100/files#diff-42eb5109ad96d4ac46cdcbf18f2938de) in our `spec.json` for `Core`.