### PR TITLE
chore(bump parity-daemonize): require rust >= 1.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "parity-daemonize"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2515,7 +2515,7 @@ dependencies = [
  "number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic_hook 0.1.0",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-daemonize 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-daemonize 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-hash-fetch 1.12.0",
  "parity-ipfs-api 1.12.0",
  "parity-local-store 0.1.0",
@@ -4641,7 +4641,7 @@ dependencies = [
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa5168b4cf41f3835e4bc6ffb32f51bc9365dc50cb351904595b3931d917fd0c"
 "checksum parity-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b9db194dfbcfe3b398d63d765437a5c7232d59906e203055f0e993f6458ff1"
-"checksum parity-daemonize 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b337f62998c855fe263e504fcf883c6a0f94370ba0afc731922e8bc23419cfb"
+"checksum parity-daemonize 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "69b1910b2793ff52713fca0a4ee92544ebec59ccd218ea74560be6f947b4ca77"
 "checksum parity-path 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5962540f99d3895d9addf535f37ab1397886bc2c68e59efd040ef458e5f8c3f7"
 "checksum parity-rocksdb 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cd55d2d6d6000ec99f021cf52c9acc7d2a402e14f95ced4c5de230696fabe00b"
 "checksum parity-rocksdb-sys 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5bbb241262c768522f6460f0e2672dee185c8504d4d0a5a5bab45c1147981c4f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ ethstore = { path = "accounts/ethstore" }
 node-filter = { path = "ethcore/node-filter" }
 rlp = { version = "0.3.0", features = ["ethereum"] }
 cli-signer= { path = "cli-signer" }
-parity-daemonize = "0.2"
+parity-daemonize = "0.3"
 parity-hash-fetch = { path = "updater/hash-fetch" }
 parity-ipfs-api = { path = "ipfs" }
 parity-local-store = { path = "miner/local-store" }

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -39,13 +39,15 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{process, env};
+
 use ansi_term::Colour;
 use ctrlc::CtrlC;
 use dir::default_hypervisor_path;
 use fdlimit::raise_fd_limit;
-use parity_ethereum::{start, ExecutionAction};
-use parking_lot::{Condvar, Mutex};
 use ethcore_logger::setup_log;
+use parity_ethereum::{start, ExecutionAction};
+use parity_daemonize::AsHandle;
+use parking_lot::{Condvar, Mutex};
 
 const PLEASE_RESTART_EXIT_CODE: i32 = 69;
 const PARITY_EXECUTABLE_NAME: &str = "parity";
@@ -195,7 +197,9 @@ fn main_direct(force_can_restart: bool) -> i32 {
 		conf.args.arg_chain = spec_override;
 	}
 
-	let handle = if let Some(ref pid) = conf.args.arg_daemon_pid_file {
+	// FIXME: `pid_file` shouldn't need to cloned here
+	// see: `https://github.com/paritytech/parity-daemonize/pull/13` for more info
+	let handle = if let Some(pid) = conf.args.arg_daemon_pid_file.clone() {
 		info!("{}", Colour::Blue.paint("starting in daemon mode").to_string());
 		let _ = std::io::stdout().flush();
 


### PR DESCRIPTION
Bump `parity-daemonize` to make `parity` compile with rustc 1.31.0 or later.

Added a comment about a `clone()` that was necessary to make it compile however it shouldn't be needed AFAIK!