### PR TITLE
Revert Constantinople activation in POA Core

### DIFF
--- a/ethcore/res/ethereum/poacore.json
+++ b/ethcore/res/ethereum/poacore.json
@@ -34,11 +34,7 @@
 		"eip140Transition": "0x0",
 		"eip211Transition": "0x0",
 		"eip214Transition": "0x0",
-		"eip658Transition": "0x0",
-		"eip145Transition": 6843780,
-		"eip1014Transition": 6843780,
-		"eip1052Transition": 6843780,
-		"eip1283Transition": 6843780
+		"eip658Transition": "0x0"
 	},
 	"genesis": {
 		"seal": {


### PR DESCRIPTION
Due to Constantinople HF being postponed in Eth mainnet,
POA Network also postpones HF in POA Core network that was planned on 18 Jan.

Reference PR: https://github.com/poanetwork/poa-chain-spec/pull/104/files