### PR TITLE
Fix to_pod storage trie value decoding

### DIFF
--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -1017,7 +1017,7 @@ impl<B: Backend> State<B> {
 		let trie = self.factories.trie.readonly(accountdb.as_hashdb(), &root)?;
 		for o_kv in trie.iter()? {
 			if let Ok((key, val)) = o_kv {
-				pod_storage.insert(key[..].into(), U256::from(&val[..]).into());
+				pod_storage.insert(key[..].into(), rlp::decode::<U256>(&val[..]).expect("Decoded from trie which was encoded from the same type; qed").into());
 			}
 		}
 


### PR DESCRIPTION
Our current decoding method is not correct, which will make things panic.