### PR TITLE
fix(compilation warns): `no-default-features`

### DIFF
--- a/parity/account.rs
+++ b/parity/account.rs
@@ -58,7 +58,7 @@ pub struct ImportFromGethAccounts {
 
 
 #[cfg(not(feature = "accounts"))]
-pub fn execute(cmd: AccountCmd) -> Result<String, String> {
+pub fn execute(_cmd: AccountCmd) -> Result<String, String> {
 		Err("Account management is deprecated. Please see #9997 for alternatives:\nhttps://github.com/paritytech/parity-ethereum/issues/9997".into())
 }
 

--- a/parity/account_utils.rs
+++ b/parity/account_utils.rs
@@ -30,12 +30,12 @@ mod accounts {
 	pub struct AccountProvider;
 
 	impl ::ethcore::miner::LocalAccounts for AccountProvider {
-		fn is_local(&self, address: &Address) -> bool {
+		fn is_local(&self, _address: &Address) -> bool {
 			false
 		}
 	}
 
-	pub fn prepare_account_provider(_spec: &SpecType, _dirs: &Directories, _data_dir: &str, cfg: AccountsConfig, _passwords: &[Password]) -> Result<AccountProvider, String> {
+	pub fn prepare_account_provider(_spec: &SpecType, _dirs: &Directories, _data_dir: &str, _cfg: AccountsConfig, _passwords: &[Password]) -> Result<AccountProvider, String> {
 		warn!("Note: Your instance of Parity Ethereum is running without account support. Some CLI options are ignored.");
 		Ok(AccountProvider)
 	}

--- a/parity/upgrade.rs
+++ b/parity/upgrade.rs
@@ -139,6 +139,7 @@ fn file_exists(path: &Path) -> bool {
 	}
 }
 
+#[cfg(any(test, feature = "accounts"))]
 pub fn upgrade_key_location(from: &PathBuf, to: &PathBuf) {
 	match fs::create_dir_all(&to).and_then(|()| fs::read_dir(from)) {
 		Ok(entries) => {

--- a/rpc/src/v1/helpers/dispatch/mod.rs
+++ b/rpc/src/v1/helpers/dispatch/mod.rs
@@ -201,6 +201,7 @@ pub enum SignWith {
 }
 
 impl SignWith {
+	#[cfg(any(test, feature = "accounts"))]
 	fn is_password(&self) -> bool {
 		if let SignWith::Password(_) = *self {
 			true

--- a/rpc/src/v1/helpers/errors.rs
+++ b/rpc/src/v1/helpers/errors.rs
@@ -43,7 +43,9 @@ mod codes {
 	pub const EXECUTION_ERROR: i64 = -32015;
 	pub const EXCEPTION_ERROR: i64 = -32016;
 	pub const DATABASE_ERROR: i64 = -32017;
+	#[cfg(any(test, feature = "accounts"))]
 	pub const ACCOUNT_LOCKED: i64 = -32020;
+	#[cfg(any(test, feature = "accounts"))]
 	pub const PASSWORD_INVALID: i64 = -32021;
 	pub const ACCOUNT_ERROR: i64 = -32023;
 	pub const PRIVATE_ERROR: i64 = -32024;
@@ -336,6 +338,7 @@ pub fn fetch<T: fmt::Debug>(error: T) -> Error {
 	}
 }
 
+#[cfg(any(test, feature = "accounts"))]
 pub fn invalid_call_data<T: fmt::Display>(error: T) -> Error {
 	Error {
 		code: ErrorCode::ServerError(codes::ENCODING_ERROR),

--- a/rpc/src/v1/helpers/mod.rs
+++ b/rpc/src/v1/helpers/mod.rs
@@ -20,6 +20,7 @@ pub mod errors;
 pub mod block_import;
 pub mod deprecated;
 pub mod dispatch;
+#[cfg(any(test, feature = "accounts"))]
 pub mod eip191;
 #[cfg(any(test, feature = "accounts"))]
 pub mod engine_signer;
@@ -28,6 +29,7 @@ pub mod fake_sign;
 pub mod ipfs;
 pub mod light_fetch;
 pub mod nonce;
+#[cfg(any(test, feature = "accounts"))]
 pub mod secretstore;
 
 mod network_settings;

--- a/rpc/src/v1/types/derivation.rs
+++ b/rpc/src/v1/types/derivation.rs
@@ -70,6 +70,7 @@ impl From<DeriveHash> for Derive {
 }
 
 /// Error converting request data
+#[cfg(any(test, feature = "accounts"))]
 #[derive(Debug)]
 pub enum ConvertError {
 	IndexOverlfow(u64),
@@ -77,6 +78,7 @@ pub enum ConvertError {
 
 impl Derive {
 	/// Convert to account provider struct dealing with possible overflows
+	#[cfg(any(test, feature = "accounts"))]
 	pub fn to_derivation(self) -> Result<ethstore::Derivation, ConvertError> {
 		Ok(match self {
 			Derive::Hierarchical(drv) => {


### PR DESCRIPTION
When compiling without no-default features the following warnings occurs:
```bash
warning: constant item is never used: `ACCOUNT_LOCKED`
  --> rpc/src/v1/helpers/errors.rs:46:2
   |
46 |     pub const ACCOUNT_LOCKED: i64 = -32020;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(dead_code)] on by default

warning: constant item is never used: `PASSWORD_INVALID`
  --> rpc/src/v1/helpers/errors.rs:47:2
   |
47 |     pub const PASSWORD_INVALID: i64 = -32021;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function is never used: `invalid_call_data`
   --> rpc/src/v1/helpers/errors.rs:339:1
    |
339 | pub fn invalid_call_data<T: fmt::Display>(error: T) -> Error {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: method is never used: `is_password`
   --> rpc/src/v1/helpers/dispatch/mod.rs:204:2
    |
204 |     fn is_password(&self) -> bool {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function is never used: `hash_message`
  --> rpc/src/v1/helpers/eip191.rs:29:1
   |
29 | pub fn hash_message(version: EIP191Version, message: Value) -> Result<H256, Error> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function is never used: `map_serde_err`
  --> rpc/src/v1/helpers/eip191.rs:57:1
   |
57 | fn map_serde_err<T: Display>(struct_name: &'static str) -> impl Fn(T) -> Error {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: constant item is never used: `INIT_VEC_LEN`
  --> rpc/src/v1/helpers/secretstore.rs:28:1
   |
28 | const INIT_VEC_LEN: usize = 16;
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function is never used: `generate_document_key`
  --> rpc/src/v1/helpers/secretstore.rs:31:1
   |
31 | pub fn generate_document_key(account_public: Public, server_key_public: Public) -> Result<EncryptedDocumentKey, Error> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function is never used: `encrypt_document`
  --> rpc/src/v1/helpers/secretstore.rs:50:1
   |
50 | pub fn encrypt_document(key: Bytes, document: Bytes) -> Result<Bytes, Error> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function is never used: `decrypt_document`
  --> rpc/src/v1/helpers/secretstore.rs:68:1
   |
68 | pub fn decrypt_document(key: Bytes, mut encrypted_document: Bytes) -> Result<Bytes, Error> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function is never used: `decrypt_document_with_shadow`
  --> rpc/src/v1/helpers/secretstore.rs:87:1
   |
87 | pub fn decrypt_document_with_shadow(decrypted_secret: Public, common_point: Public, shadows: Vec<Secret>, encrypted_document: Bytes) -> Result<Bytes, Error> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function is never used: `ordered_servers_keccak`
  --> rpc/src/v1/helpers/secretstore.rs:93:1
   |
93 | pub fn ordered_servers_keccak(servers_set: BTreeSet<H512>) -> H256 {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function is never used: `into_document_key`
   --> rpc/src/v1/helpers/secretstore.rs:105:1
    |
105 | fn into_document_key(key: Bytes) -> Result<Bytes, Error> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function is never used: `initialization_vector`
   --> rpc/src/v1/helpers/secretstore.rs:115:1
    |
115 | fn initialization_vector() -> [u8; INIT_VEC_LEN] {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function is never used: `decrypt_with_shadow_coefficients`
   --> rpc/src/v1/helpers/secretstore.rs:122:1
    |
122 | fn decrypt_with_shadow_coefficients(mut decrypted_shadow: Public, mut common_shadow_point: Public, shadow_coefficients: Vec<Secret>) -> Result<Public, Error> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function is never used: `encrypt_secret`
   --> rpc/src/v1/helpers/secretstore.rs:136:1
    |
136 | fn encrypt_secret(secret: &Public, joint_public: &Public) -> Result<(Public, Public), Error> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: field is never used: `hash`
  --> rpc/src/v1/types/derivation.rs:36:2
   |
36 |     hash: H256,
   |     ^^^^^^^^^^

warning: field is never used: `d_type`
  --> rpc/src/v1/types/derivation.rs:38:2
   |
38 |     d_type: DerivationType,
   |     ^^^^^^^^^^^^^^^^^^^^^^

warning: field is never used: `index`
  --> rpc/src/v1/types/derivation.rs:44:2
   |
44 |     index: u64,
   |     ^^^^^^^^^^

warning: field is never used: `d_type`
  --> rpc/src/v1/types/derivation.rs:46:2
   |
46 |     d_type: DerivationType,
   |     ^^^^^^^^^^^^^^^^^^^^^^

warning: enum is never used: `ConvertError`
  --> rpc/src/v1/types/derivation.rs:74:1
   |
74 | pub enum ConvertError {
   | ^^^^^^^^^^^^^^^^^^^^^

warning: method is never used: `to_derivation`
  --> rpc/src/v1/types/derivation.rs:80:2
   |
80 |     pub fn to_derivation(self) -> Result<ethstore::Derivation, ConvertError> {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    Checking parity-rpc-client v1.4.0 (/home/niklasad1/Github/parity-ethereum/cli-signer/rpc-client)
    Checking cli-signer v1.4.0 (/home/niklasad1/Github/parity-ethereum/cli-signer)
    Checking parity-ethereum v2.4.0 (/home/niklasad1/Github/parity-ethereum)
warning: unused variable: `cmd`
  --> parity/account.rs:61:16
   |
61 | pub fn execute(cmd: AccountCmd) -> Result<String, String> {
   |                ^^^ help: consider prefixing with an underscore: `_cmd`
   |
   = note: #[warn(unused_variables)] on by default

warning: unused variable: `cfg`
  --> parity/account_utils.rs:38:90
   |
38 |     pub fn prepare_account_provider(_spec: &SpecType, _dirs: &Directories, _data_dir: &str, cfg: AccountsConfig, _passwords: &[Password]) -> Result<AccountProvider, String> {
   |                                                                                             ^^^ help: consider prefixing with an underscore: `_cfg`

warning: unused variable: `address`
  --> parity/account_utils.rs:33:22
   |
33 |         fn is_local(&self, address: &Address) -> bool {
   |                            ^^^^^^^ help: consider prefixing with an underscore: `_address`

warning: function is never used: `upgrade_key_location`
   --> parity/upgrade.rs:142:1
    |
142 | pub fn upgrade_key_location(from: &PathBuf, to: &PathBuf) {
```

This PR fixes most of them
