### PR TITLE
Remove duplicate test cases

### DIFF
--- a/ethcore/src/state/account.rs
+++ b/ethcore/src/state/account.rs
@@ -741,11 +741,4 @@ mod tests {
 		assert_eq!(a.code_hash(), KECCAK_EMPTY);
 		assert_eq!(a.storage_root().unwrap(), KECCAK_NULL_RLP);
 	}
-
-	#[test]
-	fn create_account() {
-		let a = Account::new(69u8.into(), 0u8.into(), HashMap::new(), Bytes::new());
-		assert_eq!(a.rlp().to_hex(), "f8448045a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
-	}
-
 }


### PR DESCRIPTION
Case [create_account()](https://github.com/paritytech/parity-ethereum/blob/master/ethcore/src/state/account.rs#L746) is same as [new_account()](https://github.com/paritytech/parity-ethereum/blob/master/ethcore/src/state/account.rs#L736
), so just remove it.