### PR TITLE
Refactor ethcore::client::TransactResult to use it inside std::result::Result

### DIFF
--- a/ethcore/src/client/evm_test_client.rs
+++ b/ethcore/src/client/evm_test_client.rs
@@ -309,32 +309,38 @@ impl<'a> EvmTestClient<'a> {
 	}
 }
 
+/// To be returned inside a std::result::Result::Ok after a successful
+/// transaction completed.
+#[allow(dead_code)]
 pub struct TransactSuccess<T, V> {
 	/// State root
-	state_root: H256,
+	pub state_root: H256,
 	/// Amount of gas left
-	gas_left: U256,
+	pub gas_left: U256,
 	/// Output
-	output: Vec<u8>,
+	pub output: Vec<u8>,
 	/// Traces
-	trace: Vec<T>,
+	pub trace: Vec<T>,
 	/// VM Traces
-	vm_trace: Option<V>,
+	pub vm_trace: Option<V>,
 	/// Created contract address (if any)
-	contract_address: Option<H160>,
+	pub contract_address: Option<H160>,
 	/// Generated logs
-	logs: Vec<log_entry::LogEntry>,
+	pub logs: Vec<log_entry::LogEntry>,
 	/// outcome
-	outcome: receipt::TransactionOutcome,
+	pub outcome: receipt::TransactionOutcome,
 	/// end state if needed
-	end_state: Option<pod_state::PodState>,
+	pub end_state: Option<pod_state::PodState>,
 }
 
+/// To be returned inside a std::result::Result::Err after a failed
+/// transaction.
+#[allow(dead_code)]
 pub struct TransactErr {
 	/// State root
-	state_root: H256,
+	pub state_root: H256,
 	/// Execution error
-	error: ::error::Error,
+	pub error: ::error::Error,
 	/// end state if needed
-	end_state: Option<pod_state::PodState>,
+	pub end_state: Option<pod_state::PodState>,
 }

--- a/ethcore/src/client/evm_test_client.rs
+++ b/ethcore/src/client/evm_test_client.rs
@@ -241,16 +241,17 @@ impl<'a> EvmTestClient<'a> {
 		transaction: transaction::SignedTransaction,
 		tracer: T,
 		vm_tracer: V,
-	) -> TransactResult<T::Output, V::Output> {
+	) -> std::result::Result<TransactSuccess<T::Output, V::Output>, TransactErr> {
 		let initial_gas = transaction.gas;
 		// Verify transaction
 		let is_ok = transaction.verify_basic(true, None, false);
 		if let Err(error) = is_ok {
-			return TransactResult::Err {
-				state_root: *self.state.root(),
-				error: error.into(),
-				end_state: (self.dump_state)(&self.state),
-			};
+			return Err(
+				TransactErr{
+					state_root: *self.state.root(),
+					error: error.into(),
+					end_state: (self.dump_state)(&self.state),
+				});
 		}
 
 		// Apply transaction
@@ -283,7 +284,7 @@ impl<'a> EvmTestClient<'a> {
 
 		match result {
 			Ok(result) => {
-				TransactResult::Ok {
+				Ok(TransactSuccess {
 					state_root,
 					gas_left: initial_gas - result.receipt.gas_used,
 					outcome: result.receipt.outcome,
@@ -298,47 +299,42 @@ impl<'a> EvmTestClient<'a> {
 					},
 					end_state,
 				}
-			},
-			Err(error) => TransactResult::Err {
+			)},
+			Err(error) => Err(TransactErr {
 				state_root,
 				error,
 				end_state,
-			},
+			}),
 		}
 	}
 }
 
-/// A result of applying transaction to the state.
-#[derive(Debug)]
-pub enum TransactResult<T, V> {
-	/// Successful execution
-	Ok {
-		/// State root
-		state_root: H256,
-		/// Amount of gas left
-		gas_left: U256,
-		/// Output
-		output: Vec<u8>,
-		/// Traces
-		trace: Vec<T>,
-		/// VM Traces
-		vm_trace: Option<V>,
-		/// Created contract address (if any)
-		contract_address: Option<H160>,
-		/// Generated logs
-		logs: Vec<log_entry::LogEntry>,
-		/// outcome
-		outcome: receipt::TransactionOutcome,
-		/// end state if needed
-		end_state: Option<pod_state::PodState>,
-	},
-	/// Transaction failed to run
-	Err {
-		/// State root
-		state_root: H256,
-		/// Execution error
-		error: ::error::Error,
-		/// end state if needed
-		end_state: Option<pod_state::PodState>,
-	},
+pub struct TransactSuccess<T, V> {
+	/// State root
+	state_root: H256,
+	/// Amount of gas left
+	gas_left: U256,
+	/// Output
+	output: Vec<u8>,
+	/// Traces
+	trace: Vec<T>,
+	/// VM Traces
+	vm_trace: Option<V>,
+	/// Created contract address (if any)
+	contract_address: Option<H160>,
+	/// Generated logs
+	logs: Vec<log_entry::LogEntry>,
+	/// outcome
+	outcome: receipt::TransactionOutcome,
+	/// end state if needed
+	end_state: Option<pod_state::PodState>,
+}
+
+pub struct TransactErr {
+	/// State root
+	state_root: H256,
+	/// Execution error
+	error: ::error::Error,
+	/// end state if needed
+	end_state: Option<pod_state::PodState>,
 }

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -30,7 +30,7 @@ mod trace;
 pub use self::client::*;
 pub use self::config::{Mode, ClientConfig, DatabaseCompactionProfile, BlockChainConfig, VMType};
 #[cfg(any(test, feature = "test-helpers"))]
-pub use self::evm_test_client::{EvmTestClient, EvmTestError, TransactResult};
+pub use self::evm_test_client::{EvmTestClient, EvmTestError, TransactErr, TransactSuccess};
 pub use self::io_message::ClientIoMessage;
 #[cfg(any(test, feature = "test-helpers"))]
 pub use self::test_client::{TestBlockChainClient, EachBlockWith};

--- a/ethcore/src/json_tests/state.rs
+++ b/ethcore/src/json_tests/state.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 use super::test_common::*;
 use pod_state::PodState;
 use trace;
-use client::{EvmTestClient, EvmTestError, TransactResult};
+use client::{EvmTestClient, EvmTestError, TransactErr, TransactSuccess};
 use ethjson;
 use types::transaction::SignedTransaction;
 use vm::EnvInfo;
@@ -90,18 +90,18 @@ pub fn json_chain_test<H: FnMut(&str, HookType)>(json_data: &[u8], start_stop_ho
 							flushln!("{} fail", info);
 							failed.push(name.clone());
 						},
-						Ok(TransactResult::Ok { state_root, .. }) if state_root != post_root => {
+						Ok(Ok(TransactSuccess { state_root, .. })) if state_root != post_root => {
 							println!("{} !!! State mismatch (got: {}, expect: {}", info, state_root, post_root);
 							flushln!("{} fail", info);
 							failed.push(name.clone());
 						},
-						Ok(TransactResult::Err { state_root, ref error, .. }) if state_root != post_root => {
+						Ok(Err(TransactErr { state_root, ref error, .. })) if state_root != post_root => {
 							println!("{} !!! State mismatch (got: {}, expect: {}", info, state_root, post_root);
 							println!("{} !!! Execution error: {:?}", info, error);
 							flushln!("{} fail", info);
 							failed.push(name.clone());
 						},
-						Ok(TransactResult::Err { error, .. }) => {
+						Ok(Err(TransactErr { error, .. })) => {
 							flushln!("{} ok ({:?})", info, error);
 						},
 						Ok(_) => {

--- a/evmbin/src/info.rs
+++ b/evmbin/src/info.rs
@@ -18,7 +18,7 @@
 
 use std::time::{Instant, Duration};
 use ethereum_types::{H256, U256};
-use ethcore::client::{self, EvmTestClient, EvmTestError, TransactResult};
+use ethcore::client::{self, EvmTestClient, EvmTestError, TransactErr, TransactSuccess};
 use ethcore::{state, state_db, trace, spec, pod_state, TrieSpec};
 use ethjson;
 use types::transaction;
@@ -130,7 +130,7 @@ pub fn run_transaction<T: Informant>(
 	let result = run(&spec, trie_spec, transaction.gas, pre_state, |mut client| {
 		let result = client.transact(env_info, transaction, trace::NoopTracer, informant);
 		match result {
-			TransactResult::Ok { state_root, gas_left, output, vm_trace, end_state, .. } => {
+			Ok(TransactSuccess { state_root, gas_left, output, vm_trace, end_state, .. }) => {
 				if state_root != post_root {
 					(Err(EvmTestError::PostCondition(format!(
 						"State root mismatch (got: {:#x}, expected: {:#x})",
@@ -141,7 +141,7 @@ pub fn run_transaction<T: Informant>(
 					(Ok(output), state_root, end_state, Some(gas_left), vm_trace)
 				}
 			},
-			TransactResult::Err { state_root, error, end_state } => {
+			Err(TransactErr { state_root, error, end_state }) => {
 				(Err(EvmTestError::PostCondition(format!(
 					"Unexpected execution error: {:?}", error
 				))), state_root, end_state, None, None)


### PR DESCRIPTION
`ethcore::client::TransactResult` looks similar to `std::result::Result` but its functionality is actually not comparable.

This PR separates the `Ok` and the `Err` variants of `ethcore::client::TransactResult` into `struct TransactSuccess` and `struct TransactErr` to be used inside the respective variants of `std::result::Result`.

Fixes: #8755