### PR TITLE
fix(secret-store): deprecation warning

### DIFF
--- a/secret-store/src/listener/http_listener.rs
+++ b/secret-store/src/listener/http_listener.rs
@@ -334,7 +334,7 @@ fn parse_request(method: &HttpMethod, uri_path: &str, body: &[u8]) -> Request {
 		Err(_) => return Request::Invalid,
 	};
 
-	let path: Vec<String> = uri_path.trim_left_matches('/').split('/').map(Into::into).collect();
+	let path: Vec<String> = uri_path.trim_start_matches('/').split('/').map(Into::into).collect();
 	if path.len() == 0 {
 		return Request::Invalid;
 	}


### PR DESCRIPTION
use of deprecated item 'core::str::<impl str>::trim_left_matches': superseded by `trim_start_matches`