### PR TITLE
WIP - Remove usage of `ethcore::client::BlockInfo` from `ethcore/light` crate

### DIFF
--- a/ethcore/blockchain/src/blockchain.rs
+++ b/ethcore/blockchain/src/blockchain.rs
@@ -134,6 +134,7 @@ pub trait BlockProvider {
 	fn block_receipts(&self, hash: &H256) -> Option<BlockReceipts>;
 
 	/// Get the header RLP of a block.
+	// TODO: Rename to block_header()
 	fn block_header_data(&self, hash: &H256) -> Option<encoded::Header>;
 
 	/// Get the block body (uncles and transactions).

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -588,6 +588,7 @@ impl<T: ChainDataFetcher> LightChainClient for Client<T> {
 	}
 }
 
+// NOTE: Might want to replace this with BlockProvider methods
 impl<T: ChainDataFetcher> ::ethcore::client::ChainInfo for Client<T> {
 	fn chain_info(&self) -> BlockChainInfo {
 		Client::chain_info(self)

--- a/ethcore/light/src/net/tests/mod.rs
+++ b/ethcore/light/src/net/tests/mod.rs
@@ -129,11 +129,11 @@ impl Provider for TestProvider {
 	}
 
 	fn block_body(&self, req: request::CompleteBodyRequest) -> Option<request::BodyResponse> {
-		self.0.client.block_body(req)
+		Provider::block_body(&self.0.client, req)
 	}
 
 	fn block_receipts(&self, req: request::CompleteReceiptsRequest) -> Option<request::ReceiptsResponse> {
-		self.0.client.block_receipts(req)
+		Provider::block_receipts(&self.0.client, req)
 	}
 
 	fn account_proof(&self, req: request::CompleteAccountRequest) -> Option<request::AccountResponse> {
@@ -379,7 +379,7 @@ fn get_block_bodies() {
 		builder.push(Request::Body(IncompleteBodyRequest {
 			hash: hash.into(),
 		})).unwrap();
-		bodies.push(Response::Body(provider.client.block_body(CompleteBodyRequest {
+		bodies.push(Response::Body(Provider::block_body(&provider.client, CompleteBodyRequest {
 			hash: hash,
 		}).unwrap()));
 	}
@@ -431,7 +431,7 @@ fn get_block_receipts() {
 	let mut receipts = Vec::new();
 	for hash in block_hashes.iter().cloned() {
 		builder.push(Request::Receipts(IncompleteReceiptsRequest { hash: hash.into() })).unwrap();
-		receipts.push(Response::Receipts(provider.client.block_receipts(CompleteReceiptsRequest {
+		receipts.push(Response::Receipts(Provider::block_receipts(&provider.client, CompleteReceiptsRequest {
 			hash: hash
 		}).unwrap()));
 	}

--- a/ethcore/light/src/on_demand/request.rs
+++ b/ethcore/light/src/on_demand/request.rs
@@ -1108,7 +1108,7 @@ mod tests {
 	use trie::Recorder;
 	use hash::keccak;
 
-	use ethcore::client::{BlockChainClient, BlockInfo, TestBlockChainClient, EachBlockWith};
+	use ethcore::client::{BlockChainClient, TestBlockChainClient, EachBlockWith};
 	use common_types::header::Header;
 	use common_types::encoded;
 	use common_types::receipt::{Receipt, TransactionOutcome};
@@ -1125,6 +1125,7 @@ mod tests {
 	#[test]
 	fn check_header_proof() {
 		use ::cht;
+		use Provider;
 
 		let test_client = TestBlockChainClient::new();
 		test_client.add_blocks(10500, EachBlockWith::Nothing);

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -813,7 +813,7 @@ impl BlockChainClient for TestBlockChainClient {
 				.map(|block| block.view().header())
 				.map(|header| self.spec.engine.extra_info(&header))
 		} else {
-			None
+			panic!("Expected BlockId::Hash, got {:?} instead.", id)
 		}
 	}
 

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -524,8 +524,7 @@ impl BlockInfo for TestBlockChainClient {
 	}
 }
 
-// Basing test implementations off/stealing them
-// from `ethcore/src/verification/verification.rs`
+// TODO: Address redundant implementation of BlockProvider (#10253)
 impl BlockProvider for TestBlockChainClient {
 		fn is_known(&self, _hash: &H256) -> bool {
 			unimplemented!()


### PR DESCRIPTION
Continuing on some of the refactoring work I've been doing, this PR aims to remove the usage of the `BlockInfo` trait from the `ethcore/light` crate. I'm not really sure if this is the right way to go about doing this, which is the reason why I'm tossing this PR up.

I'm open to suggestions and feedback.