### PR TITLE
Cancel Constantinople HF on POA Core

### DIFF
--- a/ethcore/res/ethereum/poacore.json
+++ b/ethcore/res/ethereum/poacore.json
@@ -34,11 +34,7 @@
 		"eip140Transition": "0x0",
 		"eip211Transition": "0x0",
 		"eip214Transition": "0x0",
-		"eip658Transition": "0x0",
-		"eip145Transition": 6843780,
-		"eip1014Transition": 6843780,
-		"eip1052Transition": 6843780,
-		"eip1283Transition": 6843780
+		"eip658Transition": "0x0"
 	},
 	"genesis": {
 		"seal": {


### PR DESCRIPTION
Originally Constantinople HF was scheduled on **2019-01-18** for POA Core network

This PR changes spec for POA Core:
 - Removing of Constantinople EIPs transitions

[Related revert in POA Core spec.json](https://github.com/poanetwork/poa-chain-spec/pull/104)