### PR TITLE
Silence Error::cause deprecations for upcoming Rust 1.33

### DIFF
--- a/ethcore/light/src/on_demand/mod.rs
+++ b/ethcore/light/src/on_demand/mod.rs
@@ -70,6 +70,10 @@ pub const DEFAULT_NUM_CONSECUTIVE_FAILED_REQUESTS: usize = 1;
 
 /// OnDemand related errors
 pub mod error {
+	// Silence: `use of deprecated item 'std::error::Error::cause': replaced by Error::source, which can support downcasting`
+	// https://github.com/paritytech/parity-ethereum/issues/10302
+	#![allow(deprecated)]
+
 	use futures::sync::oneshot::Canceled;
 
 	error_chain! {

--- a/ethcore/private-tx/src/error.rs
+++ b/ethcore/private-tx/src/error.rs
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
+// Silence: `use of deprecated item 'std::error::Error::cause': replaced by Error::source, which can support downcasting`
+// https://github.com/paritytech/parity-ethereum/issues/10302
+#![allow(deprecated)]
+
 use ethereum_types::Address;
 use rlp::DecoderError;
 use ethtrie::TrieError;

--- a/ethcore/service/src/error.rs
+++ b/ethcore/service/src/error.rs
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
+// Silence: `use of deprecated item 'std::error::Error::cause': replaced by Error::source, which can support downcasting`
+// https://github.com/paritytech/parity-ethereum/issues/10302
+#![allow(deprecated)]
+
 use ethcore;
 use io;
 use ethcore_private_tx;

--- a/ethcore/src/error.rs
+++ b/ethcore/src/error.rs
@@ -16,6 +16,10 @@
 
 //! General error types for use in ethcore.
 
+// Silence: `use of deprecated item 'std::error::Error::cause': replaced by Error::source, which can support downcasting`
+// https://github.com/paritytech/parity-ethereum/issues/10302
+#![allow(deprecated)]
+
 use std::{fmt, error};
 use std::time::SystemTime;
 

--- a/util/network/src/error.rs
+++ b/util/network/src/error.rs
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
+// Silence: `use of deprecated item 'std::error::Error::cause': replaced by Error::source, which can support downcasting`
+// https://github.com/paritytech/parity-ethereum/issues/10302
+#![allow(deprecated)]
+
 use std::{io, net, fmt};
 use libc::{ENFILE, EMFILE};
 use io::IoError;


### PR DESCRIPTION
In anticipation of upcoming Rust 1.33, silence these deprecations until we replace `error-chain` https://github.com/paritytech/parity-ethereum/issues/10302