### PR TITLE
Convert to jsonrpc-derive, use jsonrpc-* from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1060,9 +1060,8 @@ version = "1.12.0"
 dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-macros 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-tcp-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-tcp-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1279,7 +1278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1778,8 +1777,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
+version = "10.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1789,13 +1788,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-derive"
+version = "10.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jsonrpc-http-server"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
+version = "10.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.12.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-server-utils 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1803,45 +1812,36 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ipc-server"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
+version = "10.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-server-utils 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-tokio-ipc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "jsonrpc-macros"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
+name = "jsonrpc-pubsub"
+version = "10.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "jsonrpc-pubsub"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
-dependencies = [
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "jsonrpc-server-utils"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
+version = "10.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1852,28 +1852,28 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-tcp-server"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
+version = "10.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-server-utils 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
+version = "10.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-server-utils 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-ws 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws 0.7.9 (git+https://github.com/tomusdrw/ws-rs)",
 ]
 
 [[package]]
@@ -2457,7 +2457,7 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "journaldb 0.2.0",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb-rocksdb 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2527,8 +2527,8 @@ dependencies = [
  "cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore 1.12.0",
  "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-http-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "multihash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2612,12 +2612,12 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hardware-wallet 1.12.0",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-ipc-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-macros 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-ws-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-derive 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-http-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-ipc-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-ws-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb-memorydb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2653,8 +2653,8 @@ name = "parity-rpc-client"
 version = "1.4.0"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-ws-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-ws-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2764,9 +2764,9 @@ dependencies = [
  "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethkey 0.3.0",
  "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-macros 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-derive 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "memzero 0.1.0",
  "ordered-float 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2790,6 +2790,23 @@ dependencies = [
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parity-ws"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3318,7 +3335,7 @@ dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3452,7 +3469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3592,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.11"
+version = "0.15.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3615,7 +3632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4181,7 +4198,7 @@ dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "validator 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4306,9 +4323,9 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-network 1.12.0",
  "ethcore-network-devp2p 1.12.0",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-http-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic_hook 0.1.0",
  "parity-whisper 0.1.0",
@@ -4360,23 +4377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ws"
-version = "0.7.9"
-source = "git+https://github.com/tomusdrw/ws-rs#4baef2dc1abc8e216559af51cfc120bbcc777e21"
-dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4529,14 +4529,14 @@ dependencies = [
 "checksum jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0cd42ac65f758063fea55126b0148b1ce0a6354ff78e07a4d6806bc65c4ab3"
 "checksum jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1ecfa3b81afc64d9a6539c4eece96ac9a93c551c713a313800dade8e33d7b5c1"
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-"checksum jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
-"checksum jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
-"checksum jsonrpc-ipc-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
-"checksum jsonrpc-macros 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
-"checksum jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
-"checksum jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
-"checksum jsonrpc-tcp-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
-"checksum jsonrpc-ws-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
+"checksum jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a5152c3fda235dfd68341b3edf4121bc4428642c93acbd6de88c26bf95fc5d7"
+"checksum jsonrpc-derive 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8de4e89cf0938dec51a14255556172b1f5208e4d8999d613813eceeae1405d37"
+"checksum jsonrpc-http-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "99e1ce36c7cc9dcab398024d76849ab2cb917ee812653bce6f74fc9eb7c82d16"
+"checksum jsonrpc-ipc-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fac6b8682243740a32bfb288880c71cc06eca29616cdf551e4136a190b11b96d"
+"checksum jsonrpc-pubsub 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "56608ed54b1b2a69f4357cb8bdfbcbd99fe1179383c03a09bb428931bd35f592"
+"checksum jsonrpc-server-utils 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5521613b31ea22d36d9f95ad642058dccec846a94ed8690957652d479f620707"
+"checksum jsonrpc-tcp-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c873dac37a601fb88d40ba49eeac3f1aa60953c06b2e99ddbf0569b6f8028478"
+"checksum jsonrpc-ws-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20b8333a5a6e6ccbcf5c90f90919de557cba4929efa164e9bd0e8e497eb20e46"
 "checksum keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "253bbe643c32c816bf58fa5a88248fafedeebb139705ad17a62add3517854a86"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kvdb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72ae89206cea31c32014b39d5a454b96135894221610dbfd19cf4d2d044fa546"
@@ -4600,6 +4600,7 @@ dependencies = [
 "checksum parity-tokio-ipc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb002c2d3539ccd3b82bd915ec060028d4ab350ad203dbffa20028c1e483af5b"
 "checksum parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)" = "511379a8194230c2395d2f5fa627a5a7e108a9f976656ce723ae68fca4097bfc"
 "checksum parity-wordlist 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf13102febd98f4ad416a526b42deb82daf482626ba6ab10d0ebf8f45327514c"
+"checksum parity-ws 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2fec5048fba72a2e01baeb0d08089db79aead4b57e2443df172fb1840075a233"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
 "checksum parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9723236a9525c757d9725b993511e3fc941e33f27751942232f0058298297edf"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
@@ -4688,7 +4689,7 @@ dependencies = [
 "checksum string 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00caf261d6f90f588f8450b8e1230fa0d5be49ee6140fdfbcb55335aff350970"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-"checksum syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b036b7b35e846707c0e55c2c9441fa47867c0f87fca416921db3261b1d8c741a"
+"checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
@@ -4768,7 +4769,6 @@ dependencies = [
 "checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
-"checksum ws 0.7.9 (git+https://github.com/tomusdrw/ws-rs)" = "<none>"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1060,8 +1060,9 @@ version = "1.12.0"
 dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 10.0.0",
- "jsonrpc-tcp-server 10.0.0",
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-macros 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-tcp-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1278,7 +1279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1777,7 +1778,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "10.0.0"
+version = "9.0.0"
+source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1787,21 +1789,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-derive"
-version = "10.0.0"
-dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "jsonrpc-http-server"
-version = "10.0.0"
+version = "9.0.0"
+source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
 dependencies = [
  "hyper 0.12.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 10.0.0",
- "jsonrpc-server-utils 10.0.0",
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1809,33 +1803,45 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ipc-server"
-version = "10.0.0"
+version = "9.0.0"
+source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
 dependencies = [
- "jsonrpc-core 10.0.0",
- "jsonrpc-server-utils 10.0.0",
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-tokio-ipc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "jsonrpc-pubsub"
-version = "10.0.0"
+name = "jsonrpc-macros"
+version = "9.0.0"
+source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
 dependencies = [
- "jsonrpc-core 10.0.0",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "jsonrpc-pubsub"
+version = "9.0.0"
+source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
+dependencies = [
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jsonrpc-server-utils"
-version = "10.0.0"
+version = "9.0.0"
+source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
 dependencies = [
  "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 10.0.0",
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1846,24 +1852,26 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-tcp-server"
-version = "10.0.0"
+version = "9.0.0"
+source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
 dependencies = [
- "jsonrpc-core 10.0.0",
- "jsonrpc-server-utils 10.0.0",
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "10.0.0"
+version = "9.0.0"
+source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 10.0.0",
- "jsonrpc-server-utils 10.0.0",
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.7.9 (git+https://github.com/tomusdrw/ws-rs)",
 ]
@@ -2449,7 +2457,7 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "journaldb 0.2.0",
- "jsonrpc-core 10.0.0",
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb-rocksdb 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2519,8 +2527,8 @@ dependencies = [
  "cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore 1.12.0",
  "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 10.0.0",
- "jsonrpc-http-server 10.0.0",
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "multihash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2604,12 +2612,12 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hardware-wallet 1.12.0",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 10.0.0",
- "jsonrpc-derive 10.0.0",
- "jsonrpc-http-server 10.0.0",
- "jsonrpc-ipc-server 10.0.0",
- "jsonrpc-pubsub 10.0.0",
- "jsonrpc-ws-server 10.0.0",
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-ipc-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-macros 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-ws-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb-memorydb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2645,8 +2653,8 @@ name = "parity-rpc-client"
 version = "1.4.0"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 10.0.0",
- "jsonrpc-ws-server 10.0.0",
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-ws-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2756,9 +2764,9 @@ dependencies = [
  "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethkey 0.3.0",
  "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 10.0.0",
- "jsonrpc-derive 10.0.0",
- "jsonrpc-pubsub 10.0.0",
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-macros 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "memzero 0.1.0",
  "ordered-float 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3310,7 +3318,7 @@ dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3444,7 +3452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3584,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.26"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3607,7 +3615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4173,7 +4181,7 @@ dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "validator 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4298,9 +4306,9 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-network 1.12.0",
  "ethcore-network-devp2p 1.12.0",
- "jsonrpc-core 10.0.0",
- "jsonrpc-http-server 10.0.0",
- "jsonrpc-pubsub 10.0.0",
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic_hook 0.1.0",
  "parity-whisper 0.1.0",
@@ -4521,6 +4529,14 @@ dependencies = [
 "checksum jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0cd42ac65f758063fea55126b0148b1ce0a6354ff78e07a4d6806bc65c4ab3"
 "checksum jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1ecfa3b81afc64d9a6539c4eece96ac9a93c551c713a313800dade8e33d7b5c1"
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+"checksum jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
+"checksum jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
+"checksum jsonrpc-ipc-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
+"checksum jsonrpc-macros 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
+"checksum jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
+"checksum jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
+"checksum jsonrpc-tcp-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
+"checksum jsonrpc-ws-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
 "checksum keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "253bbe643c32c816bf58fa5a88248fafedeebb139705ad17a62add3517854a86"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kvdb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72ae89206cea31c32014b39d5a454b96135894221610dbfd19cf4d2d044fa546"
@@ -4672,7 +4688,7 @@ dependencies = [
 "checksum string 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00caf261d6f90f588f8450b8e1230fa0d5be49ee6140fdfbcb55335aff350970"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-"checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
+"checksum syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b036b7b35e846707c0e55c2c9441fa47867c0f87fca416921db3261b1d8c741a"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,7 +645,7 @@ dependencies = [
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1287,7 +1287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1783,6 +1783,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-derive"
+version = "9.0.0"
+dependencies = [
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jsonrpc-http-server"
 version = "9.0.0"
 source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
@@ -1826,15 +1835,6 @@ source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360b
 dependencies = [
  "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "jsonrpc-macros"
-version = "9.0.0"
-dependencies = [
- "jsonrpc-core 9.0.0",
- "jsonrpc-pubsub 9.0.0",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2653,9 +2653,9 @@ dependencies = [
  "hardware-wallet 1.12.0",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 9.0.0",
+ "jsonrpc-derive 9.0.0",
  "jsonrpc-http-server 9.0.0",
  "jsonrpc-ipc-server 9.0.0",
- "jsonrpc-macros 9.0.0",
  "jsonrpc-pubsub 9.0.0",
  "jsonrpc-ws-server 9.0.0",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2804,9 +2804,9 @@ dependencies = [
  "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethkey 0.3.0",
  "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-macros 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 9.0.0",
+ "jsonrpc-derive 9.0.0",
+ "jsonrpc-pubsub 9.0.0",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "memzero 0.1.0",
  "ordered-float 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3358,7 +3358,7 @@ dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3492,7 +3492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3632,7 +3632,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.11"
+version = "0.15.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3655,7 +3655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4221,7 +4221,7 @@ dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "validator 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4724,7 +4724,7 @@ dependencies = [
 "checksum string 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00caf261d6f90f588f8450b8e1230fa0d5be49ee6140fdfbcb55335aff350970"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-"checksum syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b036b7b35e846707c0e55c2c9441fa47867c0f87fca416921db3261b1d8c741a"
+"checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,7 +2498,7 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "journaldb 0.2.0",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 9.0.0",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb-rocksdb 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,6 +1772,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-core"
+version = "9.0.0"
+dependencies = [
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jsonrpc-http-server"
 version = "9.0.0"
 source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
@@ -1785,15 +1796,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-http-server"
+version = "9.0.0"
+dependencies = [
+ "hyper 0.12.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 9.0.0",
+ "jsonrpc-server-utils 9.0.0",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jsonrpc-ipc-server"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
 dependencies = [
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 9.0.0",
+ "jsonrpc-server-utils 9.0.0",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-tokio-ipc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1808,6 +1830,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-macros"
+version = "9.0.0"
+dependencies = [
+ "jsonrpc-core 9.0.0",
+ "jsonrpc-pubsub 9.0.0",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jsonrpc-pubsub"
 version = "9.0.0"
 source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
@@ -1818,6 +1849,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-pubsub"
+version = "9.0.0"
+dependencies = [
+ "jsonrpc-core 9.0.0",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jsonrpc-server-utils"
 version = "9.0.0"
 source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
@@ -1825,6 +1866,21 @@ dependencies = [
  "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jsonrpc-server-utils"
+version = "9.0.0"
+dependencies = [
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 9.0.0",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1855,6 +1911,19 @@ dependencies = [
  "jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ws 0.7.9 (git+https://github.com/tomusdrw/ws-rs)",
+]
+
+[[package]]
+name = "jsonrpc-ws-server"
+version = "9.0.0"
+dependencies = [
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 9.0.0",
+ "jsonrpc-server-utils 9.0.0",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.7.9 (git+https://github.com/tomusdrw/ws-rs)",
 ]
@@ -2583,12 +2652,12 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hardware-wallet 1.12.0",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-ipc-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-macros 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-ws-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 9.0.0",
+ "jsonrpc-http-server 9.0.0",
+ "jsonrpc-ipc-server 9.0.0",
+ "jsonrpc-macros 9.0.0",
+ "jsonrpc-pubsub 9.0.0",
+ "jsonrpc-ws-server 9.0.0",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb-memorydb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4500,7 +4569,6 @@ dependencies = [
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 "checksum jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
 "checksum jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
-"checksum jsonrpc-ipc-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
 "checksum jsonrpc-macros 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
 "checksum jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
 "checksum jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,9 +1068,8 @@ version = "1.12.0"
 dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-macros 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-tcp-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.0",
+ "jsonrpc-tcp-server 10.0.0",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1761,19 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
-dependencies = [
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "jsonrpc-core"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1784,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-derive"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1793,24 +1780,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-http-server"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
+version = "10.0.0"
 dependencies = [
  "hyper 0.12.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "jsonrpc-http-server"
-version = "9.0.0"
-dependencies = [
- "hyper 0.12.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0",
- "jsonrpc-server-utils 9.0.0",
+ "jsonrpc-core 10.0.0",
+ "jsonrpc-server-utils 10.0.0",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1818,10 +1792,10 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ipc-server"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
- "jsonrpc-core 9.0.0",
- "jsonrpc-server-utils 9.0.0",
+ "jsonrpc-core 10.0.0",
+ "jsonrpc-server-utils 10.0.0",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-tokio-ipc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1829,30 +1803,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-macros"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
-dependencies = [
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "jsonrpc-pubsub"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
+version = "10.0.0"
 dependencies = [
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "jsonrpc-pubsub"
-version = "9.0.0"
-dependencies = [
- "jsonrpc-core 9.0.0",
+ "jsonrpc-core 10.0.0",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1860,27 +1814,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-server-utils"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
+version = "10.0.0"
 dependencies = [
  "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "jsonrpc-server-utils"
-version = "9.0.0"
-dependencies = [
- "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0",
+ "jsonrpc-core 10.0.0",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1891,37 +1829,22 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-tcp-server"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
+version = "10.0.0"
 dependencies = [
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.0",
+ "jsonrpc-server-utils 10.0.0",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2#84360bf1d03821b8fd669a6a95fcdf847aaf6cca"
+version = "10.0.0"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws 0.7.9 (git+https://github.com/tomusdrw/ws-rs)",
-]
-
-[[package]]
-name = "jsonrpc-ws-server"
-version = "9.0.0"
-dependencies = [
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0",
- "jsonrpc-server-utils 9.0.0",
+ "jsonrpc-core 10.0.0",
+ "jsonrpc-server-utils 10.0.0",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2498,7 +2421,7 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "journaldb 0.2.0",
- "jsonrpc-core 9.0.0",
+ "jsonrpc-core 10.0.0",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb-rocksdb 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2567,8 +2490,8 @@ dependencies = [
  "cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore 1.12.0",
  "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.0",
+ "jsonrpc-http-server 10.0.0",
  "multihash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2652,12 +2575,12 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hardware-wallet 1.12.0",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0",
- "jsonrpc-derive 9.0.0",
- "jsonrpc-http-server 9.0.0",
- "jsonrpc-ipc-server 9.0.0",
- "jsonrpc-pubsub 9.0.0",
- "jsonrpc-ws-server 9.0.0",
+ "jsonrpc-core 10.0.0",
+ "jsonrpc-derive 10.0.0",
+ "jsonrpc-http-server 10.0.0",
+ "jsonrpc-ipc-server 10.0.0",
+ "jsonrpc-pubsub 10.0.0",
+ "jsonrpc-ws-server 10.0.0",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb-memorydb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2693,8 +2616,8 @@ name = "parity-rpc-client"
 version = "1.4.0"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-ws-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.0",
+ "jsonrpc-ws-server 10.0.0",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2804,9 +2727,9 @@ dependencies = [
  "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethkey 0.3.0",
  "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 9.0.0",
- "jsonrpc-derive 9.0.0",
- "jsonrpc-pubsub 9.0.0",
+ "jsonrpc-core 10.0.0",
+ "jsonrpc-derive 10.0.0",
+ "jsonrpc-pubsub 10.0.0",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "memzero 0.1.0",
  "ordered-float 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4346,9 +4269,9 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-network 1.12.0",
  "ethcore-network-devp2p 1.12.0",
- "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
- "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)",
+ "jsonrpc-core 10.0.0",
+ "jsonrpc-http-server 10.0.0",
+ "jsonrpc-pubsub 10.0.0",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic_hook 0.1.0",
  "parity-whisper 0.1.0",
@@ -4567,13 +4490,6 @@ dependencies = [
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1ecfa3b81afc64d9a6539c4eece96ac9a93c551c713a313800dade8e33d7b5c1"
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-"checksum jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
-"checksum jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
-"checksum jsonrpc-macros 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
-"checksum jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
-"checksum jsonrpc-server-utils 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
-"checksum jsonrpc-tcp-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
-"checksum jsonrpc-ws-server 9.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-2.2)" = "<none>"
 "checksum keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "253bbe643c32c816bf58fa5a88248fafedeebb139705ad17a62add3517854a86"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kvdb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72ae89206cea31c32014b39d5a454b96135894221610dbfd19cf4d2d044fa546"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde_derive = "1.0"
 futures = "0.1"
 fdlimit = "0.1"
 ctrlc = { git = "https://github.com/paritytech/rust-ctrlc.git" }
-jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
+jsonrpc-core = "10.0.1"
 ethcore = { path = "ethcore", features = ["parity"] }
 parity-bytes = "0.1"
 common-types = { path = "ethcore/types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde_derive = "1.0"
 futures = "0.1"
 fdlimit = "0.1"
 ctrlc = { git = "https://github.com/paritytech/rust-ctrlc.git" }
-jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
+jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
 ethcore = { path = "ethcore", features = ["parity"] }
 parity-bytes = "0.1"
 common-types = { path = "ethcore/types" }

--- a/cli-signer/rpc-client/Cargo.toml
+++ b/cli-signer/rpc-client/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = "1.0"
 url = "1.2.0"
 matches = "0.1"
 parking_lot = "0.7"
-jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
-jsonrpc-ws-server = { path = "/home/andrew/code/paritytech/jsonrpc/ws" }
+jsonrpc-core = "10.0.1"
+jsonrpc-ws-server = "10.0.1"
 parity-rpc = { path = "../../rpc" }
 keccak-hash = "0.1"

--- a/cli-signer/rpc-client/Cargo.toml
+++ b/cli-signer/rpc-client/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = "1.0"
 url = "1.2.0"
 matches = "0.1"
 parking_lot = "0.7"
-jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-jsonrpc-ws-server = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
+jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
+jsonrpc-ws-server = { path = "/home/andrew/code/paritytech/jsonrpc/ws" }
 parity-rpc = { path = "../../rpc" }
 keccak-hash = "0.1"

--- a/ipfs/Cargo.toml
+++ b/ipfs/Cargo.toml
@@ -9,8 +9,8 @@ authors = ["Parity Technologies <admin@parity.io>"]
 ethcore = { path = "../ethcore" }
 parity-bytes = "0.1"
 ethereum-types = "0.4"
-jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-jsonrpc-http-server = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
+jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
+jsonrpc-http-server = { path = "/home/andrew/code/paritytech/jsonrpc/http" }
 rlp = { version = "0.3.0", features = ["ethereum"] }
 cid = "0.3"
 multihash = "0.8"

--- a/ipfs/Cargo.toml
+++ b/ipfs/Cargo.toml
@@ -9,8 +9,8 @@ authors = ["Parity Technologies <admin@parity.io>"]
 ethcore = { path = "../ethcore" }
 parity-bytes = "0.1"
 ethereum-types = "0.4"
-jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
-jsonrpc-http-server = { path = "/home/andrew/code/paritytech/jsonrpc/http" }
+jsonrpc-core = "10.0.1"
+jsonrpc-http-server = "10.0.1"
 rlp = { version = "0.3.0", features = ["ethereum"] }
 cid = "0.3"
 multihash = "0.8"

--- a/miner/stratum/Cargo.toml
+++ b/miner/stratum/Cargo.toml
@@ -8,8 +8,8 @@ authors = ["Parity Technologies <admin@parity.io>"]
 [dependencies]
 ethereum-types = "0.4"
 keccak-hash = "0.1"
-jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
-jsonrpc-tcp-server = { path = "/home/andrew/code/paritytech/jsonrpc/tcp" }
+jsonrpc-core = "10.0.1"
+jsonrpc-tcp-server = "10.0.1"
 log = "0.4"
 parking_lot = "0.7"
 

--- a/miner/stratum/Cargo.toml
+++ b/miner/stratum/Cargo.toml
@@ -8,9 +8,8 @@ authors = ["Parity Technologies <admin@parity.io>"]
 [dependencies]
 ethereum-types = "0.4"
 keccak-hash = "0.1"
-jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-jsonrpc-macros = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-jsonrpc-tcp-server = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
+jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
+jsonrpc-tcp-server = { path = "/home/andrew/code/paritytech/jsonrpc/tcp" }
 log = "0.4"
 parking_lot = "0.7"
 

--- a/miner/stratum/src/lib.rs
+++ b/miner/stratum/src/lib.rs
@@ -18,7 +18,6 @@
 
 extern crate jsonrpc_tcp_server;
 extern crate jsonrpc_core;
-extern crate jsonrpc_macros;
 extern crate ethereum_types;
 extern crate keccak_hash as hash;
 extern crate parking_lot;
@@ -39,8 +38,7 @@ use jsonrpc_tcp_server::{
 	Server as JsonRpcServer, ServerBuilder as JsonRpcServerBuilder,
 	RequestContext, MetaExtractor, Dispatcher, PushMessageError,
 };
-use jsonrpc_core::{MetaIoHandler, Params, to_value, Value, Metadata, Compatibility};
-use jsonrpc_macros::IoDelegate;
+use jsonrpc_core::{MetaIoHandler, Params, to_value, Value, Metadata, Compatibility, IoDelegate};
 use std::sync::Arc;
 
 use std::net::SocketAddr;

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -27,12 +27,12 @@ tokio-timer = "0.1"
 transient-hashmap = "0.4"
 itertools = "0.5"
 
-jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
-jsonrpc-derive = { path = "/home/andrew/code/paritytech/jsonrpc/derive" }
-jsonrpc-http-server = { path = "/home/andrew/code/paritytech/jsonrpc/http" }
-jsonrpc-ws-server = { path = "/home/andrew/code/paritytech/jsonrpc/ws" }
-jsonrpc-ipc-server = { path = "/home/andrew/code/paritytech/jsonrpc/ipc" }
-jsonrpc-pubsub = { path = "/home/andrew/code/paritytech/jsonrpc/pubsub" }
+jsonrpc-core = "10.0.1"
+jsonrpc-derive = "10.0.1"
+jsonrpc-http-server = "10.0.1"
+jsonrpc-ws-server = "10.0.1"
+jsonrpc-ipc-server = "10.0.1"
+jsonrpc-pubsub = "10.0.1"
 
 common-types = { path = "../ethcore/types" }
 ethash = { path = "../ethash" }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -27,12 +27,12 @@ tokio-timer = "0.1"
 transient-hashmap = "0.4"
 itertools = "0.5"
 
-jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-jsonrpc-http-server = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-jsonrpc-ws-server = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-jsonrpc-ipc-server = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-jsonrpc-macros = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-jsonrpc-pubsub = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
+jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
+jsonrpc-http-server = { path = "/home/andrew/code/paritytech/jsonrpc/http" }
+jsonrpc-ws-server = { path = "/home/andrew/code/paritytech/jsonrpc/ws" }
+jsonrpc-ipc-server = { path = "/home/andrew/code/paritytech/jsonrpc/ipc" }
+jsonrpc-macros = { path = "/home/andrew/code/paritytech/jsonrpc/macros" }
+jsonrpc-pubsub = { path = "/home/andrew/code/paritytech/jsonrpc/pubsub" }
 
 common-types = { path = "../ethcore/types" }
 ethash = { path = "../ethash" }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -28,10 +28,10 @@ transient-hashmap = "0.4"
 itertools = "0.5"
 
 jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
+jsonrpc-derive = { path = "/home/andrew/code/paritytech/jsonrpc/derive" }
 jsonrpc-http-server = { path = "/home/andrew/code/paritytech/jsonrpc/http" }
 jsonrpc-ws-server = { path = "/home/andrew/code/paritytech/jsonrpc/ws" }
 jsonrpc-ipc-server = { path = "/home/andrew/code/paritytech/jsonrpc/ipc" }
-jsonrpc-macros = { path = "/home/andrew/code/paritytech/jsonrpc/macros" }
 jsonrpc-pubsub = { path = "/home/andrew/code/paritytech/jsonrpc/pubsub" }
 
 common-types = { path = "../ethcore/types" }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -37,6 +37,7 @@ extern crate tokio_timer;
 extern crate transient_hashmap;
 
 extern crate jsonrpc_core;
+extern crate jsonrpc_derive;
 extern crate jsonrpc_http_server as http;
 extern crate jsonrpc_ipc_server as ipc;
 extern crate jsonrpc_pubsub;
@@ -74,8 +75,6 @@ extern crate fake_hardware_wallet as hardware_wallet;
 
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate jsonrpc_macros;
 #[macro_use]
 extern crate serde_derive;
 

--- a/rpc/src/v1/helpers/light_fetch.rs
+++ b/rpc/src/v1/helpers/light_fetch.rs
@@ -29,7 +29,6 @@ use ethcore::executed::ExecutionError;
 use jsonrpc_core::{Result, Error};
 use jsonrpc_core::futures::{future, Future};
 use jsonrpc_core::futures::future::Either;
-use jsonrpc_macros::Trailing;
 
 use light::cache::Cache;
 use light::client::LightChainClient;
@@ -202,7 +201,7 @@ impl LightFetch {
 	}
 
 	/// Helper for getting proved execution.
-	pub fn proved_read_only_execution(&self, req: CallRequest, num: Trailing<BlockNumber>) -> impl Future<Item = ExecutionResult, Error = Error> + Send {
+	pub fn proved_read_only_execution(&self, req: CallRequest, num: Option<BlockNumber>) -> impl Future<Item = ExecutionResult, Error = Error> + Send {
 		const DEFAULT_GAS_PRICE: u64 = 21_000;
 		// (21000 G_transaction + 32000 G_create + some marginal to allow a few operations)
 		const START_GAS: u64 = 60_000;

--- a/rpc/src/v1/helpers/subscribers.rs
+++ b/rpc/src/v1/helpers/subscribers.rs
@@ -18,7 +18,7 @@
 
 use std::{ops, str};
 use std::collections::HashMap;
-use jsonrpc_macros::pubsub::{Subscriber, Sink, SubscriptionId};
+use jsonrpc_pubsub::{typed::{Subscriber, Sink}, SubscriptionId};
 use rand::{Rng, StdRng};
 use v1::types::H64;
 

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -39,7 +39,6 @@ use types::filter::Filter as EthcoreFilter;
 
 use jsonrpc_core::{BoxFuture, Result};
 use jsonrpc_core::futures::future;
-use jsonrpc_macros::Trailing;
 
 use v1::helpers::{self, errors, limit_logs, fake_sign};
 use v1::helpers::dispatch::{FullDispatcher, default_gas_price};
@@ -568,7 +567,7 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 		Ok(RpcU256::from(self.client.chain_info().best_block_number))
 	}
 
-	fn balance(&self, address: RpcH160, num: Trailing<BlockNumber>) -> BoxFuture<RpcU256> {
+	fn balance(&self, address: RpcH160, num: Option<BlockNumber>) -> BoxFuture<RpcU256> {
 		let address = address.into();
 
 		let num = num.unwrap_or_default();
@@ -582,7 +581,7 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 		Box::new(future::done(res))
 	}
 
-	fn proof(&self, address: RpcH160, values: Vec<RpcH256>, num: Trailing<BlockNumber>) -> BoxFuture<EthAccount> {
+	fn proof(&self, address: RpcH160, values: Vec<RpcH256>, num: Option<BlockNumber>) -> BoxFuture<EthAccount> {
 		try_bf!(errors::require_experimental(self.options.allow_experimental_rpcs, "1186"));
 
 		let a: H160 = address.clone().into();
@@ -625,7 +624,7 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 		Box::new(future::done(res))
 	}
 
-	fn storage_at(&self, address: RpcH160, pos: RpcU256, num: Trailing<BlockNumber>) -> BoxFuture<RpcH256> {
+	fn storage_at(&self, address: RpcH160, pos: RpcU256, num: Option<BlockNumber>) -> BoxFuture<RpcH256> {
 		let address: Address = RpcH160::into(address);
 		let position: U256 = RpcU256::into(pos);
 
@@ -640,7 +639,7 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 		Box::new(future::done(res))
 	}
 
-	fn transaction_count(&self, address: RpcH160, num: Trailing<BlockNumber>) -> BoxFuture<RpcU256> {
+	fn transaction_count(&self, address: RpcH160, num: Option<BlockNumber>) -> BoxFuture<RpcU256> {
 		let address: Address = RpcH160::into(address);
 
 		let res = match num.unwrap_or_default() {
@@ -723,7 +722,7 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 		}))
 	}
 
-	fn code_at(&self, address: RpcH160, num: Trailing<BlockNumber>) -> BoxFuture<Bytes> {
+	fn code_at(&self, address: RpcH160, num: Option<BlockNumber>) -> BoxFuture<Bytes> {
 		let address: Address = RpcH160::into(address);
 
 		let num = num.unwrap_or_default();
@@ -832,7 +831,7 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 		base_logs(&*self.client, &*self.miner, filter.into())
 	}
 
-	fn work(&self, no_new_work_timeout: Trailing<u64>) -> Result<Work> {
+	fn work(&self, no_new_work_timeout: Option<u64>) -> Result<Work> {
 		let no_new_work_timeout = no_new_work_timeout.unwrap_or_default();
 
 		// check if we're still syncing and return empty strings in that case
@@ -918,7 +917,7 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 		self.send_raw_transaction(raw)
 	}
 
-	fn call(&self, request: CallRequest, num: Trailing<BlockNumber>) -> BoxFuture<Bytes> {
+	fn call(&self, request: CallRequest, num: Option<BlockNumber>) -> BoxFuture<Bytes> {
 		let request = CallRequest::into(request);
 		let signed = try_bf!(fake_sign::sign_call(request));
 
@@ -958,7 +957,7 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 		))
 	}
 
-	fn estimate_gas(&self, request: CallRequest, num: Trailing<BlockNumber>) -> BoxFuture<RpcU256> {
+	fn estimate_gas(&self, request: CallRequest, num: Option<BlockNumber>) -> BoxFuture<RpcU256> {
 		let request = CallRequest::into(request);
 		let signed = try_bf!(fake_sign::sign_call(request));
 		let num = num.unwrap_or_default();

--- a/rpc/src/v1/impls/eth_pubsub.rs
+++ b/rpc/src/v1/impls/eth_pubsub.rs
@@ -21,9 +21,7 @@ use std::collections::BTreeMap;
 
 use jsonrpc_core::{BoxFuture, Result, Error};
 use jsonrpc_core::futures::{self, Future, IntoFuture};
-use jsonrpc_macros::Trailing;
-use jsonrpc_macros::pubsub::{Sink, Subscriber};
-use jsonrpc_pubsub::SubscriptionId;
+use jsonrpc_pubsub::{SubscriptionId, typed::{Sink, Subscriber}};
 
 use v1::helpers::{errors, limit_logs, Subscribers};
 use v1::helpers::light_fetch::LightFetch;
@@ -262,7 +260,7 @@ impl<C: Send + Sync + 'static> EthPubSub for EthPubSubClient<C> {
 		_meta: Metadata,
 		subscriber: Subscriber<pubsub::Result>,
 		kind: pubsub::Kind,
-		params: Trailing<pubsub::Params>,
+		params: Option<pubsub::Params>,
 	) {
 		let error = match (kind, params.into()) {
 			(pubsub::Kind::NewHeads, None) => {
@@ -299,7 +297,7 @@ impl<C: Send + Sync + 'static> EthPubSub for EthPubSubClient<C> {
 		let _ = subscriber.reject(error);
 	}
 
-	fn unsubscribe(&self, id: SubscriptionId) -> Result<bool> {
+	fn unsubscribe(&self, _: Option<Self::Metadata>, id: SubscriptionId) -> Result<bool> {
 		let res = self.heads_subscribers.write().remove(&id).is_some();
 		let res2 = self.logs_subscribers.write().remove(&id).is_some();
 		let res3 = self.transactions_subscribers.write().remove(&id).is_some();

--- a/rpc/src/v1/impls/light/eth.rs
+++ b/rpc/src/v1/impls/light/eth.rs
@@ -22,7 +22,6 @@ use std::sync::Arc;
 use jsonrpc_core::{Result, BoxFuture};
 use jsonrpc_core::futures::{future, Future};
 use jsonrpc_core::futures::future::Either;
-use jsonrpc_macros::Trailing;
 
 use light::cache::Cache as LightDataCache;
 use light::client::LightChainClient;
@@ -272,12 +271,12 @@ impl<T: LightChainClient + 'static> Eth for EthClient<T> {
 		Ok(self.client.chain_info().best_block_number.into())
 	}
 
-	fn balance(&self, address: RpcH160, num: Trailing<BlockNumber>) -> BoxFuture<RpcU256> {
+	fn balance(&self, address: RpcH160, num: Option<BlockNumber>) -> BoxFuture<RpcU256> {
 		Box::new(self.fetcher().account(address.into(), num.unwrap_or_default().to_block_id())
 			.map(|acc| acc.map_or(0.into(), |a| a.balance).into()))
 	}
 
-	fn storage_at(&self, _address: RpcH160, _key: RpcU256, _num: Trailing<BlockNumber>) -> BoxFuture<RpcH256> {
+	fn storage_at(&self, _address: RpcH160, _key: RpcU256, _num: Option<BlockNumber>) -> BoxFuture<RpcH256> {
 		Box::new(future::err(errors::unimplemented(None)))
 	}
 
@@ -289,7 +288,7 @@ impl<T: LightChainClient + 'static> Eth for EthClient<T> {
 		Box::new(self.rich_block(num.to_block_id(), include_txs).map(Some))
 	}
 
-	fn transaction_count(&self, address: RpcH160, num: Trailing<BlockNumber>) -> BoxFuture<RpcU256> {
+	fn transaction_count(&self, address: RpcH160, num: Option<BlockNumber>) -> BoxFuture<RpcU256> {
 		Box::new(self.fetcher().account(address.into(), num.unwrap_or_default().to_block_id())
 			.map(|acc| acc.map_or(0.into(), |a| a.nonce).into()))
 	}
@@ -358,7 +357,7 @@ impl<T: LightChainClient + 'static> Eth for EthClient<T> {
 		}))
 	}
 
-	fn code_at(&self, address: RpcH160, num: Trailing<BlockNumber>) -> BoxFuture<Bytes> {
+	fn code_at(&self, address: RpcH160, num: Option<BlockNumber>) -> BoxFuture<Bytes> {
 		Box::new(self.fetcher().code(address.into(), num.unwrap_or_default().to_block_id()).map(Into::into))
 	}
 
@@ -385,7 +384,7 @@ impl<T: LightChainClient + 'static> Eth for EthClient<T> {
 		self.send_raw_transaction(raw)
 	}
 
-	fn call(&self, req: CallRequest, num: Trailing<BlockNumber>) -> BoxFuture<Bytes> {
+	fn call(&self, req: CallRequest, num: Option<BlockNumber>) -> BoxFuture<Bytes> {
 		Box::new(self.fetcher().proved_read_only_execution(req, num).and_then(|res| {
 			match res {
 				Ok(exec) => Ok(exec.output.into()),
@@ -394,7 +393,7 @@ impl<T: LightChainClient + 'static> Eth for EthClient<T> {
 		}))
 	}
 
-	fn estimate_gas(&self, req: CallRequest, num: Trailing<BlockNumber>) -> BoxFuture<RpcU256> {
+	fn estimate_gas(&self, req: CallRequest, num: Option<BlockNumber>) -> BoxFuture<RpcU256> {
 		// TODO: binary chop for more accurate estimates.
 		Box::new(self.fetcher().proved_read_only_execution(req, num).and_then(|res| {
 			match res {
@@ -475,7 +474,7 @@ impl<T: LightChainClient + 'static> Eth for EthClient<T> {
 		}))
 	}
 
-	fn proof(&self, _address: RpcH160, _values:Vec<RpcH256>, _num: Trailing<BlockNumber>) -> BoxFuture<EthAccount> {
+	fn proof(&self, _address: RpcH160, _values:Vec<RpcH256>, _num: Option<BlockNumber>) -> BoxFuture<EthAccount> {
 		Box::new(future::err(errors::unimplemented(None)))
 	}
 
@@ -505,7 +504,7 @@ impl<T: LightChainClient + 'static> Eth for EthClient<T> {
 			}).map(move |logs| limit_logs(logs, limit)))
 	}
 
-	fn work(&self, _timeout: Trailing<u64>) -> Result<Work> {
+	fn work(&self, _timeout: Option<u64>) -> Result<Work> {
 		Err(errors::light_unimplemented(None))
 	}
 

--- a/rpc/src/v1/impls/light/parity.rs
+++ b/rpc/src/v1/impls/light/parity.rs
@@ -29,7 +29,6 @@ use ethcore_logger::RotatingLogger;
 
 use jsonrpc_core::{Result, BoxFuture};
 use jsonrpc_core::futures::{future, Future};
-use jsonrpc_macros::Trailing;
 use v1::helpers::{self, errors, ipfs, SigningQueue, SignerService, NetworkSettings, verify_signature};
 use v1::helpers::dispatch::LightDispatcher;
 use v1::helpers::light_fetch::{LightFetch, light_all_transactions};
@@ -232,11 +231,11 @@ impl Parity for ParityClient {
 		Ok(Brain::new(phrase).generate().unwrap().address().into())
 	}
 
-	fn list_accounts(&self, _: u64, _: Option<H160>, _: Trailing<BlockNumber>) -> Result<Option<Vec<H160>>> {
+	fn list_accounts(&self, _: u64, _: Option<H160>, _: Option<BlockNumber>) -> Result<Option<Vec<H160>>> {
 		Err(errors::light_unimplemented(None))
 	}
 
-	fn list_storage_keys(&self, _: H160, _: u64, _: Option<H256>, _: Trailing<BlockNumber>) -> Result<Option<Vec<H256>>> {
+	fn list_storage_keys(&self, _: H160, _: u64, _: Option<H256>, _: Option<BlockNumber>) -> Result<Option<Vec<H256>>> {
 		Err(errors::light_unimplemented(None))
 	}
 
@@ -246,7 +245,7 @@ impl Parity for ParityClient {
 			.map(Into::into)
 	}
 
-	fn pending_transactions(&self, limit: Trailing<usize>) -> Result<Vec<Transaction>> {
+	fn pending_transactions(&self, limit: Option<usize>) -> Result<Vec<Transaction>> {
 		let txq = self.light_dispatch.transaction_queue.read();
 		let chain_info = self.light_dispatch.client.chain_info();
 		Ok(
@@ -365,7 +364,7 @@ impl Parity for ParityClient {
 		})
 	}
 
-	fn block_header(&self, number: Trailing<BlockNumber>) -> BoxFuture<RichHeader> {
+	fn block_header(&self, number: Option<BlockNumber>) -> BoxFuture<RichHeader> {
 		use types::encoded;
 
 		let engine = self.light_dispatch.client.engine().clone();
@@ -399,7 +398,7 @@ impl Parity for ParityClient {
 		Box::new(self.fetcher().header(id).and_then(from_encoded))
 	}
 
-	fn block_receipts(&self, number: Trailing<BlockNumber>) -> BoxFuture<Vec<Receipt>> {
+	fn block_receipts(&self, number: Option<BlockNumber>) -> BoxFuture<Vec<Receipt>> {
 		let id = number.unwrap_or_default().to_block_id();
 		Box::new(self.fetcher().receipts(id).and_then(|receipts| Ok(receipts.into_iter().map(Into::into).collect())))
 	}
@@ -408,7 +407,7 @@ impl Parity for ParityClient {
 		ipfs::cid(content)
 	}
 
-	fn call(&self, _requests: Vec<CallRequest>, _block: Trailing<BlockNumber>) -> Result<Vec<Bytes>> {
+	fn call(&self, _requests: Vec<CallRequest>, _block: Option<BlockNumber>) -> Result<Vec<Bytes>> {
 		Err(errors::light_unimplemented(None))
 	}
 

--- a/rpc/src/v1/impls/light/trace.rs
+++ b/rpc/src/v1/impls/light/trace.rs
@@ -17,7 +17,6 @@
 //! Traces api implementation.
 
 use jsonrpc_core::Result;
-use jsonrpc_macros::Trailing;
 use v1::Metadata;
 use v1::traits::Traces;
 use v1::helpers::errors;
@@ -46,15 +45,15 @@ impl Traces for TracesClient {
 		Err(errors::light_unimplemented(None))
 	}
 
-	fn call(&self, _request: CallRequest, _flags: TraceOptions, _block: Trailing<BlockNumber>) -> Result<TraceResults> {
+	fn call(&self, _request: CallRequest, _flags: TraceOptions, _block: Option<BlockNumber>) -> Result<TraceResults> {
 		Err(errors::light_unimplemented(None))
 	}
 
-	fn call_many(&self, _request: Vec<(CallRequest, TraceOptions)>, _block: Trailing<BlockNumber>) -> Result<Vec<TraceResults>> {
+	fn call_many(&self, _request: Vec<(CallRequest, TraceOptions)>, _block: Option<BlockNumber>) -> Result<Vec<TraceResults>> {
 		Err(errors::light_unimplemented(None))
 	}
 
-	fn raw_transaction(&self, _raw_transaction: Bytes, _flags: TraceOptions, _block: Trailing<BlockNumber>) -> Result<TraceResults> {
+	fn raw_transaction(&self, _raw_transaction: Bytes, _flags: TraceOptions, _block: Option<BlockNumber>) -> Result<TraceResults> {
 		Err(errors::light_unimplemented(None))
 	}
 

--- a/rpc/src/v1/impls/parity.rs
+++ b/rpc/src/v1/impls/parity.rs
@@ -33,7 +33,6 @@ use ethkey::{crypto::ecies, Brain, Generator};
 use ethstore::random_phrase;
 use jsonrpc_core::futures::future;
 use jsonrpc_core::{BoxFuture, Result};
-use jsonrpc_macros::Trailing;
 use sync::{SyncProvider, ManageNetwork};
 use types::ids::BlockId;
 use updater::{Service as UpdateService};
@@ -252,7 +251,7 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 		Ok(Brain::new(phrase).generate().unwrap().address().into())
 	}
 
-	fn list_accounts(&self, count: u64, after: Option<H160>, block_number: Trailing<BlockNumber>) -> Result<Option<Vec<H160>>> {
+	fn list_accounts(&self, count: u64, after: Option<H160>, block_number: Option<BlockNumber>) -> Result<Option<Vec<H160>>> {
 		let number = match block_number.unwrap_or_default() {
 			BlockNumber::Pending => {
 				warn!("BlockNumber::Pending is unsupported");
@@ -267,7 +266,7 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 			.map(|a| a.into_iter().map(Into::into).collect()))
 	}
 
-	fn list_storage_keys(&self, address: H160, count: u64, after: Option<H256>, block_number: Trailing<BlockNumber>) -> Result<Option<Vec<H256>>> {
+	fn list_storage_keys(&self, address: H160, count: u64, after: Option<H256>, block_number: Option<BlockNumber>) -> Result<Option<Vec<H256>>> {
 		let number = match block_number.unwrap_or_default() {
 			BlockNumber::Pending => {
 				warn!("BlockNumber::Pending is unsupported");
@@ -288,7 +287,7 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 			.map(Into::into)
 	}
 
-	fn pending_transactions(&self, limit: Trailing<usize>) -> Result<Vec<Transaction>> {
+	fn pending_transactions(&self, limit: Option<usize>) -> Result<Vec<Transaction>> {
 		let ready_transactions = self.miner.ready_transactions(
 			&*self.client,
 			limit.unwrap_or_else(usize::max_value),
@@ -394,7 +393,7 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 		})
 	}
 
-	fn block_header(&self, number: Trailing<BlockNumber>) -> BoxFuture<RichHeader> {
+	fn block_header(&self, number: Option<BlockNumber>) -> BoxFuture<RichHeader> {
 		const EXTRA_INFO_PROOF: &str = "Object exists in blockchain (fetched earlier), extra_info is always available if object exists; qed";
 		let number = number.unwrap_or_default();
 
@@ -424,7 +423,7 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 		}))
 	}
 
-	fn block_receipts(&self, number: Trailing<BlockNumber>) -> BoxFuture<Vec<Receipt>> {
+	fn block_receipts(&self, number: Option<BlockNumber>) -> BoxFuture<Vec<Receipt>> {
 		let number = number.unwrap_or_default();
 
 		let id = match number {
@@ -449,7 +448,7 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 		ipfs::cid(content)
 	}
 
-	fn call(&self, requests: Vec<CallRequest>, num: Trailing<BlockNumber>) -> Result<Vec<Bytes>> {
+	fn call(&self, requests: Vec<CallRequest>, num: Option<BlockNumber>) -> Result<Vec<Bytes>> {
 		let requests = requests
 			.into_iter()
 			.map(|request| Ok((

--- a/rpc/src/v1/impls/pubsub.rs
+++ b/rpc/src/v1/impls/pubsub.rs
@@ -22,8 +22,7 @@ use parking_lot::RwLock;
 
 use jsonrpc_core::{self as core, Result, MetaIoHandler};
 use jsonrpc_core::futures::{future, Future, Stream, Sink};
-use jsonrpc_macros::Trailing;
-use jsonrpc_macros::pubsub::Subscriber;
+use jsonrpc_pubsub::typed::Subscriber;
 use jsonrpc_pubsub::SubscriptionId;
 use tokio_timer;
 
@@ -81,7 +80,7 @@ impl PubSubClient<core::NoopMiddleware> {
 impl<S: core::Middleware<Metadata>> PubSub for PubSubClient<S> {
 	type Metadata = Metadata;
 
-	fn parity_subscribe(&self, mut meta: Metadata, subscriber: Subscriber<core::Value>, method: String, params: Trailing<core::Params>) {
+	fn parity_subscribe(&self, mut meta: Metadata, subscriber: Subscriber<core::Value>, method: String, params: Option<core::Params>) {
 		let params = params.unwrap_or(core::Params::Array(vec![]));
 		// Make sure to get rid of PubSub session otherwise it will never be dropped.
 		meta.session = None;
@@ -100,7 +99,7 @@ impl<S: core::Middleware<Metadata>> PubSub for PubSubClient<S> {
 		}
 	}
 
-	fn parity_unsubscribe(&self, id: SubscriptionId) -> Result<bool> {
+	fn parity_unsubscribe(&self, _: Option<Self::Metadata>, id: SubscriptionId) -> Result<bool> {
 		let res = self.poll_manager.write().unsubscribe(&id);
 		Ok(res)
 	}

--- a/rpc/src/v1/impls/signer.rs
+++ b/rpc/src/v1/impls/signer.rs
@@ -28,8 +28,7 @@ use types::transaction::{SignedTransaction, PendingTransaction};
 use jsonrpc_core::{Result, BoxFuture, Error};
 use jsonrpc_core::futures::{future, Future, IntoFuture};
 use jsonrpc_core::futures::future::Either;
-use jsonrpc_pubsub::SubscriptionId;
-use jsonrpc_macros::pubsub::{Sink, Subscriber};
+use jsonrpc_pubsub::{SubscriptionId, typed::{Sink, Subscriber}};
 use v1::helpers::dispatch::{self, Dispatcher, WithToken, eth_data_hash};
 use v1::helpers::{errors, SignerService, SigningQueue, ConfirmationPayload, FilledTransactionRequest, Subscribers};
 use v1::metadata::Metadata;
@@ -255,7 +254,7 @@ impl<D: Dispatcher + 'static> Signer for SignerClient<D> {
 		self.subscribers.lock().push(sub)
 	}
 
-	fn unsubscribe_pending(&self, id: SubscriptionId) -> Result<bool> {
+	fn unsubscribe_pending(&self, _: Option<Self::Metadata>, id: SubscriptionId) -> Result<bool> {
 		let res = self.subscribers.lock().remove(&id).is_some();
 		Ok(res)
 	}

--- a/rpc/src/v1/impls/traces.rs
+++ b/rpc/src/v1/impls/traces.rs
@@ -23,7 +23,6 @@ use rlp::Rlp;
 use types::transaction::SignedTransaction;
 
 use jsonrpc_core::Result;
-use jsonrpc_macros::Trailing;
 use v1::Metadata;
 use v1::traits::Traces;
 use v1::helpers::{errors, fake_sign};
@@ -87,7 +86,7 @@ impl<C, S> Traces for TracesClient<C> where
 			.map(LocalizedTrace::from))
 	}
 
-	fn call(&self, request: CallRequest, flags: TraceOptions, block: Trailing<BlockNumber>) -> Result<TraceResults> {
+	fn call(&self, request: CallRequest, flags: TraceOptions, block: Option<BlockNumber>) -> Result<TraceResults> {
 		let block = block.unwrap_or_default();
 
 		let request = CallRequest::into(request);
@@ -109,7 +108,7 @@ impl<C, S> Traces for TracesClient<C> where
 			.map_err(errors::call)
 	}
 
-	fn call_many(&self, requests: Vec<(CallRequest, TraceOptions)>, block: Trailing<BlockNumber>) -> Result<Vec<TraceResults>> {
+	fn call_many(&self, requests: Vec<(CallRequest, TraceOptions)>, block: Option<BlockNumber>) -> Result<Vec<TraceResults>> {
 		let block = block.unwrap_or_default();
 
 		let requests = requests.into_iter()
@@ -136,7 +135,7 @@ impl<C, S> Traces for TracesClient<C> where
 			.map_err(errors::call)
 	}
 
-	fn raw_transaction(&self, raw_transaction: Bytes, flags: TraceOptions, block: Trailing<BlockNumber>) -> Result<TraceResults> {
+	fn raw_transaction(&self, raw_transaction: Bytes, flags: TraceOptions, block: Option<BlockNumber>) -> Result<TraceResults> {
 		let block = block.unwrap_or_default();
 
 		let tx = Rlp::new(&raw_transaction.into_vec()).as_val().map_err(|e| errors::invalid_params("Transaction is not valid RLP", e))?;

--- a/rpc/src/v1/traits/debug.rs
+++ b/rpc/src/v1/traits/debug.rs
@@ -21,9 +21,8 @@ use jsonrpc_derive::rpc;
 
 use v1::types::RichBlock;
 
-#[rpc]
 /// Debug RPC interface.
-
+#[rpc]
 pub trait Debug {
 	/// Returns recently seen bad blocks.
 	#[rpc(name = "debug_getBadBlocks")]

--- a/rpc/src/v1/traits/debug.rs
+++ b/rpc/src/v1/traits/debug.rs
@@ -17,14 +17,15 @@
 //! Debug RPC interface.
 
 use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
 
 use v1::types::RichBlock;
 
-build_rpc_trait! {
-	/// Debug RPC interface.
-	pub trait Debug {
-		/// Returns recently seen bad blocks.
-		#[rpc(name = "debug_getBadBlocks")]
-		fn bad_blocks(&self) -> Result<Vec<RichBlock>>;
-	}
+#[rpc]
+/// Debug RPC interface.
+
+pub trait Debug {
+	/// Returns recently seen bad blocks.
+	#[rpc(name = "debug_getBadBlocks")]
+	fn bad_blocks(&self) -> Result<Vec<RichBlock>>;
 }

--- a/rpc/src/v1/traits/eth.rs
+++ b/rpc/src/v1/traits/eth.rs
@@ -16,203 +16,202 @@
 
 //! Eth rpc interface.
 use jsonrpc_core::{Result, BoxFuture};
-use jsonrpc_macros::Trailing;
+use jsonrpc_derive::rpc;
 
 use v1::types::{RichBlock, BlockNumber, Bytes, CallRequest, Filter, FilterChanges, Index, EthAccount};
 use v1::types::{Log, Receipt, SyncStatus, Transaction, Work};
 use v1::types::{H64, H160, H256, U256, U64};
 
-build_rpc_trait! {
-	/// Eth rpc interface.
-	pub trait Eth {
-		type Metadata;
+/// Eth rpc interface.
+#[rpc]
+pub trait Eth {
+	/// RPC Metadata
+	type Metadata;
 
-		/// Returns protocol version encoded as a string (quotes are necessary).
-		#[rpc(name = "eth_protocolVersion")]
-		fn protocol_version(&self) -> Result<String>;
+	/// Returns protocol version encoded as a string (quotes are necessary).
+	#[rpc(name = "eth_protocolVersion")]
+	fn protocol_version(&self) -> Result<String>;
 
-		/// Returns an object with data about the sync status or false. (wtf?)
-		#[rpc(name = "eth_syncing")]
-		fn syncing(&self) -> Result<SyncStatus>;
+	/// Returns an object with data about the sync status or false. (wtf?)
+	#[rpc(name = "eth_syncing")]
+	fn syncing(&self) -> Result<SyncStatus>;
 
-		/// Returns the number of hashes per second that the node is mining with.
-		#[rpc(name = "eth_hashrate")]
-		fn hashrate(&self) -> Result<U256>;
+	/// Returns the number of hashes per second that the node is mining with.
+	#[rpc(name = "eth_hashrate")]
+	fn hashrate(&self) -> Result<U256>;
 
-		/// Returns block author.
-		#[rpc(name = "eth_coinbase")]
-		fn author(&self) -> Result<H160>;
+	/// Returns block author.
+	#[rpc(name = "eth_coinbase")]
+	fn author(&self) -> Result<H160>;
 
-		/// Returns true if client is actively mining new blocks.
-		#[rpc(name = "eth_mining")]
-		fn is_mining(&self) -> Result<bool>;
+	/// Returns true if client is actively mining new blocks.
+	#[rpc(name = "eth_mining")]
+	fn is_mining(&self) -> Result<bool>;
 
-		/// Returns the chain ID used for transaction signing at the
-		/// current best block. None is returned if not
-		/// available.
-		#[rpc(name = "eth_chainId")]
-		fn chain_id(&self) -> Result<Option<U64>>;
+	/// Returns the chain ID used for transaction signing at the
+	/// current best block. None is returned if not
+	/// available.
+	#[rpc(name = "eth_chainId")]
+	fn chain_id(&self) -> Result<Option<U64>>;
 
-		/// Returns current gas_price.
-		#[rpc(name = "eth_gasPrice")]
-		fn gas_price(&self) -> Result<U256>;
+	/// Returns current gas_price.
+	#[rpc(name = "eth_gasPrice")]
+	fn gas_price(&self) -> Result<U256>;
 
-		/// Returns accounts list.
-		#[rpc(name = "eth_accounts")]
-		fn accounts(&self) -> Result<Vec<H160>>;
+	/// Returns accounts list.
+	#[rpc(name = "eth_accounts")]
+	fn accounts(&self) -> Result<Vec<H160>>;
 
-		/// Returns highest block number.
-		#[rpc(name = "eth_blockNumber")]
-		fn block_number(&self) -> Result<U256>;
+	/// Returns highest block number.
+	#[rpc(name = "eth_blockNumber")]
+	fn block_number(&self) -> Result<U256>;
 
-		/// Returns balance of the given account.
-		#[rpc(name = "eth_getBalance")]
-		fn balance(&self, H160, Trailing<BlockNumber>) -> BoxFuture<U256>;
+	/// Returns balance of the given account.
+	#[rpc(name = "eth_getBalance")]
+	fn balance(&self, H160, Option<BlockNumber>) -> BoxFuture<U256>;
 
-		/// Returns the account- and storage-values of the specified account including the Merkle-proof
-		#[rpc(name = "eth_getProof")]
-		fn proof(&self, H160, Vec<H256>, Trailing<BlockNumber>) -> BoxFuture<EthAccount>;
+	/// Returns the account- and storage-values of the specified account including the Merkle-proof
+	#[rpc(name = "eth_getProof")]
+	fn proof(&self, H160, Vec<H256>, Option<BlockNumber>) -> BoxFuture<EthAccount>;
 
-		/// Returns content of the storage at given address.
-		#[rpc(name = "eth_getStorageAt")]
-		fn storage_at(&self, H160, U256, Trailing<BlockNumber>) -> BoxFuture<H256>;
+	/// Returns content of the storage at given address.
+	#[rpc(name = "eth_getStorageAt")]
+	fn storage_at(&self, H160, U256, Option<BlockNumber>) -> BoxFuture<H256>;
 
-		/// Returns block with given hash.
-		#[rpc(name = "eth_getBlockByHash")]
-		fn block_by_hash(&self, H256, bool) -> BoxFuture<Option<RichBlock>>;
+	/// Returns block with given hash.
+	#[rpc(name = "eth_getBlockByHash")]
+	fn block_by_hash(&self, H256, bool) -> BoxFuture<Option<RichBlock>>;
 
-		/// Returns block with given number.
-		#[rpc(name = "eth_getBlockByNumber")]
-		fn block_by_number(&self, BlockNumber, bool) -> BoxFuture<Option<RichBlock>>;
+	/// Returns block with given number.
+	#[rpc(name = "eth_getBlockByNumber")]
+	fn block_by_number(&self, BlockNumber, bool) -> BoxFuture<Option<RichBlock>>;
 
-		/// Returns the number of transactions sent from given address at given time (block number).
-		#[rpc(name = "eth_getTransactionCount")]
-		fn transaction_count(&self, H160, Trailing<BlockNumber>) -> BoxFuture<U256>;
+	/// Returns the number of transactions sent from given address at given time (block number).
+	#[rpc(name = "eth_getTransactionCount")]
+	fn transaction_count(&self, H160, Option<BlockNumber>) -> BoxFuture<U256>;
 
-		/// Returns the number of transactions in a block with given hash.
-		#[rpc(name = "eth_getBlockTransactionCountByHash")]
-		fn block_transaction_count_by_hash(&self, H256) -> BoxFuture<Option<U256>>;
+	/// Returns the number of transactions in a block with given hash.
+	#[rpc(name = "eth_getBlockTransactionCountByHash")]
+	fn block_transaction_count_by_hash(&self, H256) -> BoxFuture<Option<U256>>;
 
-		/// Returns the number of transactions in a block with given block number.
-		#[rpc(name = "eth_getBlockTransactionCountByNumber")]
-		fn block_transaction_count_by_number(&self, BlockNumber) -> BoxFuture<Option<U256>>;
+	/// Returns the number of transactions in a block with given block number.
+	#[rpc(name = "eth_getBlockTransactionCountByNumber")]
+	fn block_transaction_count_by_number(&self, BlockNumber) -> BoxFuture<Option<U256>>;
 
-		/// Returns the number of uncles in a block with given hash.
-		#[rpc(name = "eth_getUncleCountByBlockHash")]
-		fn block_uncles_count_by_hash(&self, H256) -> BoxFuture<Option<U256>>;
+	/// Returns the number of uncles in a block with given hash.
+	#[rpc(name = "eth_getUncleCountByBlockHash")]
+	fn block_uncles_count_by_hash(&self, H256) -> BoxFuture<Option<U256>>;
 
-		/// Returns the number of uncles in a block with given block number.
-		#[rpc(name = "eth_getUncleCountByBlockNumber")]
-		fn block_uncles_count_by_number(&self, BlockNumber) -> BoxFuture<Option<U256>>;
+	/// Returns the number of uncles in a block with given block number.
+	#[rpc(name = "eth_getUncleCountByBlockNumber")]
+	fn block_uncles_count_by_number(&self, BlockNumber) -> BoxFuture<Option<U256>>;
 
-		/// Returns the code at given address at given time (block number).
-		#[rpc(name = "eth_getCode")]
-		fn code_at(&self, H160, Trailing<BlockNumber>) -> BoxFuture<Bytes>;
+	/// Returns the code at given address at given time (block number).
+	#[rpc(name = "eth_getCode")]
+	fn code_at(&self, H160, Option<BlockNumber>) -> BoxFuture<Bytes>;
 
-		/// Sends signed transaction, returning its hash.
-		#[rpc(name = "eth_sendRawTransaction")]
-		fn send_raw_transaction(&self, Bytes) -> Result<H256>;
+	/// Sends signed transaction, returning its hash.
+	#[rpc(name = "eth_sendRawTransaction")]
+	fn send_raw_transaction(&self, Bytes) -> Result<H256>;
 
-		/// @alias of `eth_sendRawTransaction`.
-		#[rpc(name = "eth_submitTransaction")]
-		fn submit_transaction(&self, Bytes) -> Result<H256>;
+	/// @alias of `eth_sendRawTransaction`.
+	#[rpc(name = "eth_submitTransaction")]
+	fn submit_transaction(&self, Bytes) -> Result<H256>;
 
-		/// Call contract, returning the output data.
-		#[rpc(name = "eth_call")]
-		fn call(&self, CallRequest, Trailing<BlockNumber>) -> BoxFuture<Bytes>;
+	/// Call contract, returning the output data.
+	#[rpc(name = "eth_call")]
+	fn call(&self, CallRequest, Option<BlockNumber>) -> BoxFuture<Bytes>;
 
-		/// Estimate gas needed for execution of given contract.
-		#[rpc(name = "eth_estimateGas")]
-		fn estimate_gas(&self, CallRequest, Trailing<BlockNumber>) -> BoxFuture<U256>;
+	/// Estimate gas needed for execution of given contract.
+	#[rpc(name = "eth_estimateGas")]
+	fn estimate_gas(&self, CallRequest, Option<BlockNumber>) -> BoxFuture<U256>;
 
-		/// Get transaction by its hash.
-		#[rpc(name = "eth_getTransactionByHash")]
-		fn transaction_by_hash(&self, H256) -> BoxFuture<Option<Transaction>>;
+	/// Get transaction by its hash.
+	#[rpc(name = "eth_getTransactionByHash")]
+	fn transaction_by_hash(&self, H256) -> BoxFuture<Option<Transaction>>;
 
-		/// Returns transaction at given block hash and index.
-		#[rpc(name = "eth_getTransactionByBlockHashAndIndex")]
-		fn transaction_by_block_hash_and_index(&self, H256, Index) -> BoxFuture<Option<Transaction>>;
+	/// Returns transaction at given block hash and index.
+	#[rpc(name = "eth_getTransactionByBlockHashAndIndex")]
+	fn transaction_by_block_hash_and_index(&self, H256, Index) -> BoxFuture<Option<Transaction>>;
 
-		/// Returns transaction by given block number and index.
-		#[rpc(name = "eth_getTransactionByBlockNumberAndIndex")]
-		fn transaction_by_block_number_and_index(&self, BlockNumber, Index) -> BoxFuture<Option<Transaction>>;
+	/// Returns transaction by given block number and index.
+	#[rpc(name = "eth_getTransactionByBlockNumberAndIndex")]
+	fn transaction_by_block_number_and_index(&self, BlockNumber, Index) -> BoxFuture<Option<Transaction>>;
 
-		/// Returns transaction receipt by transaction hash.
-		#[rpc(name = "eth_getTransactionReceipt")]
-		fn transaction_receipt(&self, H256) -> BoxFuture<Option<Receipt>>;
+	/// Returns transaction receipt by transaction hash.
+	#[rpc(name = "eth_getTransactionReceipt")]
+	fn transaction_receipt(&self, H256) -> BoxFuture<Option<Receipt>>;
 
-		/// Returns an uncles at given block and index.
-		#[rpc(name = "eth_getUncleByBlockHashAndIndex")]
-		fn uncle_by_block_hash_and_index(&self, H256, Index) -> BoxFuture<Option<RichBlock>>;
+	/// Returns an uncles at given block and index.
+	#[rpc(name = "eth_getUncleByBlockHashAndIndex")]
+	fn uncle_by_block_hash_and_index(&self, H256, Index) -> BoxFuture<Option<RichBlock>>;
 
-		/// Returns an uncles at given block and index.
-		#[rpc(name = "eth_getUncleByBlockNumberAndIndex")]
-		fn uncle_by_block_number_and_index(&self, BlockNumber, Index) -> BoxFuture<Option<RichBlock>>;
+	/// Returns an uncles at given block and index.
+	#[rpc(name = "eth_getUncleByBlockNumberAndIndex")]
+	fn uncle_by_block_number_and_index(&self, BlockNumber, Index) -> BoxFuture<Option<RichBlock>>;
 
-		/// Returns available compilers.
-		/// @deprecated
-		#[rpc(name = "eth_getCompilers")]
-		fn compilers(&self) -> Result<Vec<String>>;
+	/// Returns available compilers.
+	/// @deprecated
+	#[rpc(name = "eth_getCompilers")]
+	fn compilers(&self) -> Result<Vec<String>>;
 
-		/// Compiles lll code.
-		/// @deprecated
-		#[rpc(name = "eth_compileLLL")]
-		fn compile_lll(&self, String) -> Result<Bytes>;
+	/// Compiles lll code.
+	/// @deprecated
+	#[rpc(name = "eth_compileLLL")]
+	fn compile_lll(&self, String) -> Result<Bytes>;
 
-		/// Compiles solidity.
-		/// @deprecated
-		#[rpc(name = "eth_compileSolidity")]
-		fn compile_solidity(&self, String) -> Result<Bytes>;
+	/// Compiles solidity.
+	/// @deprecated
+	#[rpc(name = "eth_compileSolidity")]
+	fn compile_solidity(&self, String) -> Result<Bytes>;
 
-		/// Compiles serpent.
-		/// @deprecated
-		#[rpc(name = "eth_compileSerpent")]
-		fn compile_serpent(&self, String) -> Result<Bytes>;
+	/// Compiles serpent.
+	/// @deprecated
+	#[rpc(name = "eth_compileSerpent")]
+	fn compile_serpent(&self, String) -> Result<Bytes>;
 
-		/// Returns logs matching given filter object.
-		#[rpc(name = "eth_getLogs")]
-		fn logs(&self, Filter) -> BoxFuture<Vec<Log>>;
+	/// Returns logs matching given filter object.
+	#[rpc(name = "eth_getLogs")]
+	fn logs(&self, Filter) -> BoxFuture<Vec<Log>>;
 
-		/// Returns the hash of the current block, the seedHash, and the boundary condition to be met.
-		#[rpc(name = "eth_getWork")]
-		fn work(&self, Trailing<u64>) -> Result<Work>;
+	/// Returns the hash of the current block, the seedHash, and the boundary condition to be met.
+	#[rpc(name = "eth_getWork")]
+	fn work(&self, Option<u64>) -> Result<Work>;
 
-		/// Used for submitting a proof-of-work solution.
-		#[rpc(name = "eth_submitWork")]
-		fn submit_work(&self, H64, H256, H256) -> Result<bool>;
+	/// Used for submitting a proof-of-work solution.
+	#[rpc(name = "eth_submitWork")]
+	fn submit_work(&self, H64, H256, H256) -> Result<bool>;
 
-		/// Used for submitting mining hashrate.
-		#[rpc(name = "eth_submitHashrate")]
-		fn submit_hashrate(&self, U256, H256) -> Result<bool>;
-	}
+	/// Used for submitting mining hashrate.
+	#[rpc(name = "eth_submitHashrate")]
+	fn submit_hashrate(&self, U256, H256) -> Result<bool>;
 }
 
-build_rpc_trait! {
-	/// Eth filters rpc api (polling).
-	// TODO: do filters api properly
-	pub trait EthFilter {
-		/// Returns id of new filter.
-		#[rpc(name = "eth_newFilter")]
-		fn new_filter(&self, Filter) -> Result<U256>;
+/// Eth filters rpc api (polling).
+// TODO: do filters api properly
+#[rpc]
+pub trait EthFilter {
+	/// Returns id of new filter.
+	#[rpc(name = "eth_newFilter")]
+	fn new_filter(&self, Filter) -> Result<U256>;
 
-		/// Returns id of new block filter.
-		#[rpc(name = "eth_newBlockFilter")]
-		fn new_block_filter(&self) -> Result<U256>;
+	/// Returns id of new block filter.
+	#[rpc(name = "eth_newBlockFilter")]
+	fn new_block_filter(&self) -> Result<U256>;
 
-		/// Returns id of new block filter.
-		#[rpc(name = "eth_newPendingTransactionFilter")]
-		fn new_pending_transaction_filter(&self) -> Result<U256>;
+	/// Returns id of new block filter.
+	#[rpc(name = "eth_newPendingTransactionFilter")]
+	fn new_pending_transaction_filter(&self) -> Result<U256>;
 
-		/// Returns filter changes since last poll.
-		#[rpc(name = "eth_getFilterChanges")]
-		fn filter_changes(&self, Index) -> BoxFuture<FilterChanges>;
+	/// Returns filter changes since last poll.
+	#[rpc(name = "eth_getFilterChanges")]
+	fn filter_changes(&self, Index) -> BoxFuture<FilterChanges>;
 
-		/// Returns all logs matching given filter (in a range 'from' - 'to').
-		#[rpc(name = "eth_getFilterLogs")]
-		fn filter_logs(&self, Index) -> BoxFuture<Vec<Log>>;
+	/// Returns all logs matching given filter (in a range 'from' - 'to').
+	#[rpc(name = "eth_getFilterLogs")]
+	fn filter_logs(&self, Index) -> BoxFuture<Vec<Log>>;
 
-		/// Uninstalls filter.
-		#[rpc(name = "eth_uninstallFilter")]
-		fn uninstall_filter(&self, Index) -> Result<bool>;
-	}
+	/// Uninstalls filter.
+	#[rpc(name = "eth_uninstallFilter")]
+	fn uninstall_filter(&self, Index) -> Result<bool>;
 }

--- a/rpc/src/v1/traits/eth_pubsub.rs
+++ b/rpc/src/v1/traits/eth_pubsub.rs
@@ -17,25 +17,22 @@
 //! Eth PUB-SUB rpc interface.
 
 use jsonrpc_core::Result;
-use jsonrpc_macros::Trailing;
-use jsonrpc_macros::pubsub::Subscriber;
-use jsonrpc_pubsub::SubscriptionId;
+use jsonrpc_derive::rpc;
+use jsonrpc_pubsub::{typed, SubscriptionId};
 
 use v1::types::pubsub;
 
-build_rpc_trait! {
-	/// Eth PUB-SUB rpc interface.
-	pub trait EthPubSub {
-		type Metadata;
+/// Eth PUB-SUB rpc interface.
+#[rpc]
+pub trait EthPubSub {
+	/// RPC Metadata
+	type Metadata;
 
-		#[pubsub(name = "eth_subscription")] {
-			/// Subscribe to Eth subscription.
-			#[rpc(name = "eth_subscribe")]
-			fn subscribe(&self, Self::Metadata, Subscriber<pubsub::Result>, pubsub::Kind, Trailing<pubsub::Params>);
+	/// Subscribe to Eth subscription.
+	#[pubsub(subscription = "eth_subscription", subscribe, name = "eth_subscribe")]
+	fn subscribe(&self, Self::Metadata, typed::Subscriber<pubsub::Result>, pubsub::Kind, Option<pubsub::Params>);
 
-			/// Unsubscribe from existing Eth subscription.
-			#[rpc(name = "eth_unsubscribe")]
-			fn unsubscribe(&self, SubscriptionId) -> Result<bool>;
-		}
-	}
+	/// Unsubscribe from existing Eth subscription.
+	#[pubsub(subscription = "eth_subscription", unsubscribe, name = "eth_unsubscribe")]
+	fn unsubscribe(&self, Option<Self::Metadata>, SubscriptionId) -> Result<bool>;
 }

--- a/rpc/src/v1/traits/eth_signing.rs
+++ b/rpc/src/v1/traits/eth_signing.rs
@@ -17,28 +17,29 @@
 //! Eth rpc interface.
 
 use jsonrpc_core::BoxFuture;
+use jsonrpc_derive::rpc;
 
 use v1::types::{Bytes, H160, H256, H520, TransactionRequest, RichRawTransaction};
 
-build_rpc_trait! {
-	/// Signing methods implementation relying on unlocked accounts.
-	pub trait EthSigning {
-		type Metadata;
+/// Signing methods implementation relying on unlocked accounts.
+#[rpc]
+pub trait EthSigning {
+	/// RPC Metadata
+	type Metadata;
 
-		/// Signs the hash of data with given address signature.
-		#[rpc(meta, name = "eth_sign")]
-		fn sign(&self, Self::Metadata, H160, Bytes) -> BoxFuture<H520>;
+	/// Signs the hash of data with given address signature.
+	#[rpc(meta, name = "eth_sign")]
+	fn sign(&self, Self::Metadata, H160, Bytes) -> BoxFuture<H520>;
 
-		/// Sends transaction; will block waiting for signer to return the
-		/// transaction hash.
-		/// If Signer is disable it will require the account to be unlocked.
-		#[rpc(meta, name = "eth_sendTransaction")]
-		fn send_transaction(&self, Self::Metadata, TransactionRequest) -> BoxFuture<H256>;
+	/// Sends transaction; will block waiting for signer to return the
+	/// transaction hash.
+	/// If Signer is disable it will require the account to be unlocked.
+	#[rpc(meta, name = "eth_sendTransaction")]
+	fn send_transaction(&self, Self::Metadata, TransactionRequest) -> BoxFuture<H256>;
 
-		/// Signs transactions without dispatching it to the network.
-		/// Returns signed transaction RLP representation and the transaction itself.
-		/// It can be later submitted using `eth_sendRawTransaction/eth_submitTransaction`.
-		#[rpc(meta, name = "eth_signTransaction")]
-		fn sign_transaction(&self, Self::Metadata, TransactionRequest) -> BoxFuture<RichRawTransaction>;
-	}
+	/// Signs transactions without dispatching it to the network.
+	/// Returns signed transaction RLP representation and the transaction itself.
+	/// It can be later submitted using `eth_sendRawTransaction/eth_submitTransaction`.
+	#[rpc(meta, name = "eth_signTransaction")]
+	fn sign_transaction(&self, Self::Metadata, TransactionRequest) -> BoxFuture<RichRawTransaction>;
 }

--- a/rpc/src/v1/traits/net.rs
+++ b/rpc/src/v1/traits/net.rs
@@ -16,21 +16,21 @@
 
 //! Net rpc interface.
 use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
 
-build_rpc_trait! {
-	/// Net rpc interface.
-	pub trait Net {
-		/// Returns protocol version.
-		#[rpc(name = "net_version")]
-		fn version(&self) -> Result<String>;
+/// Net rpc interface.
+#[rpc]
+pub trait Net {
+	/// Returns protocol version.
+	#[rpc(name = "net_version")]
+	fn version(&self) -> Result<String>;
 
-		/// Returns number of peers connected to node.
-		#[rpc(name = "net_peerCount")]
-		fn peer_count(&self) -> Result<String>;
+	/// Returns number of peers connected to node.
+	#[rpc(name = "net_peerCount")]
+	fn peer_count(&self) -> Result<String>;
 
-		/// Returns true if client is actively listening for network connections.
-		/// Otherwise false.
-		#[rpc(name = "net_listening")]
-		fn is_listening(&self) -> Result<bool>;
-	}
+	/// Returns true if client is actively listening for network connections.
+	/// Otherwise false.
+	#[rpc(name = "net_listening")]
+	fn is_listening(&self) -> Result<bool>;
 }

--- a/rpc/src/v1/traits/parity.rs
+++ b/rpc/src/v1/traits/parity.rs
@@ -19,7 +19,7 @@
 use std::collections::BTreeMap;
 
 use jsonrpc_core::{BoxFuture, Result};
-use jsonrpc_macros::Trailing;
+use jsonrpc_derive::rpc;
 use v1::types::{
 	H160, H256, H512, U256, U64, H64, Bytes, CallRequest,
 	Peers, Transaction, RpcSettings, Histogram, RecoveredAccount,
@@ -29,223 +29,222 @@ use v1::types::{
 	AccountInfo, HwAccountInfo, RichHeader, Receipt,
 };
 
-build_rpc_trait! {
-	/// Parity-specific rpc interface.
-	pub trait Parity {
-		type Metadata;
+/// Parity-specific rpc interface.
+#[rpc]
+pub trait Parity {
+	/// RPC Metadata
+	type Metadata;
 
-		/// Returns accounts information.
-		#[rpc(name = "parity_accountsInfo")]
-		fn accounts_info(&self) -> Result<BTreeMap<H160, AccountInfo>>;
+	/// Returns accounts information.
+	#[rpc(name = "parity_accountsInfo")]
+	fn accounts_info(&self) -> Result<BTreeMap<H160, AccountInfo>>;
 
-		/// Returns hardware accounts information.
-		#[rpc(name = "parity_hardwareAccountsInfo")]
-		fn hardware_accounts_info(&self) -> Result<BTreeMap<H160, HwAccountInfo>>;
+	/// Returns hardware accounts information.
+	#[rpc(name = "parity_hardwareAccountsInfo")]
+	fn hardware_accounts_info(&self) -> Result<BTreeMap<H160, HwAccountInfo>>;
 
-		/// Get a list of paths to locked hardware wallets
-		#[rpc(name = "parity_lockedHardwareAccountsInfo")]
-		fn locked_hardware_accounts_info(&self) -> Result<Vec<String>>;
+	/// Get a list of paths to locked hardware wallets
+	#[rpc(name = "parity_lockedHardwareAccountsInfo")]
+	fn locked_hardware_accounts_info(&self) -> Result<Vec<String>>;
 
-		/// Returns default account for dapp.
-		#[rpc(name = "parity_defaultAccount")]
-		fn default_account(&self) -> Result<H160>;
+	/// Returns default account for dapp.
+	#[rpc(name = "parity_defaultAccount")]
+	fn default_account(&self) -> Result<H160>;
 
-		/// Returns current transactions limit.
-		#[rpc(name = "parity_transactionsLimit")]
-		fn transactions_limit(&self) -> Result<usize>;
+	/// Returns current transactions limit.
+	#[rpc(name = "parity_transactionsLimit")]
+	fn transactions_limit(&self) -> Result<usize>;
 
-		/// Returns mining extra data.
-		#[rpc(name = "parity_extraData")]
-		fn extra_data(&self) -> Result<Bytes>;
+	/// Returns mining extra data.
+	#[rpc(name = "parity_extraData")]
+	fn extra_data(&self) -> Result<Bytes>;
 
-		/// Returns mining gas floor target.
-		#[rpc(name = "parity_gasFloorTarget")]
-		fn gas_floor_target(&self) -> Result<U256>;
+	/// Returns mining gas floor target.
+	#[rpc(name = "parity_gasFloorTarget")]
+	fn gas_floor_target(&self) -> Result<U256>;
 
-		/// Returns mining gas floor cap.
-		#[rpc(name = "parity_gasCeilTarget")]
-		fn gas_ceil_target(&self) -> Result<U256>;
+	/// Returns mining gas floor cap.
+	#[rpc(name = "parity_gasCeilTarget")]
+	fn gas_ceil_target(&self) -> Result<U256>;
 
-		/// Returns minimal gas price for transaction to be included in queue.
-		#[rpc(name = "parity_minGasPrice")]
-		fn min_gas_price(&self) -> Result<U256>;
+	/// Returns minimal gas price for transaction to be included in queue.
+	#[rpc(name = "parity_minGasPrice")]
+	fn min_gas_price(&self) -> Result<U256>;
 
-		/// Returns latest logs
-		#[rpc(name = "parity_devLogs")]
-		fn dev_logs(&self) -> Result<Vec<String>>;
+	/// Returns latest logs
+	#[rpc(name = "parity_devLogs")]
+	fn dev_logs(&self) -> Result<Vec<String>>;
 
-		/// Returns logs levels
-		#[rpc(name = "parity_devLogsLevels")]
-		fn dev_logs_levels(&self) -> Result<String>;
+	/// Returns logs levels
+	#[rpc(name = "parity_devLogsLevels")]
+	fn dev_logs_levels(&self) -> Result<String>;
 
-		/// Returns chain name - DEPRECATED. Use `parity_chainName` instead.
-		#[rpc(name = "parity_netChain")]
-		fn net_chain(&self) -> Result<String>;
+	/// Returns chain name - DEPRECATED. Use `parity_chainName` instead.
+	#[rpc(name = "parity_netChain")]
+	fn net_chain(&self) -> Result<String>;
 
-		/// Returns peers details
-		#[rpc(name = "parity_netPeers")]
-		fn net_peers(&self) -> Result<Peers>;
+	/// Returns peers details
+	#[rpc(name = "parity_netPeers")]
+	fn net_peers(&self) -> Result<Peers>;
 
-		/// Returns network port
-		#[rpc(name = "parity_netPort")]
-		fn net_port(&self) -> Result<u16>;
+	/// Returns network port
+	#[rpc(name = "parity_netPort")]
+	fn net_port(&self) -> Result<u16>;
 
-		/// Returns rpc settings
-		#[rpc(name = "parity_rpcSettings")]
-		fn rpc_settings(&self) -> Result<RpcSettings>;
+	/// Returns rpc settings
+	#[rpc(name = "parity_rpcSettings")]
+	fn rpc_settings(&self) -> Result<RpcSettings>;
 
-		/// Returns node name
-		#[rpc(name = "parity_nodeName")]
-		fn node_name(&self) -> Result<String>;
+	/// Returns node name
+	#[rpc(name = "parity_nodeName")]
+	fn node_name(&self) -> Result<String>;
 
-		/// Returns default extra data
-		#[rpc(name = "parity_defaultExtraData")]
-		fn default_extra_data(&self) -> Result<Bytes>;
+	/// Returns default extra data
+	#[rpc(name = "parity_defaultExtraData")]
+	fn default_extra_data(&self) -> Result<Bytes>;
 
-		/// Returns distribution of gas price in latest blocks.
-		#[rpc(name = "parity_gasPriceHistogram")]
-		fn gas_price_histogram(&self) -> BoxFuture<Histogram>;
+	/// Returns distribution of gas price in latest blocks.
+	#[rpc(name = "parity_gasPriceHistogram")]
+	fn gas_price_histogram(&self) -> BoxFuture<Histogram>;
 
-		/// Returns number of unsigned transactions waiting in the signer queue (if signer enabled)
-		/// Returns error when signer is disabled
-		#[rpc(name = "parity_unsignedTransactionsCount")]
-		fn unsigned_transactions_count(&self) -> Result<usize>;
+	/// Returns number of unsigned transactions waiting in the signer queue (if signer enabled)
+	/// Returns error when signer is disabled
+	#[rpc(name = "parity_unsignedTransactionsCount")]
+	fn unsigned_transactions_count(&self) -> Result<usize>;
 
-		/// Returns a cryptographically random phrase sufficient for securely seeding a secret key.
-		#[rpc(name = "parity_generateSecretPhrase")]
-		fn generate_secret_phrase(&self) -> Result<String>;
+	/// Returns a cryptographically random phrase sufficient for securely seeding a secret key.
+	#[rpc(name = "parity_generateSecretPhrase")]
+	fn generate_secret_phrase(&self) -> Result<String>;
 
-		/// Returns whatever address would be derived from the given phrase if it were to seed a brainwallet.
-		#[rpc(name = "parity_phraseToAddress")]
-		fn phrase_to_address(&self, String) -> Result<H160>;
+	/// Returns whatever address would be derived from the given phrase if it were to seed a brainwallet.
+	#[rpc(name = "parity_phraseToAddress")]
+	fn phrase_to_address(&self, String) -> Result<H160>;
 
-		/// Returns the value of the registrar for this network.
-		#[rpc(name = "parity_registryAddress")]
-		fn registry_address(&self) -> Result<Option<H160>>;
+	/// Returns the value of the registrar for this network.
+	#[rpc(name = "parity_registryAddress")]
+	fn registry_address(&self) -> Result<Option<H160>>;
 
-		/// Returns all addresses if Fat DB is enabled (`--fat-db`), or null if not.
-		#[rpc(name = "parity_listAccounts")]
-		fn list_accounts(&self, u64, Option<H160>, Trailing<BlockNumber>) -> Result<Option<Vec<H160>>>;
+	/// Returns all addresses if Fat DB is enabled (`--fat-db`), or null if not.
+	#[rpc(name = "parity_listAccounts")]
+	fn list_accounts(&self, u64, Option<H160>, Option<BlockNumber>) -> Result<Option<Vec<H160>>>;
 
-		/// Returns all storage keys of the given address (first parameter) if Fat DB is enabled (`--fat-db`),
-		/// or null if not.
-		#[rpc(name = "parity_listStorageKeys")]
-		fn list_storage_keys(&self, H160, u64, Option<H256>, Trailing<BlockNumber>) -> Result<Option<Vec<H256>>>;
+	/// Returns all storage keys of the given address (first parameter) if Fat DB is enabled (`--fat-db`),
+	/// or null if not.
+	#[rpc(name = "parity_listStorageKeys")]
+	fn list_storage_keys(&self, H160, u64, Option<H256>, Option<BlockNumber>) -> Result<Option<Vec<H256>>>;
 
-		/// Encrypt some data with a public key under ECIES.
-		/// First parameter is the 512-byte destination public key, second is the message.
-		#[rpc(name = "parity_encryptMessage")]
-		fn encrypt_message(&self, H512, Bytes) -> Result<Bytes>;
+	/// Encrypt some data with a public key under ECIES.
+	/// First parameter is the 512-byte destination public key, second is the message.
+	#[rpc(name = "parity_encryptMessage")]
+	fn encrypt_message(&self, H512, Bytes) -> Result<Bytes>;
 
-		/// Returns all pending transactions from transaction queue.
-		#[rpc(name = "parity_pendingTransactions")]
-		fn pending_transactions(&self, Trailing<usize>) -> Result<Vec<Transaction>>;
+	/// Returns all pending transactions from transaction queue.
+	#[rpc(name = "parity_pendingTransactions")]
+	fn pending_transactions(&self, Option<usize>) -> Result<Vec<Transaction>>;
 
-		/// Returns all transactions from transaction queue.
-		///
-		/// Some of them might not be ready to be included in a block yet.
-		#[rpc(name = "parity_allTransactions")]
-		fn all_transactions(&self) -> Result<Vec<Transaction>>;
+	/// Returns all transactions from transaction queue.
+	///
+	/// Some of them might not be ready to be included in a block yet.
+	#[rpc(name = "parity_allTransactions")]
+	fn all_transactions(&self) -> Result<Vec<Transaction>>;
 
-		/// Same as parity_allTransactions, but return only transactions hashes.
-		#[rpc(name = "parity_allTransactionHashes")]
-		fn all_transaction_hashes(&self) -> Result<Vec<H256>>;
+	/// Same as parity_allTransactions, but return only transactions hashes.
+	#[rpc(name = "parity_allTransactionHashes")]
+	fn all_transaction_hashes(&self) -> Result<Vec<H256>>;
 
-		/// Returns all future transactions from transaction queue (deprecated)
-		#[rpc(name = "parity_futureTransactions")]
-		fn future_transactions(&self) -> Result<Vec<Transaction>>;
+	/// Returns all future transactions from transaction queue (deprecated)
+	#[rpc(name = "parity_futureTransactions")]
+	fn future_transactions(&self) -> Result<Vec<Transaction>>;
 
-		/// Returns propagation statistics on transactions pending in the queue.
-		#[rpc(name = "parity_pendingTransactionsStats")]
-		fn pending_transactions_stats(&self) -> Result<BTreeMap<H256, TransactionStats>>;
+	/// Returns propagation statistics on transactions pending in the queue.
+	#[rpc(name = "parity_pendingTransactionsStats")]
+	fn pending_transactions_stats(&self) -> Result<BTreeMap<H256, TransactionStats>>;
 
-		/// Returns a list of current and past local transactions with status details.
-		#[rpc(name = "parity_localTransactions")]
-		fn local_transactions(&self) -> Result<BTreeMap<H256, LocalTransactionStatus>>;
+	/// Returns a list of current and past local transactions with status details.
+	#[rpc(name = "parity_localTransactions")]
+	fn local_transactions(&self) -> Result<BTreeMap<H256, LocalTransactionStatus>>;
 
-		/// Returns current WS Server interface and port or an error if ws server is disabled.
-		#[rpc(name = "parity_wsUrl")]
-		fn ws_url(&self) -> Result<String>;
+	/// Returns current WS Server interface and port or an error if ws server is disabled.
+	#[rpc(name = "parity_wsUrl")]
+	fn ws_url(&self) -> Result<String>;
 
-		/// Returns next nonce for particular sender. Should include all transactions in the queue.
-		#[rpc(name = "parity_nextNonce")]
-		fn next_nonce(&self, H160) -> BoxFuture<U256>;
+	/// Returns next nonce for particular sender. Should include all transactions in the queue.
+	#[rpc(name = "parity_nextNonce")]
+	fn next_nonce(&self, H160) -> BoxFuture<U256>;
 
-		/// Get the mode. Returns one of: "active", "passive", "dark", "offline".
-		#[rpc(name = "parity_mode")]
-		fn mode(&self) -> Result<String>;
+	/// Get the mode. Returns one of: "active", "passive", "dark", "offline".
+	#[rpc(name = "parity_mode")]
+	fn mode(&self) -> Result<String>;
 
-		/// Get the chain name. Returns one of the pre-configured chain names or a filename.
-		#[rpc(name = "parity_chain")]
-		fn chain(&self) -> Result<String>;
+	/// Get the chain name. Returns one of the pre-configured chain names or a filename.
+	#[rpc(name = "parity_chain")]
+	fn chain(&self) -> Result<String>;
 
-		/// Get the enode of this node.
-		#[rpc(name = "parity_enode")]
-		fn enode(&self) -> Result<String>;
+	/// Get the enode of this node.
+	#[rpc(name = "parity_enode")]
+	fn enode(&self) -> Result<String>;
 
-		/// Returns information on current consensus capability.
-		#[rpc(name = "parity_consensusCapability")]
-		fn consensus_capability(&self) -> Result<ConsensusCapability>;
+	/// Returns information on current consensus capability.
+	#[rpc(name = "parity_consensusCapability")]
+	fn consensus_capability(&self) -> Result<ConsensusCapability>;
 
-		/// Get our version information in a nice object.
-		#[rpc(name = "parity_versionInfo")]
-		fn version_info(&self) -> Result<VersionInfo>;
+	/// Get our version information in a nice object.
+	#[rpc(name = "parity_versionInfo")]
+	fn version_info(&self) -> Result<VersionInfo>;
 
-		/// Get information concerning the latest releases if available.
-		#[rpc(name = "parity_releasesInfo")]
-		fn releases_info(&self) -> Result<Option<OperationsInfo>>;
+	/// Get information concerning the latest releases if available.
+	#[rpc(name = "parity_releasesInfo")]
+	fn releases_info(&self) -> Result<Option<OperationsInfo>>;
 
-		/// Get the current chain status.
-		#[rpc(name = "parity_chainStatus")]
-		fn chain_status(&self) -> Result<ChainStatus>;
+	/// Get the current chain status.
+	#[rpc(name = "parity_chainStatus")]
+	fn chain_status(&self) -> Result<ChainStatus>;
 
-		/// Get node kind info.
-		#[rpc(name = "parity_nodeKind")]
-		fn node_kind(&self) -> Result<::v1::types::NodeKind>;
+	/// Get node kind info.
+	#[rpc(name = "parity_nodeKind")]
+	fn node_kind(&self) -> Result<::v1::types::NodeKind>;
 
-		/// Get block header.
-		/// Same as `eth_getBlockByNumber` but without uncles and transactions.
-		#[rpc(name = "parity_getBlockHeaderByNumber")]
-		fn block_header(&self, Trailing<BlockNumber>) -> BoxFuture<RichHeader>;
+	/// Get block header.
+	/// Same as `eth_getBlockByNumber` but without uncles and transactions.
+	#[rpc(name = "parity_getBlockHeaderByNumber")]
+	fn block_header(&self, Option<BlockNumber>) -> BoxFuture<RichHeader>;
 
-		/// Get block receipts.
-		/// Allows you to fetch receipts from the entire block at once.
-		/// If no parameter is provided defaults to `latest`.
-		#[rpc(name = "parity_getBlockReceipts")]
-		fn block_receipts(&self, Trailing<BlockNumber>) -> BoxFuture<Vec<Receipt>>;
+	/// Get block receipts.
+	/// Allows you to fetch receipts from the entire block at once.
+	/// If no parameter is provided defaults to `latest`.
+	#[rpc(name = "parity_getBlockReceipts")]
+	fn block_receipts(&self, Option<BlockNumber>) -> BoxFuture<Vec<Receipt>>;
 
-		/// Get IPFS CIDv0 given protobuf encoded bytes.
-		#[rpc(name = "parity_cidV0")]
-		fn ipfs_cid(&self, Bytes) -> Result<String>;
+	/// Get IPFS CIDv0 given protobuf encoded bytes.
+	#[rpc(name = "parity_cidV0")]
+	fn ipfs_cid(&self, Bytes) -> Result<String>;
 
-		/// Call contract, returning the output data.
-		#[rpc(name = "parity_call")]
-		fn call(&self, Vec<CallRequest>, Trailing<BlockNumber>) -> Result<Vec<Bytes>>;
+	/// Call contract, returning the output data.
+	#[rpc(name = "parity_call")]
+	fn call(&self, Vec<CallRequest>, Option<BlockNumber>) -> Result<Vec<Bytes>>;
 
-		/// Used for submitting a proof-of-work solution (similar to `eth_submitWork`,
-		/// but returns block hash on success, and returns an explicit error message on failure).
-		#[rpc(name = "parity_submitWorkDetail")]
-		fn submit_work_detail(&self, H64, H256, H256) -> Result<H256>;
+	/// Used for submitting a proof-of-work solution (similar to `eth_submitWork`,
+	/// but returns block hash on success, and returns an explicit error message on failure).
+	#[rpc(name = "parity_submitWorkDetail")]
+	fn submit_work_detail(&self, H64, H256, H256) -> Result<H256>;
 
-		/// Returns the status of the node. Used as the health endpoint.
-		///
-		/// The RPC returns successful response if:
-		/// - The node have a peer (unless running a dev chain)
-		/// - The node is not syncing.
-		///
-		/// Otherwise the RPC returns error.
-		#[rpc(name = "parity_nodeStatus")]
-		fn status(&self) -> Result<()>;
+	/// Returns the status of the node. Used as the health endpoint.
+	///
+	/// The RPC returns successful response if:
+	/// - The node have a peer (unless running a dev chain)
+	/// - The node is not syncing.
+	///
+	/// Otherwise the RPC returns error.
+	#[rpc(name = "parity_nodeStatus")]
+	fn status(&self) -> Result<()>;
 
-		/// Extracts Address and public key from signature using the r, s and v params. Equivalent to Solidity erecover
-		/// as well as checks the signature for chain replay protection
-		#[rpc(name = "parity_verifySignature")]
-		fn verify_signature(&self, bool, Bytes, H256, H256, U64) -> Result<RecoveredAccount>;
+	/// Extracts Address and public key from signature using the r, s and v params. Equivalent to Solidity erecover
+	/// as well as checks the signature for chain replay protection
+	#[rpc(name = "parity_verifySignature")]
+	fn verify_signature(&self, bool, Bytes, H256, H256, U64) -> Result<RecoveredAccount>;
 
-		/// Returns logs matching given filter object.
-		/// Is allowed to skip filling transaction hash for faster query.
-		#[rpc(name = "parity_getLogsNoTransactionHash")]
-		fn logs_no_tx_hash(&self, Filter) -> BoxFuture<Vec<Log>>;
-
-	}
+	/// Returns logs matching given filter object.
+	/// Is allowed to skip filling transaction hash for faster query.
+	#[rpc(name = "parity_getLogsNoTransactionHash")]
+	fn logs_no_tx_hash(&self, Filter) -> BoxFuture<Vec<Log>>;
 }

--- a/rpc/src/v1/traits/parity_accounts.rs
+++ b/rpc/src/v1/traits/parity_accounts.rs
@@ -18,125 +18,125 @@
 use std::collections::BTreeMap;
 
 use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
 use ethkey::Password;
 use ethstore::KeyFile;
 use v1::types::{H160, H256, H520, DeriveHash, DeriveHierarchical, ExtAccountInfo};
 
-build_rpc_trait! {
-	/// Personal Parity rpc interface.
-	pub trait ParityAccounts {
-		/// Returns accounts information.
-		#[rpc(name = "parity_allAccountsInfo")]
-		fn all_accounts_info(&self) -> Result<BTreeMap<H160, ExtAccountInfo>>;
+/// Personal Parity rpc interface.
+#[rpc]
+pub trait ParityAccounts {
+	/// Returns accounts information.
+	#[rpc(name = "parity_allAccountsInfo")]
+	fn all_accounts_info(&self) -> Result<BTreeMap<H160, ExtAccountInfo>>;
 
-		/// Creates new account from the given phrase using standard brainwallet mechanism.
-		/// Second parameter is password for the new account.
-		#[rpc(name = "parity_newAccountFromPhrase")]
-		fn new_account_from_phrase(&self, String, Password) -> Result<H160>;
+	/// Creates new account from the given phrase using standard brainwallet mechanism.
+	/// Second parameter is password for the new account.
+	#[rpc(name = "parity_newAccountFromPhrase")]
+	fn new_account_from_phrase(&self, String, Password) -> Result<H160>;
 
-		/// Creates new account from the given JSON wallet.
-		/// Second parameter is password for the wallet and the new account.
-		#[rpc(name = "parity_newAccountFromWallet")]
-		fn new_account_from_wallet(&self, String, Password) -> Result<H160>;
+	/// Creates new account from the given JSON wallet.
+	/// Second parameter is password for the wallet and the new account.
+	#[rpc(name = "parity_newAccountFromWallet")]
+	fn new_account_from_wallet(&self, String, Password) -> Result<H160>;
 
-		/// Creates new account from the given raw secret.
-		/// Second parameter is password for the new account.
-		#[rpc(name = "parity_newAccountFromSecret")]
-		fn new_account_from_secret(&self, H256, Password) -> Result<H160>;
+	/// Creates new account from the given raw secret.
+	/// Second parameter is password for the new account.
+	#[rpc(name = "parity_newAccountFromSecret")]
+	fn new_account_from_secret(&self, H256, Password) -> Result<H160>;
 
-		/// Returns true if given `password` would unlock given `account`.
-		/// Arguments: `account`, `password`.
-		#[rpc(name = "parity_testPassword")]
-		fn test_password(&self, H160, Password) -> Result<bool>;
+	/// Returns true if given `password` would unlock given `account`.
+	/// Arguments: `account`, `password`.
+	#[rpc(name = "parity_testPassword")]
+	fn test_password(&self, H160, Password) -> Result<bool>;
 
-		/// Changes an account's password.
-		/// Arguments: `account`, `password`, `new_password`.
-		#[rpc(name = "parity_changePassword")]
-		fn change_password(&self, H160, Password, Password) -> Result<bool>;
+	/// Changes an account's password.
+	/// Arguments: `account`, `password`, `new_password`.
+	#[rpc(name = "parity_changePassword")]
+	fn change_password(&self, H160, Password, Password) -> Result<bool>;
 
-		/// Permanently deletes an account.
-		/// Arguments: `account`, `password`.
-		#[rpc(name = "parity_killAccount")]
-		fn kill_account(&self, H160, Password) -> Result<bool>;
+	/// Permanently deletes an account.
+	/// Arguments: `account`, `password`.
+	#[rpc(name = "parity_killAccount")]
+	fn kill_account(&self, H160, Password) -> Result<bool>;
 
-		/// Permanently deletes an address from the addressbook
-		/// Arguments: `address`
-		#[rpc(name = "parity_removeAddress")]
-		fn remove_address(&self, H160) -> Result<bool>;
+	/// Permanently deletes an address from the addressbook
+	/// Arguments: `address`
+	#[rpc(name = "parity_removeAddress")]
+	fn remove_address(&self, H160) -> Result<bool>;
 
-		/// Set an account's name.
-		#[rpc(name = "parity_setAccountName")]
-		fn set_account_name(&self, H160, String) -> Result<bool>;
+	/// Set an account's name.
+	#[rpc(name = "parity_setAccountName")]
+	fn set_account_name(&self, H160, String) -> Result<bool>;
 
-		/// Set an account's metadata string.
-		#[rpc(name = "parity_setAccountMeta")]
-		fn set_account_meta(&self, H160, String) -> Result<bool>;
+	/// Set an account's metadata string.
+	#[rpc(name = "parity_setAccountMeta")]
+	fn set_account_meta(&self, H160, String) -> Result<bool>;
 
-		/// Imports a number of Geth accounts, with the list provided as the argument.
-		#[rpc(name = "parity_importGethAccounts")]
-		fn import_geth_accounts(&self, Vec<H160>) -> Result<Vec<H160>>;
+	/// Imports a number of Geth accounts, with the list provided as the argument.
+	#[rpc(name = "parity_importGethAccounts")]
+	fn import_geth_accounts(&self, Vec<H160>) -> Result<Vec<H160>>;
 
-		/// Returns the accounts available for importing from Geth.
-		#[rpc(name = "parity_listGethAccounts")]
-		fn geth_accounts(&self) -> Result<Vec<H160>>;
+	/// Returns the accounts available for importing from Geth.
+	#[rpc(name = "parity_listGethAccounts")]
+	fn geth_accounts(&self) -> Result<Vec<H160>>;
 
-		/// Create new vault.
-		#[rpc(name = "parity_newVault")]
-		fn create_vault(&self, String, Password) -> Result<bool>;
+	/// Create new vault.
+	#[rpc(name = "parity_newVault")]
+	fn create_vault(&self, String, Password) -> Result<bool>;
 
-		/// Open existing vault.
-		#[rpc(name = "parity_openVault")]
-		fn open_vault(&self, String, Password) -> Result<bool>;
+	/// Open existing vault.
+	#[rpc(name = "parity_openVault")]
+	fn open_vault(&self, String, Password) -> Result<bool>;
 
-		/// Close previously opened vault.
-		#[rpc(name = "parity_closeVault")]
-		fn close_vault(&self, String) -> Result<bool>;
+	/// Close previously opened vault.
+	#[rpc(name = "parity_closeVault")]
+	fn close_vault(&self, String) -> Result<bool>;
 
-		/// List all vaults.
-		#[rpc(name = "parity_listVaults")]
-		fn list_vaults(&self) -> Result<Vec<String>>;
+	/// List all vaults.
+	#[rpc(name = "parity_listVaults")]
+	fn list_vaults(&self) -> Result<Vec<String>>;
 
-		/// List all currently opened vaults.
-		#[rpc(name = "parity_listOpenedVaults")]
-		fn list_opened_vaults(&self) -> Result<Vec<String>>;
+	/// List all currently opened vaults.
+	#[rpc(name = "parity_listOpenedVaults")]
+	fn list_opened_vaults(&self) -> Result<Vec<String>>;
 
-		/// Change vault password.
-		#[rpc(name = "parity_changeVaultPassword")]
-		fn change_vault_password(&self, String, Password) -> Result<bool>;
+	/// Change vault password.
+	#[rpc(name = "parity_changeVaultPassword")]
+	fn change_vault_password(&self, String, Password) -> Result<bool>;
 
-		/// Change vault of the given address.
-		#[rpc(name = "parity_changeVault")]
-		fn change_vault(&self, H160, String) -> Result<bool>;
+	/// Change vault of the given address.
+	#[rpc(name = "parity_changeVault")]
+	fn change_vault(&self, H160, String) -> Result<bool>;
 
-		/// Get vault metadata string.
-		#[rpc(name = "parity_getVaultMeta")]
-		fn get_vault_meta(&self, String) -> Result<String>;
+	/// Get vault metadata string.
+	#[rpc(name = "parity_getVaultMeta")]
+	fn get_vault_meta(&self, String) -> Result<String>;
 
-		/// Set vault metadata string.
-		#[rpc(name = "parity_setVaultMeta")]
-		fn set_vault_meta(&self, String, String) -> Result<bool>;
+	/// Set vault metadata string.
+	#[rpc(name = "parity_setVaultMeta")]
+	fn set_vault_meta(&self, String, String) -> Result<bool>;
 
-		/// Derive new address from given account address using specific hash.
-		/// Resulting address can be either saved as a new account (with the same password).
-		#[rpc(name = "parity_deriveAddressHash")]
-		fn derive_key_hash(&self, H160, Password, DeriveHash, bool) -> Result<H160>;
+	/// Derive new address from given account address using specific hash.
+	/// Resulting address can be either saved as a new account (with the same password).
+	#[rpc(name = "parity_deriveAddressHash")]
+	fn derive_key_hash(&self, H160, Password, DeriveHash, bool) -> Result<H160>;
 
-		/// Derive new address from given account address using
-		/// hierarchical derivation (sequence of 32-bit integer indices).
-		/// Resulting address can be either saved as a new account (with the same password).
-		#[rpc(name = "parity_deriveAddressIndex")]
-		fn derive_key_index(&self, H160, Password, DeriveHierarchical, bool) -> Result<H160>;
+	/// Derive new address from given account address using
+	/// hierarchical derivation (sequence of 32-bit integer indices).
+	/// Resulting address can be either saved as a new account (with the same password).
+	#[rpc(name = "parity_deriveAddressIndex")]
+	fn derive_key_index(&self, H160, Password, DeriveHierarchical, bool) -> Result<H160>;
 
-		/// Exports an account with given address if provided password matches.
-		#[rpc(name = "parity_exportAccount")]
-		fn export_account(&self, H160, Password) -> Result<KeyFile>;
+	/// Exports an account with given address if provided password matches.
+	#[rpc(name = "parity_exportAccount")]
+	fn export_account(&self, H160, Password) -> Result<KeyFile>;
 
-		/// Sign raw hash with the key corresponding to address and password.
-		#[rpc(name = "parity_signMessage")]
-		fn sign_message(&self, H160, Password, H256) -> Result<H520>;
+	/// Sign raw hash with the key corresponding to address and password.
+	#[rpc(name = "parity_signMessage")]
+	fn sign_message(&self, H160, Password, H256) -> Result<H520>;
 
-		/// Send a PinMatrixAck to a hardware wallet, unlocking it
-		#[rpc(name = "parity_hardwarePinMatrixAck")]
-		fn hardware_pin_matrix_ack(&self, String, String) -> Result<bool>;
-	}
+	/// Send a PinMatrixAck to a hardware wallet, unlocking it
+	#[rpc(name = "parity_hardwarePinMatrixAck")]
+	fn hardware_pin_matrix_ack(&self, String, String) -> Result<bool>;
 }

--- a/rpc/src/v1/traits/parity_set.rs
+++ b/rpc/src/v1/traits/parity_set.rs
@@ -17,99 +17,99 @@
 //! Parity-specific rpc interface for operations altering the settings.
 
 use jsonrpc_core::{BoxFuture, Result};
+use jsonrpc_derive::rpc;
 
 use v1::types::{Bytes, H160, H256, U256, ReleaseInfo, Transaction};
 
-build_rpc_trait! {
-	/// Parity-specific rpc interface for operations altering the settings.
-	pub trait ParitySet {
-		/// Sets new minimal gas price for mined blocks.
-		#[rpc(name = "parity_setMinGasPrice")]
-		fn set_min_gas_price(&self, U256) -> Result<bool>;
+/// Parity-specific rpc interface for operations altering the settings.
+#[rpc]
+pub trait ParitySet {
+	/// Sets new minimal gas price for mined blocks.
+	#[rpc(name = "parity_setMinGasPrice")]
+	fn set_min_gas_price(&self, U256) -> Result<bool>;
 
-		/// Sets new gas floor target for mined blocks.
-		#[rpc(name = "parity_setGasFloorTarget")]
-		fn set_gas_floor_target(&self, U256) -> Result<bool>;
+	/// Sets new gas floor target for mined blocks.
+	#[rpc(name = "parity_setGasFloorTarget")]
+	fn set_gas_floor_target(&self, U256) -> Result<bool>;
 
-		/// Sets new gas ceiling target for mined blocks.
-		#[rpc(name = "parity_setGasCeilTarget")]
-		fn set_gas_ceil_target(&self, U256) -> Result<bool>;
+	/// Sets new gas ceiling target for mined blocks.
+	#[rpc(name = "parity_setGasCeilTarget")]
+	fn set_gas_ceil_target(&self, U256) -> Result<bool>;
 
-		/// Sets new extra data for mined blocks.
-		#[rpc(name = "parity_setExtraData")]
-		fn set_extra_data(&self, Bytes) -> Result<bool>;
+	/// Sets new extra data for mined blocks.
+	#[rpc(name = "parity_setExtraData")]
+	fn set_extra_data(&self, Bytes) -> Result<bool>;
 
-		/// Sets new author for mined block.
-		#[rpc(name = "parity_setAuthor")]
-		fn set_author(&self, H160) -> Result<bool>;
+	/// Sets new author for mined block.
+	#[rpc(name = "parity_setAuthor")]
+	fn set_author(&self, H160) -> Result<bool>;
 
-		/// Sets account for signing consensus messages.
-		#[rpc(name = "parity_setEngineSigner")]
-		fn set_engine_signer(&self, H160, String) -> Result<bool>;
+	/// Sets account for signing consensus messages.
+	#[rpc(name = "parity_setEngineSigner")]
+	fn set_engine_signer(&self, H160, String) -> Result<bool>;
 
-		/// Sets the limits for transaction queue.
-		#[rpc(name = "parity_setTransactionsLimit")]
-		fn set_transactions_limit(&self, usize) -> Result<bool>;
+	/// Sets the limits for transaction queue.
+	#[rpc(name = "parity_setTransactionsLimit")]
+	fn set_transactions_limit(&self, usize) -> Result<bool>;
 
-		/// Sets the maximum amount of gas a single transaction may consume.
-		#[rpc(name = "parity_setMaxTransactionGas")]
-		fn set_tx_gas_limit(&self, U256) -> Result<bool>;
+	/// Sets the maximum amount of gas a single transaction may consume.
+	#[rpc(name = "parity_setMaxTransactionGas")]
+	fn set_tx_gas_limit(&self, U256) -> Result<bool>;
 
-		/// Add a reserved peer.
-		#[rpc(name = "parity_addReservedPeer")]
-		fn add_reserved_peer(&self, String) -> Result<bool>;
+	/// Add a reserved peer.
+	#[rpc(name = "parity_addReservedPeer")]
+	fn add_reserved_peer(&self, String) -> Result<bool>;
 
-		/// Remove a reserved peer.
-		#[rpc(name = "parity_removeReservedPeer")]
-		fn remove_reserved_peer(&self, String) -> Result<bool>;
+	/// Remove a reserved peer.
+	#[rpc(name = "parity_removeReservedPeer")]
+	fn remove_reserved_peer(&self, String) -> Result<bool>;
 
-		/// Drop all non-reserved peers.
-		#[rpc(name = "parity_dropNonReservedPeers")]
-		fn drop_non_reserved_peers(&self) -> Result<bool>;
+	/// Drop all non-reserved peers.
+	#[rpc(name = "parity_dropNonReservedPeers")]
+	fn drop_non_reserved_peers(&self) -> Result<bool>;
 
-		/// Accept non-reserved peers (default behavior)
-		#[rpc(name = "parity_acceptNonReservedPeers")]
-		fn accept_non_reserved_peers(&self) -> Result<bool>;
+	/// Accept non-reserved peers (default behavior)
+	#[rpc(name = "parity_acceptNonReservedPeers")]
+	fn accept_non_reserved_peers(&self) -> Result<bool>;
 
-		/// Start the network.
-		///
-		/// @deprecated - Use `set_mode("active")` instead.
-		#[rpc(name = "parity_startNetwork")]
-		fn start_network(&self) -> Result<bool>;
+	/// Start the network.
+	///
+	/// @deprecated - Use `set_mode("active")` instead.
+	#[rpc(name = "parity_startNetwork")]
+	fn start_network(&self) -> Result<bool>;
 
-		/// Stop the network.
-		///
-		/// @deprecated - Use `set_mode("offline")` instead.
-		#[rpc(name = "parity_stopNetwork")]
-		fn stop_network(&self) -> Result<bool>;
+	/// Stop the network.
+	///
+	/// @deprecated - Use `set_mode("offline")` instead.
+	#[rpc(name = "parity_stopNetwork")]
+	fn stop_network(&self) -> Result<bool>;
 
-		/// Set the mode. Argument must be one of: "active", "passive", "dark", "offline".
-		#[rpc(name = "parity_setMode")]
-		fn set_mode(&self, String) -> Result<bool>;
+	/// Set the mode. Argument must be one of: "active", "passive", "dark", "offline".
+	#[rpc(name = "parity_setMode")]
+	fn set_mode(&self, String) -> Result<bool>;
 
-		/// Set the network spec. Argument must be one of pre-configured chains or a filename.
-		#[rpc(name = "parity_setChain")]
-		fn set_spec_name(&self, String) -> Result<bool>;
+	/// Set the network spec. Argument must be one of pre-configured chains or a filename.
+	#[rpc(name = "parity_setChain")]
+	fn set_spec_name(&self, String) -> Result<bool>;
 
-		/// Hash a file content under given URL.
-		#[rpc(name = "parity_hashContent")]
-		fn hash_content(&self, String) -> BoxFuture<H256>;
+	/// Hash a file content under given URL.
+	#[rpc(name = "parity_hashContent")]
+	fn hash_content(&self, String) -> BoxFuture<H256>;
 
-		/// Is there a release ready for install?
-		#[rpc(name = "parity_upgradeReady")]
-		fn upgrade_ready(&self) -> Result<Option<ReleaseInfo>>;
+	/// Is there a release ready for install?
+	#[rpc(name = "parity_upgradeReady")]
+	fn upgrade_ready(&self) -> Result<Option<ReleaseInfo>>;
 
-		/// Execute a release which is ready according to upgrade_ready().
-		#[rpc(name = "parity_executeUpgrade")]
-		fn execute_upgrade(&self) -> Result<bool>;
+	/// Execute a release which is ready according to upgrade_ready().
+	#[rpc(name = "parity_executeUpgrade")]
+	fn execute_upgrade(&self) -> Result<bool>;
 
-		/// Removes transaction from transaction queue.
-		/// Makes sense only for transactions that were not propagated to other peers yet
-		/// like scheduled transactions or transactions in future.
-		/// It might also work for some local transactions with to low gas price
-		/// or excessive gas limit that are not accepted by other peers whp.
-		/// Returns `true` when transaction was removed, `false` if it was not found.
-		#[rpc(name = "parity_removeTransaction")]
-		fn remove_transaction(&self, H256) -> Result<Option<Transaction>>;
-	}
+	/// Removes transaction from transaction queue.
+	/// Makes sense only for transactions that were not propagated to other peers yet
+	/// like scheduled transactions or transactions in future.
+	/// It might also work for some local transactions with to low gas price
+	/// or excessive gas limit that are not accepted by other peers whp.
+	/// Returns `true` when transaction was removed, `false` if it was not found.
+	#[rpc(name = "parity_removeTransaction")]
+	fn remove_transaction(&self, H256) -> Result<Option<Transaction>>;
 }

--- a/rpc/src/v1/traits/parity_signing.rs
+++ b/rpc/src/v1/traits/parity_signing.rs
@@ -16,37 +16,38 @@
 
 //! ParitySigning rpc interface.
 use jsonrpc_core::{BoxFuture, Result};
+use jsonrpc_derive::rpc;
 
 use v1::types::{U256, H160, Bytes, ConfirmationResponse, TransactionRequest, Either};
 
-build_rpc_trait! {
-	/// Signing methods implementation.
-	pub trait ParitySigning {
-		type Metadata;
+/// Signing methods implementation.
+#[rpc]
+pub trait ParitySigning {
+	/// RPC Metadata
+	type Metadata;
 
-		/// Given partial transaction request produces transaction with all fields filled in.
-		/// Such transaction can be then signed externally.
-		#[rpc(meta, name = "parity_composeTransaction")]
-		fn compose_transaction(&self, Self::Metadata, TransactionRequest) -> BoxFuture<TransactionRequest>;
+	/// Given partial transaction request produces transaction with all fields filled in.
+	/// Such transaction can be then signed externally.
+	#[rpc(meta, name = "parity_composeTransaction")]
+	fn compose_transaction(&self, Self::Metadata, TransactionRequest) -> BoxFuture<TransactionRequest>;
 
-		/// Posts sign request asynchronously.
-		/// Will return a confirmation ID for later use with check_transaction.
-		#[rpc(meta, name = "parity_postSign")]
-		fn post_sign(&self, Self::Metadata, H160, Bytes) -> BoxFuture<Either<U256, ConfirmationResponse>>;
+	/// Posts sign request asynchronously.
+	/// Will return a confirmation ID for later use with check_transaction.
+	#[rpc(meta, name = "parity_postSign")]
+	fn post_sign(&self, Self::Metadata, H160, Bytes) -> BoxFuture<Either<U256, ConfirmationResponse>>;
 
-		/// Posts transaction asynchronously.
-		/// Will return a transaction ID for later use with check_transaction.
-		#[rpc(meta, name = "parity_postTransaction")]
-		fn post_transaction(&self, Self::Metadata, TransactionRequest) -> BoxFuture<Either<U256, ConfirmationResponse>>;
+	/// Posts transaction asynchronously.
+	/// Will return a transaction ID for later use with check_transaction.
+	#[rpc(meta, name = "parity_postTransaction")]
+	fn post_transaction(&self, Self::Metadata, TransactionRequest) -> BoxFuture<Either<U256, ConfirmationResponse>>;
 
-		/// Checks the progress of a previously posted request (transaction/sign).
-		/// Should be given a valid send_transaction ID.
-		#[rpc(name = "parity_checkRequest")]
-		fn check_request(&self, U256) -> Result<Option<ConfirmationResponse>>;
+	/// Checks the progress of a previously posted request (transaction/sign).
+	/// Should be given a valid send_transaction ID.
+	#[rpc(name = "parity_checkRequest")]
+	fn check_request(&self, U256) -> Result<Option<ConfirmationResponse>>;
 
-		/// Decrypt some ECIES-encrypted message.
-		/// First parameter is the address with which it is encrypted, second is the ciphertext.
-		#[rpc(meta, name = "parity_decryptMessage")]
-		fn decrypt_message(&self, Self::Metadata, H160, Bytes) -> BoxFuture<Bytes>;
-	}
+	/// Decrypt some ECIES-encrypted message.
+	/// First parameter is the address with which it is encrypted, second is the ciphertext.
+	#[rpc(meta, name = "parity_decryptMessage")]
+	fn decrypt_message(&self, Self::Metadata, H160, Bytes) -> BoxFuture<Bytes>;
 }

--- a/rpc/src/v1/traits/personal.rs
+++ b/rpc/src/v1/traits/personal.rs
@@ -18,56 +18,57 @@
 use eip_712::EIP712;
 use jsonrpc_core::types::Value;
 use jsonrpc_core::{BoxFuture, Result};
+use jsonrpc_derive::rpc;
 use v1::types::{Bytes, U128, H160, H256, H520, TransactionRequest, RichRawTransaction as RpcRichRawTransaction, EIP191Version};
 
-build_rpc_trait! {
-	/// Personal rpc interface. Safe (read-only) functions.
-	pub trait Personal {
-		type Metadata;
+/// Personal rpc interface. Safe (read-only) functions.
+#[rpc]
+pub trait Personal {
+	/// RPC Metadata
+	type Metadata;
 
-		/// Lists all stored accounts
-		#[rpc(name = "personal_listAccounts")]
-		fn accounts(&self) -> Result<Vec<H160>>;
+	/// Lists all stored accounts
+	#[rpc(name = "personal_listAccounts")]
+	fn accounts(&self) -> Result<Vec<H160>>;
 
-		/// Creates new account (it becomes new current unlocked account)
-		/// Param is the password for the account.
-		#[rpc(name = "personal_newAccount")]
-		fn new_account(&self, String) -> Result<H160>;
+	/// Creates new account (it becomes new current unlocked account)
+	/// Param is the password for the account.
+	#[rpc(name = "personal_newAccount")]
+	fn new_account(&self, String) -> Result<H160>;
 
-		/// Unlocks specified account for use (can only be one unlocked account at one moment)
-		#[rpc(name = "personal_unlockAccount")]
-		fn unlock_account(&self, H160, String, Option<U128>) -> Result<bool>;
+	/// Unlocks specified account for use (can only be one unlocked account at one moment)
+	#[rpc(name = "personal_unlockAccount")]
+	fn unlock_account(&self, H160, String, Option<U128>) -> Result<bool>;
 
-		/// Signs the hash of data with given account signature using the given password to unlock the account during
-		/// the request.
-		#[rpc(name = "personal_sign")]
-		fn sign(&self, Bytes, H160, String) -> BoxFuture<H520>;
+	/// Signs the hash of data with given account signature using the given password to unlock the account during
+	/// the request.
+	#[rpc(name = "personal_sign")]
+	fn sign(&self, Bytes, H160, String) -> BoxFuture<H520>;
 
-		/// Produces an EIP-712 compliant signature with given account using the given password to unlock the
-		/// account during the request.
-		#[rpc(name = "personal_signTypedData")]
-		fn sign_typed_data(&self, EIP712, H160, String) -> BoxFuture<H520>;
+	/// Produces an EIP-712 compliant signature with given account using the given password to unlock the
+	/// account during the request.
+	#[rpc(name = "personal_signTypedData")]
+	fn sign_typed_data(&self, EIP712, H160, String) -> BoxFuture<H520>;
 
-		/// Signs an arbitrary message based on the version specified
-		#[rpc(name = "personal_sign191")]
-		fn sign_191(&self, EIP191Version, Value, H160, String) -> BoxFuture<H520>;
+	/// Signs an arbitrary message based on the version specified
+	#[rpc(name = "personal_sign191")]
+	fn sign_191(&self, EIP191Version, Value, H160, String) -> BoxFuture<H520>;
 
-		/// Returns the account associated with the private key that was used to calculate the signature in
-		/// `personal_sign`.
-		#[rpc(name = "personal_ecRecover")]
-		fn ec_recover(&self, Bytes, H520) -> BoxFuture<H160>;
+	/// Returns the account associated with the private key that was used to calculate the signature in
+	/// `personal_sign`.
+	#[rpc(name = "personal_ecRecover")]
+	fn ec_recover(&self, Bytes, H520) -> BoxFuture<H160>;
 
-		/// Signs transaction. The account is not unlocked in such case.
-		#[rpc(meta, name = "personal_signTransaction")]
-		fn sign_transaction(&self, Self::Metadata, TransactionRequest, String) -> BoxFuture<RpcRichRawTransaction>;
+	/// Signs transaction. The account is not unlocked in such case.
+	#[rpc(meta, name = "personal_signTransaction")]
+	fn sign_transaction(&self, Self::Metadata, TransactionRequest, String) -> BoxFuture<RpcRichRawTransaction>;
 
-		/// Sends transaction and signs it in single call. The account is not unlocked in such case.
-		#[rpc(meta, name = "personal_sendTransaction")]
-		fn send_transaction(&self, Self::Metadata, TransactionRequest, String) -> BoxFuture<H256>;
+	/// Sends transaction and signs it in single call. The account is not unlocked in such case.
+	#[rpc(meta, name = "personal_sendTransaction")]
+	fn send_transaction(&self, Self::Metadata, TransactionRequest, String) -> BoxFuture<H256>;
 
-		/// @deprecated alias for `personal_sendTransaction`.
-		#[rpc(meta, name = "personal_signAndSendTransaction")]
-		fn sign_and_send_transaction(&self, Self::Metadata, TransactionRequest, String) -> BoxFuture<H256>;
+	/// @deprecated alias for `personal_sendTransaction`.
+	#[rpc(meta, name = "personal_signAndSendTransaction")]
+	fn sign_and_send_transaction(&self, Self::Metadata, TransactionRequest, String) -> BoxFuture<H256>;
 
-	}
 }

--- a/rpc/src/v1/traits/private.rs
+++ b/rpc/src/v1/traits/private.rs
@@ -17,29 +17,30 @@
 //! SecretStore-specific rpc interface.
 
 use jsonrpc_core::Error;
+use jsonrpc_derive::rpc;
 
 use v1::types::{Bytes, PrivateTransactionReceipt, H160, H256, U256, BlockNumber,
 	PrivateTransactionReceiptAndTransaction, CallRequest};
 
-build_rpc_trait! {
-	/// Private transaction management RPC interface.
-	pub trait Private {
-		type Metadata;
+/// Private transaction management RPC interface.
+#[rpc]
+pub trait Private {
+	/// RPC Metadata
+	type Metadata;
 
-		/// Sends private transaction; Transaction will be added to the validation queue and sent out when ready.
-		#[rpc(name = "private_sendTransaction")]
-		fn send_transaction(&self, Bytes) -> Result<PrivateTransactionReceipt, Error>;
+	/// Sends private transaction; Transaction will be added to the validation queue and sent out when ready.
+	#[rpc(name = "private_sendTransaction")]
+	fn send_transaction(&self, Bytes) -> Result<PrivateTransactionReceipt, Error>;
 
-		/// Creates a transaction for contract's deployment from origin (signed transaction)
-		#[rpc(name = "private_composeDeploymentTransaction")]
-		fn compose_deployment_transaction(&self, BlockNumber, Bytes, Vec<H160>, U256) -> Result<PrivateTransactionReceiptAndTransaction, Error>;
+	/// Creates a transaction for contract's deployment from origin (signed transaction)
+	#[rpc(name = "private_composeDeploymentTransaction")]
+	fn compose_deployment_transaction(&self, BlockNumber, Bytes, Vec<H160>, U256) -> Result<PrivateTransactionReceiptAndTransaction, Error>;
 
-		/// Make a call to the private contract
-		#[rpc(name = "private_call")]
-		fn private_call(&self, BlockNumber, CallRequest) -> Result<Bytes, Error>;
+	/// Make a call to the private contract
+	#[rpc(name = "private_call")]
+	fn private_call(&self, BlockNumber, CallRequest) -> Result<Bytes, Error>;
 
-		/// Retrieve the id of the key associated with the contract
-		#[rpc(name = "private_contractKey")]
-		fn private_contract_key(&self, H160) -> Result<H256, Error>;
-	}
+	/// Retrieve the id of the key associated with the contract
+	#[rpc(name = "private_contractKey")]
+	fn private_contract_key(&self, H160) -> Result<H256, Error>;
 }

--- a/rpc/src/v1/traits/pubsub.rs
+++ b/rpc/src/v1/traits/pubsub.rs
@@ -17,23 +17,20 @@
 //! Parity-specific PUB-SUB rpc interface.
 
 use jsonrpc_core::{Result, Value, Params};
-use jsonrpc_pubsub::SubscriptionId;
-use jsonrpc_macros::Trailing;
-use jsonrpc_macros::pubsub::Subscriber;
+use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId};
+use jsonrpc_derive::rpc;
 
-build_rpc_trait! {
-	/// Parity-specific PUB-SUB rpc interface.
-	pub trait PubSub {
-		type Metadata;
+/// Parity-specific PUB-SUB rpc interface.
+#[rpc]
+pub trait PubSub {
+	/// Pub/Sub Metadata
+	type Metadata;
 
-		#[pubsub(name = "parity_subscription")] {
-			/// Subscribe to changes of any RPC method in Parity.
-			#[rpc(name = "parity_subscribe")]
-			fn parity_subscribe(&self, Self::Metadata, Subscriber<Value>, String, Trailing<Params>);
+	/// Subscribe to changes of any RPC method in Parity.
+	#[pubsub(subscription = "parity_subscription", subscribe, name = "parity_subscribe")]
+	fn parity_subscribe(&self, Self::Metadata, Subscriber<Value>, String, Option<Params>);
 
-			/// Unsubscribe from existing Parity subscription.
-			#[rpc(name = "parity_unsubscribe")]
-			fn parity_unsubscribe(&self, SubscriptionId) -> Result<bool>;
-		}
-	}
+	/// Unsubscribe from existing Parity subscription.
+	#[pubsub(subscription = "parity_subscription", unsubscribe, name = "parity_unsubscribe")]
+	fn parity_unsubscribe(&self, Option<Self::Metadata>, SubscriptionId) -> Result<bool>;
 }

--- a/rpc/src/v1/traits/rpc.rs
+++ b/rpc/src/v1/traits/rpc.rs
@@ -19,18 +19,18 @@
 use std::collections::BTreeMap;
 
 use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
 
-build_rpc_trait! {
-	/// RPC Interface.
-	pub trait Rpc {
-		/// Returns supported modules for Geth 1.3.6
-        /// @ignore
-		#[rpc(name = "modules")]
-		fn modules(&self) -> Result<BTreeMap<String, String>>;
+/// RPC Interface.
+#[rpc]
+pub trait Rpc {
+	/// Returns supported modules for Geth 1.3.6
+	/// @ignore
+	#[rpc(name = "modules")]
+	fn modules(&self) -> Result<BTreeMap<String, String>>;
 
-		/// Returns supported modules for Geth 1.4.0
-        /// @ignore
-		#[rpc(name = "rpc_modules")]
-		fn rpc_modules(&self) -> Result<BTreeMap<String, String>>;
-	}
+	/// Returns supported modules for Geth 1.4.0
+	/// @ignore
+	#[rpc(name = "rpc_modules")]
+	fn rpc_modules(&self) -> Result<BTreeMap<String, String>>;
 }

--- a/rpc/src/v1/traits/secretstore.rs
+++ b/rpc/src/v1/traits/secretstore.rs
@@ -18,43 +18,43 @@
 
 use std::collections::BTreeSet;
 use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
 use ethkey::Password;
 
 use v1::types::{H160, H256, H512, Bytes, EncryptedDocumentKey};
 
-build_rpc_trait! {
-	/// Parity-specific rpc interface.
-	pub trait SecretStore {
-		/// Generate document key to store in secret store.
-		/// Arguments: `account`, `password`, `server_key_public`.
-		#[rpc(name = "secretstore_generateDocumentKey")]
-		fn generate_document_key(&self, H160, Password, H512) -> Result<EncryptedDocumentKey>;
+/// Parity-specific rpc interface.
+#[rpc]
+pub trait SecretStore {
+	/// Generate document key to store in secret store.
+	/// Arguments: `account`, `password`, `server_key_public`.
+	#[rpc(name = "secretstore_generateDocumentKey")]
+	fn generate_document_key(&self, H160, Password, H512) -> Result<EncryptedDocumentKey>;
 
-		/// Encrypt data with key, received from secret store.
-		/// Arguments: `account`, `password`, `key`, `data`.
-		#[rpc(name = "secretstore_encrypt")]
-		fn encrypt(&self, H160, Password, Bytes, Bytes) -> Result<Bytes>;
+	/// Encrypt data with key, received from secret store.
+	/// Arguments: `account`, `password`, `key`, `data`.
+	#[rpc(name = "secretstore_encrypt")]
+	fn encrypt(&self, H160, Password, Bytes, Bytes) -> Result<Bytes>;
 
-		/// Decrypt data with key, received from secret store.
-		/// Arguments: `account`, `password`, `key`, `data`.
-		#[rpc(name = "secretstore_decrypt")]
-		fn decrypt(&self, H160, Password, Bytes, Bytes) -> Result<Bytes>;
+	/// Decrypt data with key, received from secret store.
+	/// Arguments: `account`, `password`, `key`, `data`.
+	#[rpc(name = "secretstore_decrypt")]
+	fn decrypt(&self, H160, Password, Bytes, Bytes) -> Result<Bytes>;
 
-		/// Decrypt data with shadow key, received from secret store.
-		/// Arguments: `account`, `password`, `decrypted_secret`, `common_point`, `decrypt_shadows`, `data`.
-		#[rpc(name = "secretstore_shadowDecrypt")]
-		fn shadow_decrypt(&self, H160, Password, H512, H512, Vec<Bytes>, Bytes) -> Result<Bytes>;
+	/// Decrypt data with shadow key, received from secret store.
+	/// Arguments: `account`, `password`, `decrypted_secret`, `common_point`, `decrypt_shadows`, `data`.
+	#[rpc(name = "secretstore_shadowDecrypt")]
+	fn shadow_decrypt(&self, H160, Password, H512, H512, Vec<Bytes>, Bytes) -> Result<Bytes>;
 
-		/// Calculates the hash (keccak256) of servers set for using in ServersSetChange session.
-		/// Returned hash must be signed later by using `secretstore_signRawHash` method.
-		/// Arguments: `servers_set`.
-		#[rpc(name = "secretstore_serversSetHash")]
-		fn servers_set_hash(&self, BTreeSet<H512>) -> Result<H256>;
+	/// Calculates the hash (keccak256) of servers set for using in ServersSetChange session.
+	/// Returned hash must be signed later by using `secretstore_signRawHash` method.
+	/// Arguments: `servers_set`.
+	#[rpc(name = "secretstore_serversSetHash")]
+	fn servers_set_hash(&self, BTreeSet<H512>) -> Result<H256>;
 
-		/// Generate recoverable ECDSA signature of raw hash.
-		/// Passed hash is treated as an input to the `sign` function (no prefixes added, no hash function is applied).
-		/// Arguments: `account`, `password`, `raw_hash`.
-		#[rpc(name = "secretstore_signRawHash")]
-		fn sign_raw_hash(&self, H160, Password, H256) -> Result<Bytes>;
-	}
+	/// Generate recoverable ECDSA signature of raw hash.
+	/// Passed hash is treated as an input to the `sign` function (no prefixes added, no hash function is applied).
+	/// Arguments: `account`, `password`, `raw_hash`.
+	#[rpc(name = "secretstore_signRawHash")]
+	fn sign_raw_hash(&self, H160, Password, H256) -> Result<Bytes>;
 }

--- a/rpc/src/v1/traits/signer.rs
+++ b/rpc/src/v1/traits/signer.rs
@@ -16,52 +16,50 @@
 
 //! Parity Signer-related rpc interface.
 use jsonrpc_core::{BoxFuture, Result};
-use jsonrpc_pubsub::SubscriptionId;
-use jsonrpc_macros::pubsub::Subscriber;
+use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId};
+use jsonrpc_derive::rpc;
 
 use v1::types::{U256, Bytes, TransactionModification, ConfirmationRequest, ConfirmationResponse, ConfirmationResponseWithToken};
 
-build_rpc_trait! {
-	/// Signer extension for confirmations rpc interface.
-	pub trait Signer {
-		type Metadata;
+/// Signer extension for confirmations rpc interface.
+#[rpc]
+pub trait Signer {
+	/// RPC Metadata
+	type Metadata;
 
-		/// Returns a list of items to confirm.
-		#[rpc(name = "signer_requestsToConfirm")]
-		fn requests_to_confirm(&self) -> Result<Vec<ConfirmationRequest>>;
+	/// Returns a list of items to confirm.
+	#[rpc(name = "signer_requestsToConfirm")]
+	fn requests_to_confirm(&self) -> Result<Vec<ConfirmationRequest>>;
 
-		/// Confirm specific request.
-		#[rpc(name = "signer_confirmRequest")]
-		fn confirm_request(&self, U256, TransactionModification, String) -> BoxFuture<ConfirmationResponse>;
+	/// Confirm specific request.
+	#[rpc(name = "signer_confirmRequest")]
+	fn confirm_request(&self, U256, TransactionModification, String) -> BoxFuture<ConfirmationResponse>;
 
-		/// Confirm specific request with token.
-		#[rpc(name = "signer_confirmRequestWithToken")]
-		fn confirm_request_with_token(&self, U256, TransactionModification, String) -> BoxFuture<ConfirmationResponseWithToken>;
+	/// Confirm specific request with token.
+	#[rpc(name = "signer_confirmRequestWithToken")]
+	fn confirm_request_with_token(&self, U256, TransactionModification, String) -> BoxFuture<ConfirmationResponseWithToken>;
 
-		/// Confirm specific request with already signed data.
-		#[rpc(name = "signer_confirmRequestRaw")]
-		fn confirm_request_raw(&self, U256, Bytes) -> Result<ConfirmationResponse>;
+	/// Confirm specific request with already signed data.
+	#[rpc(name = "signer_confirmRequestRaw")]
+	fn confirm_request_raw(&self, U256, Bytes) -> Result<ConfirmationResponse>;
 
-		/// Reject the confirmation request.
-		#[rpc(name = "signer_rejectRequest")]
-		fn reject_request(&self, U256) -> Result<bool>;
+	/// Reject the confirmation request.
+	#[rpc(name = "signer_rejectRequest")]
+	fn reject_request(&self, U256) -> Result<bool>;
 
-		/// Generates new authorization token.
-		#[rpc(name = "signer_generateAuthorizationToken")]
-		fn generate_token(&self) -> Result<String>;
+	/// Generates new authorization token.
+	#[rpc(name = "signer_generateAuthorizationToken")]
+	fn generate_token(&self) -> Result<String>;
 
-		/// Generates new web proxy access token for particular domain.
-		#[rpc(name = "signer_generateWebProxyAccessToken")]
-		fn generate_web_proxy_token(&self, String) -> Result<String>;
+	/// Generates new web proxy access token for particular domain.
+	#[rpc(name = "signer_generateWebProxyAccessToken")]
+	fn generate_web_proxy_token(&self, String) -> Result<String>;
 
-		#[pubsub(name = "signer_pending")] {
-			/// Subscribe to new pending requests on signer interface.
-			#[rpc(name = "signer_subscribePending")]
-			fn subscribe_pending(&self, Self::Metadata, Subscriber<Vec<ConfirmationRequest>>);
+	/// Subscribe to new pending requests on signer interface.
+	#[pubsub(subscription = "signer_pending", subscribe, name = "signer_subscribePending")]
+	fn subscribe_pending(&self, Self::Metadata, Subscriber<Vec<ConfirmationRequest>>);
 
-			/// Unsubscribe from pending requests subscription.
-			#[rpc(name = "signer_unsubscribePending")]
-			fn unsubscribe_pending(&self, SubscriptionId) -> Result<bool>;
-		}
-	}
+	/// Unsubscribe from pending requests subscription.
+	#[pubsub(subscription = "signer_pending", unsubscribe, name = "signer_unsubscribePending")]
+	fn unsubscribe_pending(&self, Option<Self::Metadata>, SubscriptionId) -> Result<bool>;
 }

--- a/rpc/src/v1/traits/traces.rs
+++ b/rpc/src/v1/traits/traces.rs
@@ -17,48 +17,48 @@
 //! Traces specific rpc interface.
 
 use jsonrpc_core::Result;
-use jsonrpc_macros::Trailing;
+use jsonrpc_derive::rpc;
 use v1::types::{TraceFilter, LocalizedTrace, BlockNumber, Index, CallRequest, Bytes, TraceResults, TraceResultsWithTransactionHash, H256, TraceOptions};
 
-build_rpc_trait! {
-	/// Traces specific rpc interface.
-	pub trait Traces {
-		type Metadata;
+/// Traces specific rpc interface.
+#[rpc]
+pub trait Traces {
+	/// RPC Metadata
+	type Metadata;
 
-		/// Returns traces matching given filter.
-		#[rpc(name = "trace_filter")]
-		fn filter(&self, TraceFilter) -> Result<Option<Vec<LocalizedTrace>>>;
+	/// Returns traces matching given filter.
+	#[rpc(name = "trace_filter")]
+	fn filter(&self, TraceFilter) -> Result<Option<Vec<LocalizedTrace>>>;
 
-		/// Returns transaction trace at given index.
-		#[rpc(name = "trace_get")]
-		fn trace(&self, H256, Vec<Index>) -> Result<Option<LocalizedTrace>>;
+	/// Returns transaction trace at given index.
+	#[rpc(name = "trace_get")]
+	fn trace(&self, H256, Vec<Index>) -> Result<Option<LocalizedTrace>>;
 
-		/// Returns all traces of given transaction.
-		#[rpc(name = "trace_transaction")]
-		fn transaction_traces(&self, H256) -> Result<Option<Vec<LocalizedTrace>>>;
+	/// Returns all traces of given transaction.
+	#[rpc(name = "trace_transaction")]
+	fn transaction_traces(&self, H256) -> Result<Option<Vec<LocalizedTrace>>>;
 
-		/// Returns all traces produced at given block.
-		#[rpc(name = "trace_block")]
-		fn block_traces(&self, BlockNumber) -> Result<Option<Vec<LocalizedTrace>>>;
+	/// Returns all traces produced at given block.
+	#[rpc(name = "trace_block")]
+	fn block_traces(&self, BlockNumber) -> Result<Option<Vec<LocalizedTrace>>>;
 
-		/// Executes the given call and returns a number of possible traces for it.
-		#[rpc(name = "trace_call")]
-		fn call(&self, CallRequest, TraceOptions, Trailing<BlockNumber>) -> Result<TraceResults>;
+	/// Executes the given call and returns a number of possible traces for it.
+	#[rpc(name = "trace_call")]
+	fn call(&self, CallRequest, TraceOptions, Option<BlockNumber>) -> Result<TraceResults>;
 
-		/// Executes all given calls and returns a number of possible traces for each of it.
-		#[rpc(name = "trace_callMany")]
-		fn call_many(&self, Vec<(CallRequest, TraceOptions)>, Trailing<BlockNumber>) -> Result<Vec<TraceResults>>;
+	/// Executes all given calls and returns a number of possible traces for each of it.
+	#[rpc(name = "trace_callMany")]
+	fn call_many(&self, Vec<(CallRequest, TraceOptions)>, Option<BlockNumber>) -> Result<Vec<TraceResults>>;
 
-		/// Executes the given raw transaction and returns a number of possible traces for it.
-		#[rpc(name = "trace_rawTransaction")]
-		fn raw_transaction(&self, Bytes, TraceOptions, Trailing<BlockNumber>) -> Result<TraceResults>;
+	/// Executes the given raw transaction and returns a number of possible traces for it.
+	#[rpc(name = "trace_rawTransaction")]
+	fn raw_transaction(&self, Bytes, TraceOptions, Option<BlockNumber>) -> Result<TraceResults>;
 
-		/// Executes the transaction with the given hash and returns a number of possible traces for it.
-		#[rpc(name = "trace_replayTransaction")]
-		fn replay_transaction(&self, H256, TraceOptions) -> Result<TraceResults>;
+	/// Executes the transaction with the given hash and returns a number of possible traces for it.
+	#[rpc(name = "trace_replayTransaction")]
+	fn replay_transaction(&self, H256, TraceOptions) -> Result<TraceResults>;
 
-		/// Executes all the transactions at the given block and returns a number of possible traces for each transaction.
-		#[rpc(name = "trace_replayBlockTransactions")]
-		fn replay_block_transactions(&self, BlockNumber, TraceOptions) ->  Result<Vec<TraceResultsWithTransactionHash>>;
-	}
+	/// Executes all the transactions at the given block and returns a number of possible traces for each transaction.
+	#[rpc(name = "trace_replayBlockTransactions")]
+	fn replay_block_transactions(&self, BlockNumber, TraceOptions) ->  Result<Vec<TraceResultsWithTransactionHash>>;
 }

--- a/rpc/src/v1/traits/web3.rs
+++ b/rpc/src/v1/traits/web3.rs
@@ -16,18 +16,18 @@
 
 //! Web3 rpc interface.
 use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
 
 use v1::types::{H256, Bytes};
 
-build_rpc_trait! {
-	/// Web3 rpc interface.
-	pub trait Web3 {
-		/// Returns current client version.
-		#[rpc(name = "web3_clientVersion")]
-		fn client_version(&self) -> Result<String>;
+/// Web3 rpc interface.
+#[rpc]
+pub trait Web3 {
+	/// Returns current client version.
+	#[rpc(name = "web3_clientVersion")]
+	fn client_version(&self) -> Result<String>;
 
-		/// Returns sha3 of the given data
-		#[rpc(name = "web3_sha3")]
-		fn sha3(&self, Bytes) -> Result<H256>;
-	}
+	/// Returns sha3 of the given data
+	#[rpc(name = "web3_sha3")]
+	fn sha3(&self, Bytes) -> Result<H256>;
 }

--- a/whisper/Cargo.toml
+++ b/whisper/Cargo.toml
@@ -25,10 +25,6 @@ slab = "0.3"
 smallvec = "0.6"
 tiny-keccak = "1.4"
 
-# jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-# jsonrpc-macros = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-# jsonrpc-pubsub = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-
 jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
 jsonrpc-derive = { path = "/home/andrew/code/paritytech/jsonrpc/derive" }
 jsonrpc-pubsub = { path = "/home/andrew/code/paritytech/jsonrpc/pubsub" }

--- a/whisper/Cargo.toml
+++ b/whisper/Cargo.toml
@@ -25,6 +25,6 @@ slab = "0.3"
 smallvec = "0.6"
 tiny-keccak = "1.4"
 
-jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
-jsonrpc-derive = { path = "/home/andrew/code/paritytech/jsonrpc/derive" }
-jsonrpc-pubsub = { path = "/home/andrew/code/paritytech/jsonrpc/pubsub" }
+jsonrpc-core = "10.0.1"
+jsonrpc-derive = "10.0.1"
+jsonrpc-pubsub = "10.0.1"

--- a/whisper/Cargo.toml
+++ b/whisper/Cargo.toml
@@ -25,6 +25,10 @@ slab = "0.3"
 smallvec = "0.6"
 tiny-keccak = "1.4"
 
-jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-jsonrpc-macros = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-jsonrpc-pubsub = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
+# jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
+# jsonrpc-macros = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
+# jsonrpc-pubsub = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
+
+jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
+jsonrpc-derive = { path = "/home/andrew/code/paritytech/jsonrpc/derive" }
+jsonrpc-pubsub = { path = "/home/andrew/code/paritytech/jsonrpc/pubsub" }

--- a/whisper/cli/Cargo.toml
+++ b/whisper/cli/Cargo.toml
@@ -10,9 +10,9 @@ docopt = "1.0"
 env_logger = "0.5"
 ethcore-network = { path = "../../util/network" }
 ethcore-network-devp2p = { path = "../../util/network-devp2p" }
-jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-jsonrpc-http-server = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
-jsonrpc-pubsub = { git = "https://github.com/paritytech/jsonrpc.git", branch = "parity-2.2" }
+jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
+jsonrpc-http-server = { path = "/home/andrew/code/paritytech/jsonrpc/http" }
+jsonrpc-pubsub = { path = "/home/andrew/code/paritytech/jsonrpc/pubsub" }
 log = "0.4"
 panic_hook = { path = "../../util/panic-hook" }
 parity-whisper = { path = "../" }

--- a/whisper/cli/Cargo.toml
+++ b/whisper/cli/Cargo.toml
@@ -10,9 +10,9 @@ docopt = "1.0"
 env_logger = "0.5"
 ethcore-network = { path = "../../util/network" }
 ethcore-network-devp2p = { path = "../../util/network-devp2p" }
-jsonrpc-core = { path = "/home/andrew/code/paritytech/jsonrpc/core" }
-jsonrpc-http-server = { path = "/home/andrew/code/paritytech/jsonrpc/http" }
-jsonrpc-pubsub = { path = "/home/andrew/code/paritytech/jsonrpc/pubsub" }
+jsonrpc-core = "10.0.1"
+jsonrpc-http-server = "10.0.1"
+jsonrpc-pubsub = "10.0.1"
 log = "0.4"
 panic_hook = { path = "../../util/panic-hook" }
 parity-whisper = { path = "../" }

--- a/whisper/src/lib.rs
+++ b/whisper/src/lib.rs
@@ -34,6 +34,7 @@ extern crate smallvec;
 extern crate tiny_keccak;
 
 extern crate jsonrpc_core;
+extern crate jsonrpc_derive;
 extern crate jsonrpc_pubsub;
 
 #[macro_use]
@@ -41,9 +42,6 @@ extern crate bitflags;
 
 #[macro_use]
 extern crate log;
-
-#[macro_use]
-extern crate jsonrpc_macros;
 
 #[macro_use]
 extern crate serde_derive;

--- a/whisper/src/rpc/filter.rs
+++ b/whisper/src/rpc/filter.rs
@@ -21,7 +21,7 @@ use std::{sync::{Arc, atomic, atomic::AtomicBool, mpsc}, thread};
 
 use ethereum_types::{H256, H512};
 use ethkey::Public;
-use jsonrpc_macros::pubsub::{Subscriber, Sink};
+use jsonrpc_pubsub::typed::{Subscriber, Sink};
 use parking_lot::{Mutex, RwLock};
 use rand::{Rng, OsRng};
 

--- a/whisper/src/rpc/mod.rs
+++ b/whisper/src/rpc/mod.rs
@@ -24,8 +24,8 @@
 use std::sync::Arc;
 
 use jsonrpc_core::{Error, ErrorCode, Metadata};
-use jsonrpc_pubsub::{Session, PubSubMetadata, SubscriptionId};
-use jsonrpc_macros::pubsub;
+use jsonrpc_derive::rpc;
+use jsonrpc_pubsub::{Session, PubSubMetadata, SubscriptionId, typed::Subscriber};
 
 use ethereum_types::H256;
 use memzero::Memzero;
@@ -68,81 +68,78 @@ fn abridge_topic(topic: &[u8]) -> Topic {
 	abridged.into()
 }
 
-build_rpc_trait! {
-	/// Whisper RPC interface.
-	pub trait Whisper {
-		/// Info about the node.
-		#[rpc(name = "shh_info")]
-		fn info(&self) -> Result<types::NodeInfo, Error>;
+/// Whisper RPC interface.
+#[rpc]
+pub trait Whisper {
+	/// Info about the node.
+	#[rpc(name = "shh_info")]
+	fn info(&self) -> Result<types::NodeInfo, Error>;
 
-		/// Generate a new asymmetric key pair and return an identity.
-		#[rpc(name = "shh_newKeyPair")]
-		fn new_key_pair(&self) -> Result<types::Identity, Error>;
+	/// Generate a new asymmetric key pair and return an identity.
+	#[rpc(name = "shh_newKeyPair")]
+	fn new_key_pair(&self) -> Result<types::Identity, Error>;
 
-		/// Import the given SECP2561k private key and return an identity.
-		#[rpc(name = "shh_addPrivateKey")]
-		fn add_private_key(&self, types::Private) -> Result<types::Identity, Error>;
+	/// Import the given SECP2561k private key and return an identity.
+	#[rpc(name = "shh_addPrivateKey")]
+	fn add_private_key(&self, types::Private) -> Result<types::Identity, Error>;
 
-		/// Generate a new symmetric key and return an identity.
-		#[rpc(name = "shh_newSymKey")]
-		fn new_sym_key(&self) -> Result<types::Identity, Error>;
+	/// Generate a new symmetric key and return an identity.
+	#[rpc(name = "shh_newSymKey")]
+	fn new_sym_key(&self) -> Result<types::Identity, Error>;
 
-		/// Import the given symmetric key and return an identity.
-		#[rpc(name = "shh_addSymKey")]
-		fn add_sym_key(&self, types::Symmetric) -> Result<types::Identity, Error>;
+	/// Import the given symmetric key and return an identity.
+	#[rpc(name = "shh_addSymKey")]
+	fn add_sym_key(&self, types::Symmetric) -> Result<types::Identity, Error>;
 
-		/// Get public key. Succeeds if identity is stored and asymmetric.
-		#[rpc(name = "shh_getPublicKey")]
-		fn get_public(&self, types::Identity) -> Result<types::Public, Error>;
+	/// Get public key. Succeeds if identity is stored and asymmetric.
+	#[rpc(name = "shh_getPublicKey")]
+	fn get_public(&self, types::Identity) -> Result<types::Public, Error>;
 
-		/// Get private key. Succeeds if identity is stored and asymmetric.
-		#[rpc(name = "shh_getPrivateKey")]
-		fn get_private(&self, types::Identity) -> Result<types::Private, Error>;
+	/// Get private key. Succeeds if identity is stored and asymmetric.
+	#[rpc(name = "shh_getPrivateKey")]
+	fn get_private(&self, types::Identity) -> Result<types::Private, Error>;
 
-		#[rpc(name = "shh_getSymKey")]
-		fn get_symmetric(&self, types::Identity) -> Result<types::Symmetric, Error>;
+	#[rpc(name = "shh_getSymKey")]
+	fn get_symmetric(&self, types::Identity) -> Result<types::Symmetric, Error>;
 
-		/// Delete key pair denoted by given identity.
-		///
-		/// Return true if successfully removed, false if unknown,
-		/// and error otherwise.
-		#[rpc(name = "shh_deleteKey")]
-		fn remove_key(&self, types::Identity) -> Result<bool, Error>;
+	/// Delete key pair denoted by given identity.
+	///
+	/// Return true if successfully removed, false if unknown,
+	/// and error otherwise.
+	#[rpc(name = "shh_deleteKey")]
+	fn remove_key(&self, types::Identity) -> Result<bool, Error>;
 
-		/// Post a message to the network with given parameters.
-		#[rpc(name = "shh_post")]
-		fn post(&self, types::PostRequest) -> Result<bool, Error>;
+	/// Post a message to the network with given parameters.
+	#[rpc(name = "shh_post")]
+	fn post(&self, types::PostRequest) -> Result<bool, Error>;
 
-		/// Create a new polled filter.
-		#[rpc(name = "shh_newMessageFilter")]
-		fn new_filter(&self, types::FilterRequest) -> Result<types::Identity, Error>;
+	/// Create a new polled filter.
+	#[rpc(name = "shh_newMessageFilter")]
+	fn new_filter(&self, types::FilterRequest) -> Result<types::Identity, Error>;
 
-		/// Poll changes on a polled filter.
-		#[rpc(name = "shh_getFilterMessages")]
-		fn poll_changes(&self, types::Identity) -> Result<Vec<types::FilterItem>, Error>;
+	/// Poll changes on a polled filter.
+	#[rpc(name = "shh_getFilterMessages")]
+	fn poll_changes(&self, types::Identity) -> Result<Vec<types::FilterItem>, Error>;
 
-		/// Delete polled filter. Return bool indicating success.
-		#[rpc(name = "shh_deleteMessageFilter")]
-		fn delete_filter(&self, types::Identity) -> Result<bool, Error>;
-	}
+	/// Delete polled filter. Return bool indicating success.
+	#[rpc(name = "shh_deleteMessageFilter")]
+	fn delete_filter(&self, types::Identity) -> Result<bool, Error>;
 }
 
-build_rpc_trait! {
-	/// Whisper RPC pubsub.
-	pub trait WhisperPubSub {
-		type Metadata;
+/// Whisper RPC pubsub.
+#[rpc]
+pub trait WhisperPubSub {
+	// RPC Metadata
+	type Metadata;
 
-		#[pubsub(name = "shh_subscription")] {
-			/// Subscribe to messages matching the filter.
-			#[rpc(name = "shh_subscribe")]
-			fn subscribe(&self, Self::Metadata, pubsub::Subscriber<types::FilterItem>, types::FilterRequest);
+	/// Subscribe to messages matching the filter.
+	#[pubsub(subscription = "shh_subscription", subscribe, name = "shh_subscribe")]
+	fn subscribe(&self, Self::Metadata, Subscriber<types::FilterItem>, types::FilterRequest);
 
-			/// Unsubscribe from filter matching given ID. Return
-			/// true on success, error otherwise.
-			#[rpc(name = "shh_unsubscribe")]
-			fn unsubscribe(&self, SubscriptionId) -> Result<bool, Error>;
-		}
-	}
+	/// Unsubscribe from filter matching given ID. Return
+	/// true on success, error otherwise.
+	#[pubsub(subscription = "shh_subscription", unsubscribe, name = "shh_unsubscribe")]
+	fn unsubscribe(&self, Option<Self::Metadata>, SubscriptionId) -> Result<bool, Error>;
 }
 
 /// Something which can send messages to the network.
@@ -364,7 +361,7 @@ impl<P: PoolHandle + 'static, M: Send + Sync + PubSubMetadata> WhisperPubSub for
 	fn subscribe(
 		&self,
 		_meta: Self::Metadata,
-		subscriber: pubsub::Subscriber<types::FilterItem>,
+		subscriber: Subscriber<types::FilterItem>,
 		req: types::FilterRequest,
 	) {
 		match Filter::new(req) {
@@ -377,7 +374,7 @@ impl<P: PoolHandle + 'static, M: Send + Sync + PubSubMetadata> WhisperPubSub for
 		}
 	}
 
-	fn unsubscribe(&self, id: SubscriptionId) -> Result<bool, Error> {
+	fn unsubscribe(&self, _: Option<Self::Metadata>, id: SubscriptionId) -> Result<bool, Error> {
 		use std::str::FromStr;
 
 		let res = match id {


### PR DESCRIPTION
Replaces `jsonrpc-macros` with `jsonrpc-derive` custom trait attribute. With the added bonus of now using published crates.