### PR TITLE
fix: parity-clib/examples/cpp/CMakeLists.txt

### DIFF
--- a/parity-clib/examples/cpp/CMakeLists.txt
+++ b/parity-clib/examples/cpp/CMakeLists.txt
@@ -15,4 +15,4 @@ ExternalProject_Add(
     LOG_BUILD ON)
 
 add_dependencies(parity-example libparity)
-target_link_libraries(parity-example "${CMAKE_SOURCE_DIR}/../../../target/debug/libparity.so")
+target_link_libraries(parity-example "${CMAKE_SOURCE_DIR}/../../../target/debug/${CMAKE_SHARED_LIBRARY_PREFIX}parity${CMAKE_SHARED_LIBRARY_SUFFIX}")


### PR DESCRIPTION
* use of `${CMAKE_SHARED_LIBRARY_PREFIX}` &
`${CMAKE_SHARED_LIBRARY_SUFFIX}` to support other operating systems.

This will fix linking issues on other operating systems.