### PR TITLE
Don't run the CPP example on CI

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -57,8 +57,6 @@ cpp_test () {
       cd $DIR
       cmake ..
       make -j $THREADS
-      ./parity-example > example.logs
-      tail --lines 100 example.logs
       cd -
       rm -rf $DIR
       ;;


### PR DESCRIPTION
#10007 changed the example to sync Kovan. However this example is being run by CI, and we don't want CI to sync Kovan.