### PR TITLE
fix(parity-clib-example): remove websocket

### DIFF
--- a/parity-clib/examples/cpp/main.cpp
+++ b/parity-clib/examples/cpp/main.cpp
@@ -14,20 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <chrono>
+#include <cstring>
 #include <parity.h>
-#include <regex>
 #include <string>
-#include <thread>
+#include <vector>
 
 void* parity_run(std::vector<const char*>);
-int parity_subscribe_to_websocket(void*);
 int parity_rpc_queries(void*);
 
-const int SUBSCRIPTION_ID_LEN = 18;
-const size_t TIMEOUT_ONE_MIN_AS_MILLIS = 60 * 1000;
+const size_t TIMEOUT_THIRTY_SECS_AS_MILLIS = 30 * 1000;
 const unsigned int CALLBACK_RPC = 1;
-const unsigned int CALLBACK_WS = 2;
 
 struct Callback {
 	unsigned int type;
@@ -38,15 +34,8 @@ struct Callback {
 const std::vector<std::string> rpc_queries {
 	"{\"method\":\"parity_versionInfo\",\"params\":[],\"id\":1,\"jsonrpc\":\"2.0\"}",
 	"{\"method\":\"eth_getTransactionReceipt\",\"params\":[\"0x444172bef57ad978655171a8af2cfd89baa02a97fcb773067aef7794d6913fff\"],\"id\":1,\"jsonrpc\":\"2.0\"}",
-	"{\"method\":\"eth_estimateGas\",\"params\":[{\"from\":\"0x0066Dc48bb833d2B59f730F33952B3c29fE926F5\"}],\"id\":1,\"jsonrpc\":\"2.0\"}",
-	"{\"method\":\"eth_getBalance\",\"params\":[\"0x0066Dc48bb833d2B59f730F33952B3c29fE926F5\"],\"id\":1,\"jsonrpc\":\"2.0\"}"
-};
-
-// list of subscriptions
-const std::vector<std::string> ws_subscriptions {
-	"{\"method\":\"parity_subscribe\",\"params\":[\"eth_getBalance\",[\"0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826\",\"latest\"]],\"id\":1,\"jsonrpc\":\"2.0\"}",
-	"{\"method\":\"parity_subscribe\",\"params\":[\"parity_netPeers\"],\"id\":1,\"jsonrpc\":\"2.0\"}",
-	"{\"method\":\"eth_subscribe\",\"params\":[\"newHeads\"],\"id\":1,\"jsonrpc\":\"2.0\"}"
+	"{\"method\":\"eth_estimateGas\",\"params\":[{\"from\":\"0x0010f94b296A852aAac52EA6c5Ac72e03afD032D\"}],\"id\":1,\"jsonrpc\":\"2.0\"}",
+	"{\"method\":\"eth_getBalance\",\"params\":[\"0x0010f94b296A852aAac52EA6c5Ac72e03afD032D\"],\"id\":1,\"jsonrpc\":\"2.0\"}"
 };
 
 // callback that gets invoked upon an event
@@ -55,12 +44,6 @@ void callback(void* user_data, const char* response, size_t _len) {
 	if (cb->type == CALLBACK_RPC) {
 		printf("rpc response: %s\r\n", response);
 		cb->counter -= 1;
-	} else if (cb->type == CALLBACK_WS) {
-		printf("websocket response: %s\r\n", response);
-		std::regex is_subscription ("\\{\"jsonrpc\":\"2.0\",\"result\":\"0[xX][a-fA-F0-9]{16}\",\"id\":1\\}");
-		if (std::regex_match(response, is_subscription) == true) {
-			cb->counter -= 1;
-		}
 	}
 }
 
@@ -71,11 +54,6 @@ int main() {
 		void* parity = parity_run(config);
 		if (parity_rpc_queries(parity)) {
 			printf("rpc_queries failed\r\n");
-			return 1;
-		}
-
-		if (parity_subscribe_to_websocket(parity)) {
-			printf("ws_queries failed\r\n");
 			return 1;
 		}
 
@@ -94,11 +72,6 @@ int main() {
 			return 1;
 		}
 
-		if (parity_subscribe_to_websocket(parity)) {
-			printf("ws_queries failed\r\n");
-			return 1;
-		}
-
 		if (parity != nullptr) {
 			parity_destroy(parity);
 		}
@@ -114,38 +87,12 @@ int parity_rpc_queries(void* parity) {
 	Callback cb { .type = CALLBACK_RPC, .counter = rpc_queries.size() };
 
 	for (auto query : rpc_queries) {
-		if (parity_rpc(parity, query.c_str(), query.length(), TIMEOUT_ONE_MIN_AS_MILLIS, callback, &cb) != 0) {
+		if (parity_rpc(parity, query.c_str(), query.length(), TIMEOUT_THIRTY_SECS_AS_MILLIS, callback, &cb) != 0) {
 			return 1;
 		}
 	}
 
 	while(cb.counter != 0);
-	return 0;
-}
-
-
-int parity_subscribe_to_websocket(void* parity) {
-	if (!parity) {
-		return 1;
-	}
-
-	std::vector<const void*> sessions;
-
-	Callback cb { .type = CALLBACK_WS, .counter = ws_subscriptions.size() };
-
-	for (auto sub : ws_subscriptions) {
-		void *const session = parity_subscribe_ws(parity, sub.c_str(), sub.length(), callback, &cb);
-		if (!session) {
-			return 1;
-		}
-		sessions.push_back(session);
-	}
-
-	while(cb.counter != 0);
-	std::this_thread::sleep_for(std::chrono::seconds(60));
-	for (auto session : sessions) {
-		parity_unsubscribe_ws(session);
-	}
 	return 0;
 }
 


### PR DESCRIPTION
I suspect there is something wrong with the `WebSocket subscription` in the light client so let's remove it for now in order not to deny well-formed PRs!

/cc @tomusdrw @ngotchac 