### PR TITLE
Echo CORS request headers by default

### DIFF
--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -151,9 +151,7 @@ pub fn start_http<M, S, H, T>(
 		.cors(cors_domains.into())
 		.allowed_hosts(allowed_hosts.into())
 		.health_api(("/api/health", "parity_nodeStatus"))
-		.cors_allow_headers(
-			AccessControlAllowHeaders::Any
-		)
+		.cors_allow_headers(AccessControlAllowHeaders::Any)
 		.max_request_body_size(max_payload * 1024 * 1024)
 		.start_http(addr)?)
 }
@@ -183,9 +181,7 @@ pub fn start_http_with_middleware<M, S, H, T, R>(
 		.threads(threads)
 		.cors(cors_domains.into())
 		.allowed_hosts(allowed_hosts.into())
-		.cors_allow_headers(
-			AccessControlAllowHeaders::Any
-		)
+		.cors_allow_headers(AccessControlAllowHeaders::Any)
 		.max_request_body_size(max_payload * 1024 * 1024)
 		.request_middleware(middleware)
 		.start_http(addr)?)

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -114,7 +114,7 @@ pub use ipc::{Server as IpcServer, MetaExtractor as IpcMetaExtractor, RequestCon
 pub use http::{
 	hyper,
 	RequestMiddleware, RequestMiddlewareAction,
-	AccessControlAllowOrigin, Host, DomainsValidation
+	AccessControlAllowOrigin, Host, DomainsValidation, cors::AccessControlAllowHeaders
 };
 
 pub use v1::{NetworkSettings, Metadata, Origin, informant, dispatch, signer};
@@ -151,6 +151,9 @@ pub fn start_http<M, S, H, T>(
 		.cors(cors_domains.into())
 		.allowed_hosts(allowed_hosts.into())
 		.health_api(("/api/health", "parity_nodeStatus"))
+		.cors_allow_headers(
+			AccessControlAllowHeaders::Any
+		)
 		.max_request_body_size(max_payload * 1024 * 1024)
 		.start_http(addr)?)
 }
@@ -180,6 +183,9 @@ pub fn start_http_with_middleware<M, S, H, T, R>(
 		.threads(threads)
 		.cors(cors_domains.into())
 		.allowed_hosts(allowed_hosts.into())
+		.cors_allow_headers(
+			AccessControlAllowHeaders::Any
+		)
 		.max_request_body_size(max_payload * 1024 * 1024)
 		.request_middleware(middleware)
 		.start_http(addr)?)

--- a/rpc/src/tests/rpc.rs
+++ b/rpc/src/tests/rpc.rs
@@ -116,4 +116,31 @@ mod tests {
 		res.assert_status("HTTP/1.1 200 OK");
 		assert_eq!(res.body, expected);
 	}
+
+	#[test]
+	fn should_respond_valid_to_any_requested_header() {
+		// given
+		let (server, address) = serve();
+		let headers = "Something, Anything, Xyz, 123, _?";
+
+		// when
+		let res = request(server,
+		&format!("\
+				OPTIONS / HTTP/1.1\r\n\
+				Host: {}\r\n\
+				Origin: http://parity.io\r\n\
+				Content-Length: 0\r\n\
+				Content-Type: application/json\r\n\
+				Connection: close\r\n\
+				Access-Control-Request-Headers: {}\r\n\
+				\r\n\
+			", address, headers)
+		);
+
+		// then
+		assert_eq!(res.status, "HTTP/1.1 200 OK".to_owned());
+		let expected = format!("access-control-allow-headers: {}", headers);
+		assert!(res.headers.contains(&expected), "Headers missing in {:?}", res.headers);
+	}
+
 }


### PR DESCRIPTION
This PR addresses #6616:

> For maximum compatibility, Parity should echo back all the headers from Access-Control-Request-Headers in Access-Control-Allow-Headers. 

I just noticed that this is already the default behavior of the jsonrpc `with_meta_extractor(…)`: https://github.com/paritytech/jsonrpc/blob/parity-2.2/http/src/lib.rs#L240. I still think it's a good idea to merge this, since it makes the behavior more explicit and adds a test which would fail if the default behavior would ever change.