### PR TITLE
Add missing step for  Using `systemd` service file

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ To start Parity Ethereum as a regular user using `systemd` init:
 
 1. Copy `./scripts/parity.service` to your
 `systemd` user directory (usually `~/.config/systemd/user`).
-2. To configure Parity Ethereum, write a `/etc/parity/config.toml` config file, see [Configuring Parity Ethereum](https://paritytech.github.io/wiki/Configuring-Parity) for details.
+2. Copy Parity release from target folder to bin, write `cp -R ./target/release/parity /usr/bin/`
+3. To configure Parity Ethereum, write a `/etc/parity/config.toml` config file, see [Configuring Parity Ethereum](https://paritytech.github.io/wiki/Configuring-Parity) for details.
 
 ## Parity Ethereum toolchain
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To start Parity Ethereum as a regular user using `systemd` init:
 
 1. Copy `./scripts/parity.service` to your
 `systemd` user directory (usually `~/.config/systemd/user`).
-2. Copy Parity release from target folder to bin, write `cp -R ./target/release/parity /usr/bin/`
+2. Copy release to bin folder, write `sudo install ./target/release/parity /usr/bin/parity`
 3. To configure Parity Ethereum, write a `/etc/parity/config.toml` config file, see [Configuring Parity Ethereum](https://paritytech.github.io/wiki/Configuring-Parity) for details.
 
 ## Parity Ethereum toolchain


### PR DESCRIPTION
Copy Parity release from target folder to bin, write `cp -R ./target/release/parity /usr/bin/` to match `ExecStart=/usr/bin/parity --config /etc/parity/config.toml` from `https://github.com/paritytech/parity-ethereum/blob/master/scripts/parity.service`