### PR TITLE
refactor(trim_right_matches -> trim_end_matches)

### DIFF
--- a/rpc/src/v1/types/transaction_request.rs
+++ b/rpc/src/v1/types/transaction_request.rs
@@ -57,8 +57,7 @@ pub fn format_ether(i: U256) -> String {
 	} else {
 		string.insert(idx as usize, '.');
 	}
-	String::from(string.trim_right_matches('0')
-		.trim_right_matches('.'))
+	String::from(string.trim_end_matches('0').trim_end_matches('.'))
 }
 
 impl fmt::Display for TransactionRequest {


### PR DESCRIPTION
Fixes the following warnings, only shown on nightly yet (will be deprecated in Rust 1.33):

```bash
warning: use of deprecated item 'core::str::<impl str>::trim_right_matches': superseded by `trim_end_matches`                                                                                         
  --> rpc/src/v1/types/transaction_request.rs:60:22
   |
60 |     String::from(string.trim_right_matches('0')
   |                         ^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(deprecated)] on by default

warning: use of deprecated item 'core::str::<impl str>::trim_right_matches': superseded by `trim_end_matches`                                                                                         
  --> rpc/src/v1/types/transaction_request.rs:61:4
   |
61 |         .trim_right_matches('.'))
   |          ^^^^^^^^^^^^^^^^^^

```