### PR TITLE
simplify ethcore machine by removing redundant traits

### DIFF
--- a/ethcore/src/engines/instant_seal.rs
+++ b/ethcore/src/engines/instant_seal.rs
@@ -15,7 +15,8 @@
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 use engines::{Engine, Seal};
-use parity_machine::{Machine, Transactions, TotalScoredHeader};
+use parity_machine::{Machine, Transactions};
+use types::header::ExtendedHeader;
 
 /// `InstantSeal` params.
 #[derive(Default, Debug, PartialEq)]
@@ -48,11 +49,7 @@ impl<M> InstantSeal<M> {
 	}
 }
 
-impl<M: Machine> Engine<M> for InstantSeal<M>
-  where M::LiveBlock: Transactions,
-        M::ExtendedHeader: TotalScoredHeader,
-        <M::ExtendedHeader as TotalScoredHeader>::Value: Ord
-{
+impl<M: Machine> Engine<M> for InstantSeal<M> where M::LiveBlock: Transactions {
 	fn name(&self) -> &str {
 		"InstantSeal"
 	}
@@ -84,7 +81,7 @@ impl<M: Machine> Engine<M> for InstantSeal<M>
 		header_timestamp >= parent_timestamp
 	}
 
-	fn fork_choice(&self, new: &M::ExtendedHeader, current: &M::ExtendedHeader) -> super::ForkChoice {
+	fn fork_choice(&self, new: &ExtendedHeader, current: &ExtendedHeader) -> super::ForkChoice {
 		super::total_difficulty_fork_choice(new, current)
 	}
 }

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -44,13 +44,13 @@ use builtin::Builtin;
 use vm::{EnvInfo, Schedule, CreateContractAddress, CallType, ActionValue};
 use error::Error;
 use types::BlockNumber;
-use types::header::Header;
+use types::header::{Header, ExtendedHeader};
 use snapshot::SnapshotComponents;
 use spec::CommonParams;
 use types::transaction::{self, UnverifiedTransaction, SignedTransaction};
 
 use ethkey::{Signature};
-use parity_machine::{Machine, LocalizedMachine as Localized, TotalScoredHeader};
+use parity_machine::{Machine, LocalizedMachine as Localized};
 use ethereum_types::{H256, U256, Address};
 use unexpected::{Mismatch, OutOfBounds};
 use bytes::Bytes;
@@ -255,7 +255,7 @@ pub trait Engine<M: Machine>: Sync + Send {
 		&self,
 		_block: &mut M::LiveBlock,
 		_epoch_begin: bool,
-		_ancestry: &mut Iterator<Item=M::ExtendedHeader>,
+		_ancestry: &mut Iterator<Item = ExtendedHeader>,
 	) -> Result<(), M::Error> {
 		Ok(())
 	}
@@ -421,16 +421,16 @@ pub trait Engine<M: Machine>: Sync + Send {
 
 	/// Gather all ancestry actions. Called at the last stage when a block is committed. The Engine must guarantee that
 	/// the ancestry exists.
-	fn ancestry_actions(&self, _header: &M::Header, _ancestry: &mut Iterator<Item=M::ExtendedHeader>) -> Vec<AncestryAction> {
+	fn ancestry_actions(&self, _header: &M::Header, _ancestry: &mut Iterator<Item = ExtendedHeader>) -> Vec<AncestryAction> {
 		Vec::new()
 	}
 
 	/// Check whether the given new block is the best block, after finalization check.
-	fn fork_choice(&self, new: &M::ExtendedHeader, best: &M::ExtendedHeader) -> ForkChoice;
+	fn fork_choice(&self, new: &ExtendedHeader, best: &ExtendedHeader) -> ForkChoice;
 }
 
 /// Check whether a given block is the best block based on the default total difficulty rule.
-pub fn total_difficulty_fork_choice<T: TotalScoredHeader>(new: &T, best: &T) -> ForkChoice where <T as TotalScoredHeader>::Value: Ord {
+pub fn total_difficulty_fork_choice(new: &ExtendedHeader, best: &ExtendedHeader) -> ForkChoice {
 	if new.total_score() > best.total_score() {
 		ForkChoice::New
 	} else {

--- a/ethcore/src/engines/null_engine.rs
+++ b/ethcore/src/engines/null_engine.rs
@@ -18,8 +18,9 @@ use engines::Engine;
 use engines::block_reward::{self, RewardKind};
 use ethereum_types::U256;
 use machine::WithRewards;
-use parity_machine::{Machine, Header, LiveBlock, TotalScoredHeader};
+use parity_machine::{Machine, Header, LiveBlock};
 use types::BlockNumber;
+use types::header::ExtendedHeader;
 
 /// Params for a null engine.
 #[derive(Clone, Default)]
@@ -58,10 +59,7 @@ impl<M: Default> Default for NullEngine<M> {
 	}
 }
 
-impl<M: Machine + WithRewards> Engine<M> for NullEngine<M>
-  where M::ExtendedHeader: TotalScoredHeader,
-        <M::ExtendedHeader as TotalScoredHeader>::Value: Ord
-{
+impl<M: Machine + WithRewards> Engine<M> for NullEngine<M> {
 	fn name(&self) -> &str {
 		"NullEngine"
 	}
@@ -105,7 +103,7 @@ impl<M: Machine + WithRewards> Engine<M> for NullEngine<M>
 		Some(Box::new(::snapshot::PowSnapshot::new(10000, 10000)))
 	}
 
-	fn fork_choice(&self, new: &M::ExtendedHeader, current: &M::ExtendedHeader) -> super::ForkChoice {
+	fn fork_choice(&self, new: &ExtendedHeader, current: &ExtendedHeader) -> super::ForkChoice {
 		super::total_difficulty_fork_choice(new, current)
 	}
 }

--- a/ethcore/src/machine.rs
+++ b/ethcore/src/machine.rs
@@ -24,7 +24,7 @@ use ethereum_types::{U256, H256, Address};
 use rlp::Rlp;
 use types::transaction::{self, SYSTEM_ADDRESS, UNSIGNED_SENDER, UnverifiedTransaction, SignedTransaction};
 use types::BlockNumber;
-use types::header::{Header, ExtendedHeader};
+use types::header::Header;
 use vm::{CallType, ActionParams, ActionValue, ParamsType};
 use vm::{EnvInfo, Schedule, CreateContractAddress};
 
@@ -430,7 +430,6 @@ pub enum AuxiliaryRequest {
 
 impl ::parity_machine::Machine for EthereumMachine {
 	type Header = Header;
-	type ExtendedHeader = ExtendedHeader;
 
 	type LiveBlock = ExecutedBlock;
 	type EngineClient = ::client::EngineClient;

--- a/ethcore/types/src/header.rs
+++ b/ethcore/types/src/header.rs
@@ -376,13 +376,6 @@ impl ::parity_machine::Header for Header {
 	fn number(&self) -> BlockNumber { Header::number(self) }
 }
 
-impl ::parity_machine::ScoredHeader for Header {
-	type Value = U256;
-
-	fn score(&self) -> &U256 { self.difficulty() }
-	fn set_score(&mut self, score: U256) { self.set_difficulty(score) }
-}
-
 impl ::parity_machine::Header for ExtendedHeader {
 	fn bare_hash(&self) -> H256 { self.header.bare_hash() }
 	fn hash(&self) -> H256 { self.header.hash() }
@@ -391,21 +384,11 @@ impl ::parity_machine::Header for ExtendedHeader {
 	fn number(&self) -> BlockNumber { self.header.number() }
 }
 
-impl ::parity_machine::ScoredHeader for ExtendedHeader {
-	type Value = U256;
-
-	fn score(&self) -> &U256 { self.header.difficulty() }
-	fn set_score(&mut self, score: U256) { self.header.set_difficulty(score) }
-}
-
-impl ::parity_machine::TotalScoredHeader for ExtendedHeader {
-	type Value = U256;
-
-	fn total_score(&self) -> U256 { self.parent_total_difficulty + *self.header.difficulty() }
-}
-
-impl ::parity_machine::FinalizableHeader for ExtendedHeader {
-	fn is_finalized(&self) -> bool { self.is_finalized }
+impl ExtendedHeader {
+	/// Returns combined difficulty of all ancestors together with the difficulty of this header.
+	pub fn total_score(&self) -> U256 {
+		self.parent_total_difficulty + *self.header.difficulty()
+	}
 }
 
 #[cfg(test)]

--- a/machine/src/lib.rs
+++ b/machine/src/lib.rs
@@ -40,37 +40,6 @@ pub trait Header {
 	fn number(&self) -> u64;
 }
 
-/// A header with an associated score (difficulty in PoW terms)
-pub trait ScoredHeader: Header {
-	type Value;
-
-	/// Get the score of this header.
-	fn score(&self) -> &Self::Value;
-
-	/// Set the score of this header.
-	fn set_score(&mut self, score: Self::Value);
-}
-
-/// A header with associated total score.
-pub trait TotalScoredHeader: Header {
-	type Value;
-
-	/// Get the total score of this header.
-	fn total_score(&self) -> Self::Value;
-}
-
-/// A header with finalized information.
-pub trait FinalizableHeader: Header {
-	/// Get whether this header is considered finalized, so that it will never be replaced in reorganization.
-	fn is_finalized(&self) -> bool;
-}
-
-/// A header with metadata information.
-pub trait WithMetadataHeader: Header {
-	/// Get the current header metadata.
-	fn metadata(&self) -> Option<&[u8]>;
-}
-
 /// A "live" block is one which is in the process of the transition.
 /// The state of this block can be mutated by arbitrary rules of the
 /// state transition function.
@@ -101,8 +70,6 @@ pub trait Machine: for<'a> LocalizedMachine<'a> {
 	type Header: Header;
 	/// The live block type.
 	type LiveBlock: LiveBlock<Header=Self::Header>;
-	/// Block header with metadata information.
-	type ExtendedHeader: Header;
 	/// A handle to a blockchain client for this machine.
 	type EngineClient: ?Sized;
 	/// A description of needed auxiliary data.


### PR DESCRIPTION
machine engine is too complex and we don't need it to be so generic. In the following pull requests I will try to simplify it to the bare minimum

changes:
- removed unused `ScoredHeader`
- removed unused `FinalizableHeader`
- removed unused `WithMetadataHeader`
- removed `TotalScoredHeader` and moved it's implementation to `ExtendedHeader`
- removed `type ExtendedHeader` from `trait Machine`. There is only one implementation of this type, so there is no reason to have it generic