### PR TITLE
fixed: use types::transaction::SignedTransaction; instead of transaction::SignedTransaction; 

### DIFF
--- a/rpc/src/v1/impls/personal.rs
+++ b/rpc/src/v1/impls/personal.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use ethcore::account_provider::AccountProvider;
 use types::transaction::PendingTransaction;
+use types::transaction::SignedTransaction;
 use ethereum_types::{H520, U128, Address};
 use ethkey::{public_to_address, recover, Signature};
 
@@ -41,7 +42,6 @@ use v1::types::{
 use v1::metadata::Metadata;
 use eip_712::{EIP712, hash_structured_data};
 use jsonrpc_core::types::Value;
-use transaction::SignedTransaction;
 
 /// Account management (personal) rpc implementation.
 pub struct PersonalClient<D: Dispatcher> {


### PR DESCRIPTION
When compile with `1.31.0 (339d9f9c8 2018-11-16)` on my Gentoo

I got:
```
error[E0432]: unresolved import `transaction`
  --> rpc/src/v1/impls/personal.rs:44:5
   |
44 | use transaction::SignedTransaction;
   |     ^^^^^^^^^^^ did you mean `types::transaction`?

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: Could not compile `parity-rpc`.
```

That is what this pull request for