### PR TITLE
tx pool: always accept local transactions

### DIFF
--- a/miner/src/pool/scoring.rs
+++ b/miner/src/pool/scoring.rs
@@ -123,16 +123,17 @@ impl<P> txpool::Scoring<P> for NonceAndGasPrice where P: ScoredTransaction + txp
 	}
 
 	fn should_replace(&self, old: &P, new: &P) -> scoring::Choice {
-		if old.priority().is_local() && new.priority().is_local() {
-			// accept local transactions over the limit
-			scoring::Choice::InsertNew
-		} else if old.sender() == new.sender() {
+		let both_local = old.priority().is_local() && new.priority().is_local();
+		if old.sender() == new.sender() {
 			// prefer earliest transaction
 			match new.nonce().cmp(&old.nonce()) {
+				cmp::Ordering::Equal => self.choose(old, new),
+				_ if both_local => scoring::Choice::InsertNew,
 				cmp::Ordering::Less => scoring::Choice::ReplaceOld,
 				cmp::Ordering::Greater => scoring::Choice::RejectNew,
-				cmp::Ordering::Equal => self.choose(old, new),
 			}
+		} else if both_local {
+			scoring::Choice::InsertNew
 		} else {
 			let old_score = (old.priority(), old.gas_price());
 			let new_score = (new.priority(), new.gas_price());
@@ -141,7 +142,7 @@ impl<P> txpool::Scoring<P> for NonceAndGasPrice where P: ScoredTransaction + txp
 			} else {
 				scoring::Choice::RejectNew
 			}
-	 	}
+		}
 	}
 
 	fn should_ignore_sender_limit(&self, new: &P) -> bool {
@@ -166,42 +167,52 @@ mod tests {
 	}
 
 	#[test]
-	fn should_always_accept_local_transactions() {
+	fn should_always_accept_local_transactions_unless_same_sender_and_nonce() {
 		let scoring = NonceAndGasPrice(PrioritizationStrategy::GasPriceOnly);
 
 		// same sender txs
 		let keypair = Random.generate().unwrap();
 
-		let tx1 = local_tx_verified(Tx {
+		let same_sender_tx1 = local_tx_verified(Tx {
 			nonce: 1,
 			gas_price: 1,
 			..Default::default()
 		}, &keypair);
 
-		let tx2 = local_tx_verified(Tx {
+		let same_sender_tx2 = local_tx_verified(Tx {
 			nonce: 2,
 			gas_price: 100,
 			..Default::default()
 		}, &keypair);
 
+		let same_sender_tx3 = local_tx_verified(Tx {
+			nonce: 2,
+			gas_price: 200,
+			..Default::default()
+		}, &keypair);
+
 		// different sender txs
-		let tx3 = local_tx_verified(Tx {
+		let different_sender_tx1 = local_tx_verified(Tx {
 			nonce: 2,
 			gas_price: 1,
 			..Default::default()
 		}, &Random.generate().unwrap());
 
-		let tx4 = local_tx_verified(Tx {
+		let different_sender_tx2 = local_tx_verified(Tx {
 			nonce: 1,
 			gas_price: 10,
 			..Default::default()
 		}, &Random.generate().unwrap());
 
-		assert_eq!(scoring.should_replace(&tx1, &tx2), InsertNew);
-		assert_eq!(scoring.should_replace(&tx2, &tx1), InsertNew);
+		assert_eq!(scoring.should_replace(&same_sender_tx1, &same_sender_tx2), InsertNew);
+		assert_eq!(scoring.should_replace(&same_sender_tx2, &same_sender_tx1), InsertNew);
 
-		assert_eq!(scoring.should_replace(&tx3, &tx4), InsertNew);
-		assert_eq!(scoring.should_replace(&tx4, &tx3), InsertNew);
+		assert_eq!(scoring.should_replace(&different_sender_tx1, &different_sender_tx2), InsertNew);
+		assert_eq!(scoring.should_replace(&different_sender_tx2, &different_sender_tx1), InsertNew);
+
+		// txs with same sender and nonce
+		assert_eq!(scoring.should_replace(&same_sender_tx2, &same_sender_tx3), ReplaceOld);
+		assert_eq!(scoring.should_replace(&same_sender_tx3, &same_sender_tx2), RejectNew);
 	}
 
 	#[test]


### PR DESCRIPTION
...unless sender and nonce are the same, in which case the the normal gas price comparison applies.

rel: #10344 