### PR TITLE
Create Parity unable to fetch node health

### DIFF
--- a/Parity unable to fetch node health
+++ b/Parity unable to fetch node health
@@ -1,0 +1,9 @@
+
+    Which Parity version?: v 2.3. 0
+    Which operating system?: Linux
+    How installed?: via Terminal
+    Are you fully synchronized?: no
+    Which network are you connected to?: ethereum
+    Did you try to restart the node?: yes
+    
+    Please advice.


### PR DESCRIPTION
Parity wallet unable to fetch node health on ethereum

    Which Parity version?: v 2. 3. 0.
    Which operating system?: Linux
    How installed?: via Terminal
    Are you fully synchronized?: no
    Which network are you connected to?: ethereum
    Did you try to restart the node?: yes
