### PR TITLE
snap: add the removable-media plug

### DIFF
--- a/scripts/snap/snapcraft.template.yaml
+++ b/scripts/snap/snapcraft.template.yaml
@@ -14,20 +14,20 @@ description:        |
 apps:
   parity:
     command:        parity
-    plugs:          [home, network, network-bind, mount-observe, x11, unity7, desktop, desktop-legacy, wayland]
+    plugs:          [home, network, network-bind, mount-observe, removable-media, x11, unity7, desktop, desktop-legacy, wayland]
     desktop:        ./usr/share/applications/parity.desktop
   parity-evm:
     command:        parity-evm
-    plugs:          [home, network, network-bind]
+    plugs:          [home, network, network-bind, removable-media]
   ethkey:
     command:        ethkey
-    plugs:          [home]
+    plugs:          [home, removable-media]
   ethstore:
     command:        ethstore
-    plugs:          [home]
+    plugs:          [home, removable-media]
   whisper:
     command:        whisper
-    plugs:          [home, network-bind]
+    plugs:          [home, network-bind, removable-media]
 
 icon:               ./scripts/snap/icon.png
 


### PR DESCRIPTION
This interface allows the snap to access the directories in /media. This is needed when the storage is in a separate disk, not part of home.