### PR TITLE
Add EIP-1283 disable transition

### DIFF
--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -121,6 +121,8 @@ pub struct CommonParams {
 	pub eip1052_transition: BlockNumber,
 	/// Number of first block where EIP-1283 rules begin.
 	pub eip1283_transition: BlockNumber,
+	/// Number of first block where EIP-1283 rules end.
+	pub eip1283_disable_transition: BlockNumber,
 	/// Number of first block where EIP-1014 rules begin.
 	pub eip1014_transition: BlockNumber,
 	/// Number of first block where dust cleanup rules (EIP-168 and EIP169) begin.
@@ -189,7 +191,7 @@ impl CommonParams {
 		schedule.have_return_data = block_number >= self.eip211_transition;
 		schedule.have_bitwise_shifting = block_number >= self.eip145_transition;
 		schedule.have_extcodehash = block_number >= self.eip1052_transition;
-		schedule.eip1283 = block_number >= self.eip1283_transition;
+		schedule.eip1283 = block_number >= self.eip1283_transition && !(block_number >= self.eip1283_disable_transition);
 		if block_number >= self.eip210_transition {
 			schedule.blockhash_gas = 800;
 		}
@@ -297,6 +299,10 @@ impl From<ethjson::spec::Params> for CommonParams {
 				Into::into,
 			),
 			eip1283_transition: p.eip1283_transition.map_or_else(
+				BlockNumber::max_value,
+				Into::into,
+			),
+			eip1283_disable_transition: p.eip1283_disable_transition.map_or_else(
 				BlockNumber::max_value,
 				Into::into,
 			),

--- a/json/src/spec/params.rs
+++ b/json/src/spec/params.rs
@@ -89,6 +89,9 @@ pub struct Params {
 	pub eip1052_transition: Option<Uint>,
 	/// See `CommonParams` docs.
 	pub eip1283_transition: Option<Uint>,
+	/// See `CommonParams` docs.
+	pub eip1283_disable_transition: Option<Uint>,
+	/// See `CommonParams` docs.
 	pub eip1014_transition: Option<Uint>,
 	/// See `CommonParams` docs.
 	pub dust_protection_transition: Option<Uint>,


### PR DESCRIPTION
Add a transition flag that allows disabling EIP-1283 when EIP-1283 is already enabled. Replaces https://github.com/paritytech/parity-ethereum/pull/10191