### PR TITLE
Add fields to `memzero`'s Cargo.toml

### DIFF
--- a/util/memzero/Cargo.toml
+++ b/util/memzero/Cargo.toml
@@ -2,7 +2,7 @@
 name = "memzero"
 version = "0.1.0"
 description = "A wrapper for zero-ing out memory when dropped"
-license = "MIT"
+license = "GPL-3.0"
 homepage = "https://parity.io"
 repository = "https://github.com/paritytech/parity-ethereum"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/util/memzero/Cargo.toml
+++ b/util/memzero/Cargo.toml
@@ -5,5 +5,6 @@ description = "A wrapper for zero-ing out memory when dropped"
 license = "GPL-3.0"
 homepage = "https://parity.io"
 repository = "https://github.com/paritytech/parity-ethereum"
+docs = "https://docs.rs/crate/memzero"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"

--- a/util/memzero/Cargo.toml
+++ b/util/memzero/Cargo.toml
@@ -1,4 +1,9 @@
 [package]
 name = "memzero"
 version = "0.1.0"
+description = "A wrapper for zero-ing out memory when dropped"
+license = "MIT"
+homepage = "https://parity.io"
+repository = "https://github.com/paritytech/parity-ethereum"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"


### PR DESCRIPTION
Adds some fields that are required before publishing a crate to crates.io.