### PR TITLE
Fix v2.2.7 release date in the changelog.

### DIFF
--- a/docs/CHANGELOG-2.2.md
+++ b/docs/CHANGELOG-2.2.md
@@ -1,4 +1,4 @@
-## Parity-Ethereum [v2.2.7](https://github.com/paritytech/parity-ethereum/releases/tag/v2.2.7) (2018-01-15)
+## Parity-Ethereum [v2.2.7](https://github.com/paritytech/parity-ethereum/releases/tag/v2.2.7) (2019-01-15)
 
 Parity-Ethereum 2.2.7-stable is a consensus-relevant security release that reverts Constantinople on the Ethereum network. Upgrading is mandatory for Ethereum, and strongly recommended for other networks.
 


### PR DESCRIPTION
Fix v2.2.7 release date in the changelog.

I hate being that guy who sends one line PRs to update the doc, but I installed the beta 2.3 version instead of the stable 2.2.7 because I thought it was one year old... before checking again.