### PR TITLE
Secure WS-RPC: grant access to all apis

### DIFF
--- a/parity/rpc.rs
+++ b/parity/rpc.rs
@@ -151,7 +151,7 @@ pub fn new_ws<D: rpc_apis::Dependencies>(
 	let url = format!("{}:{}", conf.interface, conf.port);
 	let addr = url.parse().map_err(|_| format!("Invalid WebSockets listen host/port given: {}", url))?;
 
-	let full_handler = setup_apis(rpc_apis::ApiSet::SafeContext, deps);
+	let full_handler = setup_apis(rpc_apis::ApiSet::All, deps);
 	let handler = {
 		let mut handler = MetaIoHandler::with_middleware((
 			rpc::WsDispatcher::new(full_handler),

--- a/parity/rpc_apis.rs
+++ b/parity/rpc_apis.rs
@@ -113,11 +113,9 @@ impl FromStr for Api {
 
 #[derive(Debug, Clone)]
 pub enum ApiSet {
-	// Safe context (like token-protected WS interface)
-	SafeContext,
 	// Unsafe context (like jsonrpc over http)
 	UnsafeContext,
-	// All possible APIs
+	// All possible APIs (safe context like token-protected WS interface)
 	All,
 	// Local "unsafe" context and accounts access
 	IpcContext,
@@ -727,16 +725,6 @@ impl ApiSet {
 				public_list.insert(Api::ParityAccounts);
 				public_list
 			}
-			ApiSet::SafeContext => {
-				public_list.insert(Api::Debug);
-				public_list.insert(Api::Traces);
-				public_list.insert(Api::ParityPubSub);
-				public_list.insert(Api::ParityAccounts);
-				public_list.insert(Api::ParitySet);
-				public_list.insert(Api::Signer);
-				public_list.insert(Api::SecretStore);
-				public_list
-			}
 			ApiSet::All => {
 				public_list.insert(Api::Debug);
 				public_list.insert(Api::Traces);
@@ -840,33 +828,6 @@ mod test {
 		].into_iter()
 		.collect();
 		assert_eq!(ApiSet::IpcContext.list_apis(), expected);
-	}
-
-	#[test]
-	fn test_api_set_safe_context() {
-		let expected = vec![
-			// safe
-			Api::Web3,
-			Api::Net,
-			Api::Eth,
-			Api::EthPubSub,
-			Api::Parity,
-			Api::ParityPubSub,
-			Api::Traces,
-			Api::Rpc,
-			Api::SecretStore,
-			Api::Whisper,
-			Api::WhisperPubSub,
-			Api::Private,
-			// semi-safe
-			Api::ParityAccounts,
-			// Unsafe
-			Api::ParitySet,
-			Api::Signer,
-			Api::Debug,
-		].into_iter()
-		.collect();
-		assert_eq!(ApiSet::SafeContext.list_apis(), expected);
 	}
 
 	#[test]


### PR DESCRIPTION
We're updating Fether/light.js to use personal_signTransaction rather than signer_*. However, currently on Parity Ethereum, ws connections with a secure token have the ApiSet::SafeContext, which is every api except personal. This PR makes ws connections with a secure token have access to all apis. This way we can launch Parity Ethereum with the default apis enabled and have personal_ only be exposed in the ws connection with secure token.