### PR TITLE
simplify block module and usage

### DIFF
--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -367,9 +367,6 @@ impl ops::Deref for SealedBlock {
 }
 
 impl ClosedBlock {
-	/// Get the hash of the header without seal arguments.
-	pub fn hash(&self) -> H256 { self.header.bare_hash() }
-
 	/// Turn this into a `LockedBlock`, unable to be reopened again.
 	pub fn lock(self) -> LockedBlock {
 		LockedBlock {

--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -31,7 +31,7 @@
 //! `ExecutedBlock` is an underlaying data structure used by all structs above to store block
 //! related info.
 
-use std::cmp;
+use std::{cmp, ops};
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -52,7 +52,6 @@ use vm::{EnvInfo, LastHashes};
 use hash::keccak;
 use rlp::{RlpStream, Encodable, encode_list};
 use types::transaction::{SignedTransaction, Error as TransactionError};
-use types::block::Block;
 use types::header::{Header, ExtendedHeader};
 use types::receipt::{Receipt, TransactionOutcome};
 
@@ -155,44 +154,10 @@ impl ExecutedBlock {
 	}
 }
 
-/// Trait for a object that is a `ExecutedBlock`.
-pub trait IsBlock {
-	/// Get the `ExecutedBlock` associated with this object.
-	fn block(&self) -> &ExecutedBlock;
-
-	/// Get the base `Block` object associated with this.
-	fn to_base(&self) -> Block {
-		Block {
-			header: self.header().clone(),
-			transactions: self.transactions().iter().cloned().map(Into::into).collect(),
-			uncles: self.uncles().to_vec(),
-		}
-	}
-
-	/// Get the header associated with this object's block.
-	fn header(&self) -> &Header { &self.block().header }
-
-	/// Get the final state associated with this object's block.
-	fn state(&self) -> &State<StateDB> { &self.block().state }
-
-	/// Get all information on transactions in this block.
-	fn transactions(&self) -> &[SignedTransaction] { &self.block().transactions }
-
-	/// Get all information on receipts in this block.
-	fn receipts(&self) -> &[Receipt] { &self.block().receipts }
-
-	/// Get all uncles in this block.
-	fn uncles(&self) -> &[Header] { &self.block().uncles }
-}
-
 /// Trait for an object that owns an `ExecutedBlock`
 pub trait Drain {
 	/// Returns `ExecutedBlock`
 	fn drain(self) -> ExecutedBlock;
-}
-
-impl IsBlock for ExecutedBlock {
-	fn block(&self) -> &ExecutedBlock { self }
 }
 
 impl<'x> OpenBlock<'x> {
@@ -250,7 +215,7 @@ impl<'x> OpenBlock<'x> {
 	/// NOTE Will check chain constraints and the uncle number but will NOT check
 	/// that the header itself is actually valid.
 	pub fn push_uncle(&mut self, valid_uncle_header: Header) -> Result<(), BlockError> {
-		let max_uncles = self.engine.maximum_uncle_count(self.block.header().number());
+		let max_uncles = self.engine.maximum_uncle_count(self.block.header.number());
 		if self.block.uncles.len() + 1 > max_uncles {
 			return Err(BlockError::TooManyUncles(OutOfBounds{
 				min: None,
@@ -264,11 +229,6 @@ impl<'x> OpenBlock<'x> {
 		Ok(())
 	}
 
-	/// Get the environment info concerning this block.
-	pub fn env_info(&self) -> EnvInfo {
-		self.block.env_info()
-	}
-
 	/// Push a transaction into the block.
 	///
 	/// If valid, it will be executed, and archived together with the receipt.
@@ -277,7 +237,7 @@ impl<'x> OpenBlock<'x> {
 			return Err(TransactionError::AlreadyImported.into());
 		}
 
-		let env_info = self.env_info();
+		let env_info = self.block.env_info();
 		let outcome = self.block.state.apply(&env_info, self.engine.machine(), &t, self.block.traces.is_enabled())?;
 
 		self.block.transactions_set.insert(h.unwrap_or_else(||t.hash()));
@@ -374,21 +334,41 @@ impl<'x> OpenBlock<'x> {
 	pub fn block_mut(&mut self) -> &mut ExecutedBlock { &mut self.block }
 }
 
-impl<'x> IsBlock for OpenBlock<'x> {
-	fn block(&self) -> &ExecutedBlock { &self.block }
+impl<'a> ops::Deref for OpenBlock<'a> {
+	type Target = ExecutedBlock;
+
+	fn deref(&self) -> &Self::Target {
+		&self.block
+	}
 }
 
-impl IsBlock for ClosedBlock {
-	fn block(&self) -> &ExecutedBlock { &self.block }
+impl ops::Deref for ClosedBlock {
+	type Target = ExecutedBlock;
+
+	fn deref(&self) -> &Self::Target {
+		&self.block
+	}
 }
 
-impl IsBlock for LockedBlock {
-	fn block(&self) -> &ExecutedBlock { &self.block }
+impl ops::Deref for LockedBlock {
+	type Target = ExecutedBlock;
+
+	fn deref(&self) -> &Self::Target {
+		&self.block
+	}
+}
+
+impl ops::Deref for SealedBlock {
+	type Target = ExecutedBlock;
+
+	fn deref(&self) -> &Self::Target {
+		&self.block
+	}
 }
 
 impl ClosedBlock {
 	/// Get the hash of the header without seal arguments.
-	pub fn hash(&self) -> H256 { self.header().bare_hash() }
+	pub fn hash(&self) -> H256 { self.header.bare_hash() }
 
 	/// Turn this into a `LockedBlock`, unable to be reopened again.
 	pub fn lock(self) -> LockedBlock {
@@ -423,18 +403,13 @@ impl LockedBlock {
 		self.block.header.set_receipts_root(
 			ordered_trie_root(self.block.receipts.iter().map(|r| r.rlp_bytes()))
 		);
-		// compute hash and cache it.
-		self.block.header.compute_hash();
 	}
-
-	/// Get the hash of the header without seal arguments.
-	pub fn hash(&self) -> H256 { self.header().bare_hash() }
 
 	/// Provide a valid seal in order to turn this into a `SealedBlock`.
 	///
 	/// NOTE: This does not check the validity of `seal` with the engine.
 	pub fn seal(self, engine: &EthEngine, seal: Vec<Bytes>) -> Result<SealedBlock, BlockError> {
-		let expected_seal_fields = engine.seal_fields(self.header());
+		let expected_seal_fields = engine.seal_fields(&self.block.header);
 		let mut s = self;
 		if seal.len() != expected_seal_fields {
 			return Err(BlockError::InvalidSealArity(
@@ -488,10 +463,6 @@ impl Drain for SealedBlock {
 	fn drain(self) -> ExecutedBlock {
 		self.block
 	}
-}
-
-impl IsBlock for SealedBlock {
-	fn block(&self) -> &ExecutedBlock { &self.block }
 }
 
 /// Enact the block given by block header, transactions and uncles

--- a/ethcore/src/engines/basic_authority.rs
+++ b/ethcore/src/engines/basic_authority.rs
@@ -104,7 +104,7 @@ impl Engine<EthereumMachine> for BasicAuthority {
 
 	/// Attempt to seal the block internally.
 	fn generate_seal(&self, block: &ExecutedBlock, _parent: &Header) -> Seal {
-		let header = block.header();
+		let header = &block.header;
 		let author = header.author();
 		if self.validators.contains(header.parent_hash(), author) {
 			// account should be pernamently unlocked, otherwise sealing will fail
@@ -266,7 +266,7 @@ mod tests {
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, addr, (3141562.into(), 31415620.into()), vec![], false, &mut Vec::new().into_iter()).unwrap();
 		let b = b.close_and_lock().unwrap();
-		if let Seal::Regular(seal) = engine.generate_seal(b.block(), &genesis_header) {
+		if let Seal::Regular(seal) = engine.generate_seal(&b, &genesis_header) {
 			assert!(b.try_seal(engine, seal).is_ok());
 		}
 	}

--- a/ethcore/src/engines/instant_seal.rs
+++ b/ethcore/src/engines/instant_seal.rs
@@ -110,7 +110,7 @@ mod tests {
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, Address::default(), (3141562.into(), 31415620.into()), vec![], false, &mut Vec::new().into_iter()).unwrap();
 		let b = b.close_and_lock().unwrap();
-		if let Seal::Regular(seal) = engine.generate_seal(b.block(), &genesis_header) {
+		if let Seal::Regular(seal) = engine.generate_seal(&b, &genesis_header) {
 			assert!(b.try_seal(engine, seal).is_ok());
 		}
 	}

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -542,7 +542,7 @@ mod tests {
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![], false, &mut Vec::new().into_iter()).unwrap();
 		let b = b.close().unwrap();
-		assert_eq!(b.state().balance(&Address::zero()).unwrap(), U256::from_str("4563918244f40000").unwrap());
+		assert_eq!(b.state.balance(&Address::zero()).unwrap(), U256::from_str("4563918244f40000").unwrap());
 	}
 
 	#[test]
@@ -596,8 +596,8 @@ mod tests {
 		b.push_uncle(uncle).unwrap();
 
 		let b = b.close().unwrap();
-		assert_eq!(b.state().balance(&Address::zero()).unwrap(), "478eae0e571ba000".into());
-		assert_eq!(b.state().balance(&uncle_author).unwrap(), "3cb71f51fc558000".into());
+		assert_eq!(b.state.balance(&Address::zero()).unwrap(), "478eae0e571ba000".into());
+		assert_eq!(b.state.balance(&uncle_author).unwrap(), "3cb71f51fc558000".into());
 	}
 
 	#[test]
@@ -612,9 +612,9 @@ mod tests {
 
 		let ubi_contract: Address = "00efdd5883ec628983e9063c7d969fe268bbf310".into();
 		let dev_contract: Address = "00756cf8159095948496617f5fb17ed95059f536".into();
-		assert_eq!(b.state().balance(&Address::zero()).unwrap(), U256::from_str("d8d726b7177a80000").unwrap());
-		assert_eq!(b.state().balance(&ubi_contract).unwrap(), U256::from_str("2b5e3af16b1880000").unwrap());
-		assert_eq!(b.state().balance(&dev_contract).unwrap(), U256::from_str("c249fdd327780000").unwrap());
+		assert_eq!(b.state.balance(&Address::zero()).unwrap(), U256::from_str("d8d726b7177a80000").unwrap());
+		assert_eq!(b.state.balance(&ubi_contract).unwrap(), U256::from_str("2b5e3af16b1880000").unwrap());
+		assert_eq!(b.state.balance(&dev_contract).unwrap(), U256::from_str("c249fdd327780000").unwrap());
 	}
 
 	#[test]

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -1194,9 +1194,9 @@ impl miner::MinerService for Miner {
 				} else {
 					GetAction::Take
 				},
-				|b| &b.hash() == &block_hash
+				|b| &b.header.bare_hash() == &block_hash
 			) {
-				trace!(target: "miner", "Submitted block {}={}={} with seal {:?}", block_hash, b.hash(), b.header.bare_hash(), seal);
+				trace!(target: "miner", "Submitted block {}={} with seal {:?}", block_hash, b.header.bare_hash(), seal);
 				b.lock().try_seal(&*self.engine, seal).or_else(|e| {
 					warn!(target: "miner", "Mined solution rejected: {}", e);
 					Err(ErrorKind::PowInvalid.into())

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -46,7 +46,7 @@ use types::header::Header;
 use types::receipt::RichReceipt;
 use using_queue::{UsingQueue, GetAction};
 
-use block::{ClosedBlock, IsBlock, SealedBlock};
+use block::{ClosedBlock, SealedBlock};
 use client::{
 	BlockChain, ChainInfo, BlockProducer, SealedBlockImporter, Nonce, TransactionInfo, TransactionId
 };
@@ -362,7 +362,7 @@ impl Miner {
 			.and_then(|b| {
 				// to prevent a data race between block import and updating pending block
 				// we allow the number to be equal.
-				if b.block().header().number() >= latest_block_number {
+				if b.header.number() >= latest_block_number {
 					Some(f(b))
 				} else {
 					None
@@ -392,7 +392,7 @@ impl Miner {
 		// Open block
 		let (mut open_block, original_work_hash) = {
 			let mut sealing = self.sealing.lock();
-			let last_work_hash = sealing.queue.peek_last_ref().map(|pb| pb.block().header().hash());
+			let last_work_hash = sealing.queue.peek_last_ref().map(|pb| pb.header.hash());
 			let best_hash = chain_info.best_block_hash;
 
 			// check to see if last ClosedBlock in would_seals is actually same parent block.
@@ -401,7 +401,7 @@ impl Miner {
 			//   if at least one was pushed successfully, close and enqueue new ClosedBlock;
 			//   otherwise, leave everything alone.
 			// otherwise, author a fresh block.
-			let mut open_block = match sealing.queue.get_pending_if(|b| b.block().header().parent_hash() == &best_hash) {
+			let mut open_block = match sealing.queue.get_pending_if(|b| b.header.parent_hash() == &best_hash) {
 				Some(old_block) => {
 					trace!(target: "miner", "prepare_block: Already have previous work; updating and returning");
 					// add transactions to old_block
@@ -436,7 +436,7 @@ impl Miner {
 		let mut invalid_transactions = HashSet::new();
 		let mut not_allowed_transactions = HashSet::new();
 		let mut senders_to_penalize = HashSet::new();
-		let block_number = open_block.block().header().number();
+		let block_number = open_block.header.number();
 
 		let mut tx_count = 0usize;
 		let mut skipped_transactions = 0usize;
@@ -453,7 +453,7 @@ impl Miner {
 		let max_transactions = if min_tx_gas.is_zero() {
 			usize::max_value()
 		} else {
-			MAX_SKIPPED_TRANSACTIONS.saturating_add(cmp::min(*open_block.block().header().gas_limit() / min_tx_gas, u64::max_value().into()).as_u64() as usize)
+			MAX_SKIPPED_TRANSACTIONS.saturating_add(cmp::min(*open_block.header.gas_limit() / min_tx_gas, u64::max_value().into()).as_u64() as usize)
 		};
 
 		let pending: Vec<Arc<_>> = self.transaction_queue.pending(
@@ -636,7 +636,7 @@ impl Miner {
 	{
 		{
 			let sealing = self.sealing.lock();
-			if block.transactions().is_empty()
+			if block.transactions.is_empty()
 				&& !self.forced_sealing()
 				&& Instant::now() <= sealing.next_mandatory_reseal
 			{
@@ -646,7 +646,7 @@ impl Miner {
 
 		trace!(target: "miner", "seal_block_internally: attempting internal seal.");
 
-		let parent_header = match chain.block_header(BlockId::Hash(*block.header().parent_hash())) {
+		let parent_header = match chain.block_header(BlockId::Hash(*block.header.parent_hash())) {
 			Some(h) => {
 				match h.decode() {
 					Ok(decoded_hdr) => decoded_hdr,
@@ -656,7 +656,7 @@ impl Miner {
 			None => return false,
 		};
 
-		match self.engine.generate_seal(block.block(), &parent_header) {
+		match self.engine.generate_seal(&block, &parent_header) {
 			// Save proposal for later seal submission and broadcast it.
 			Seal::Proposal(seal) => {
 				trace!(target: "miner", "Received a Proposal seal.");
@@ -705,11 +705,11 @@ impl Miner {
 	/// Prepares work which has to be done to seal.
 	fn prepare_work(&self, block: ClosedBlock, original_work_hash: Option<H256>) {
 		let (work, is_new) = {
-			let block_header = block.block().header().clone();
+			let block_header = block.header.clone();
 			let block_hash = block_header.hash();
 
 			let mut sealing = self.sealing.lock();
-			let last_work_hash = sealing.queue.peek_last_ref().map(|pb| pb.block().header().hash());
+			let last_work_hash = sealing.queue.peek_last_ref().map(|pb| pb.header.hash());
 
 			trace!(
 				target: "miner",
@@ -742,7 +742,7 @@ impl Miner {
 			trace!(
 				target: "miner",
 				"prepare_work: leaving (last={:?})",
-				sealing.queue.peek_last_ref().map(|b| b.block().header().hash())
+				sealing.queue.peek_last_ref().map(|b| b.header.hash())
 			);
 			(work, is_new)
 		};
@@ -994,7 +994,7 @@ impl miner::MinerService for Miner {
 
 		let from_pending = || {
 			self.map_existing_pending_block(|sealing| {
-				sealing.transactions()
+				sealing.transactions
 					.iter()
 					.map(|signed| signed.hash())
 					.collect()
@@ -1041,7 +1041,7 @@ impl miner::MinerService for Miner {
 
 		let from_pending = || {
 			self.map_existing_pending_block(|sealing| {
-				sealing.transactions()
+				sealing.transactions
 					.iter()
 					.map(|signed| pool::VerifiedTransaction::from_pending_block_transaction(signed.clone()))
 					.map(Arc::new)
@@ -1086,9 +1086,9 @@ impl miner::MinerService for Miner {
 
 	fn pending_receipts(&self, best_block: BlockNumber) -> Option<Vec<RichReceipt>> {
 		self.map_existing_pending_block(|pending| {
-			let receipts = pending.receipts();
-			pending.transactions()
-				.into_iter()
+			let receipts = &pending.receipts;
+			pending.transactions
+				.iter()
 				.enumerate()
 				.map(|(index, tx)| {
 					let prev_gas = if index == 0 { Default::default() } else { receipts[index - 1].gas_used };
@@ -1102,7 +1102,7 @@ impl miner::MinerService for Miner {
 							Action::Call(_) => None,
 							Action::Create => {
 								let sender = tx.sender();
-								Some(contract_address(self.engine.create_address_scheme(pending.header().number()), &sender, &tx.nonce, &tx.data).0)
+								Some(contract_address(self.engine.create_address_scheme(pending.header.number()), &sender, &tx.nonce, &tx.data).0)
 							}
 						},
 						logs: receipt.logs.clone(),
@@ -1139,7 +1139,7 @@ impl miner::MinerService for Miner {
 
 		// refuse to seal the first block of the chain if it contains hard forks
 		// which should be on by default.
-		if block.block().header().number() == 1 {
+		if block.header.number() == 1 {
 			if let Some(name) = self.engine.params().nonzero_bugfix_hard_fork() {
 				warn!("Your chain specification contains one or more hard forks which are required to be \
 					   on by default. Please remove these forks and start your chain again: {}.", name);
@@ -1180,7 +1180,7 @@ impl miner::MinerService for Miner {
 		self.prepare_pending_block(chain);
 
 		self.sealing.lock().queue.use_last_ref().map(|b| {
-			let header = b.header();
+			let header = &b.header;
 			(header.hash(), header.number(), header.timestamp(), *header.difficulty())
 		})
 	}
@@ -1196,7 +1196,7 @@ impl miner::MinerService for Miner {
 				},
 				|b| &b.hash() == &block_hash
 			) {
-				trace!(target: "miner", "Submitted block {}={}={} with seal {:?}", block_hash, b.hash(), b.header().bare_hash(), seal);
+				trace!(target: "miner", "Submitted block {}={}={} with seal {:?}", block_hash, b.hash(), b.header.bare_hash(), seal);
 				b.lock().try_seal(&*self.engine, seal).or_else(|e| {
 					warn!(target: "miner", "Mined solution rejected: {}", e);
 					Err(ErrorKind::PowInvalid.into())
@@ -1207,8 +1207,8 @@ impl miner::MinerService for Miner {
 			};
 
 		result.and_then(|sealed| {
-			let n = sealed.header().number();
-			let h = sealed.header().hash();
+			let n = sealed.header.number();
+			let h = sealed.header.hash();
 			info!(target: "miner", "Submitted block imported OK. #{}: {}", Colour::White.bold().paint(format!("{}", n)), Colour::White.bold().paint(format!("{:x}", h)));
 			Ok(sealed)
 		})
@@ -1304,19 +1304,25 @@ impl miner::MinerService for Miner {
 	}
 
 	fn pending_state(&self, latest_block_number: BlockNumber) -> Option<Self::State> {
-		self.map_existing_pending_block(|b| b.state().clone(), latest_block_number)
+		self.map_existing_pending_block(|b| b.state.clone(), latest_block_number)
 	}
 
 	fn pending_block_header(&self, latest_block_number: BlockNumber) -> Option<Header> {
-		self.map_existing_pending_block(|b| b.header().clone(), latest_block_number)
+		self.map_existing_pending_block(|b| b.header.clone(), latest_block_number)
 	}
 
 	fn pending_block(&self, latest_block_number: BlockNumber) -> Option<Block> {
-		self.map_existing_pending_block(|b| b.to_base(), latest_block_number)
+		self.map_existing_pending_block(|b| {
+			Block {
+				header: b.header.clone(),
+				transactions: b.transactions.iter().cloned().map(Into::into).collect(),
+				uncles: b.uncles.to_vec(),
+			}
+		}, latest_block_number)
 	}
 
 	fn pending_transactions(&self, latest_block_number: BlockNumber) -> Option<Vec<SignedTransaction>> {
-		self.map_existing_pending_block(|b| b.transactions().into_iter().cloned().collect(), latest_block_number)
+		self.map_existing_pending_block(|b| b.transactions.iter().cloned().collect(), latest_block_number)
 	}
 }
 

--- a/ethcore/src/tests/client.rs
+++ b/ethcore/src/tests/client.rs
@@ -27,7 +27,6 @@ use types::filter::Filter;
 use types::view;
 use types::views::BlockView;
 
-use block::IsBlock;
 use client::{BlockChainClient, Client, ClientConfig, BlockId, ChainInfo, BlockInfo, PrepareOpenBlock, ImportSealedBlock, ImportBlock};
 use ethereum;
 use executive::{Executive, TransactOptions};
@@ -254,7 +253,7 @@ fn can_mine() {
 
 	let b = client.prepare_open_block(Address::default(), (3141562.into(), 31415620.into()), vec![]).unwrap().close().unwrap();
 
-	assert_eq!(*b.block().header().parent_hash(), view!(BlockView, &dummy_blocks[0]).header_view().hash());
+	assert_eq!(*b.header.parent_hash(), view!(BlockView, &dummy_blocks[0]).header_view().hash());
 }
 
 #[test]

--- a/rpc/src/v1/tests/helpers/miner_service.rs
+++ b/rpc/src/v1/tests/helpers/miner_service.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use bytes::Bytes;
-use ethcore::block::{SealedBlock, IsBlock};
+use ethcore::block::SealedBlock;
 use ethcore::client::{Nonce, PrepareOpenBlock, StateClient, EngineInfo};
 use ethcore::engines::{EthEngine, signer::EngineSigner};
 use ethcore::error::Error;
@@ -193,7 +193,7 @@ impl MinerService for TestMinerService {
 		let params = self.authoring_params();
 		let open_block = chain.prepare_open_block(params.author, params.gas_range_target, params.extra_data).unwrap();
 		let closed = open_block.close().unwrap();
-		let header = closed.header();
+		let header = &closed.header;
 
 		Some((header.hash(), header.number(), header.timestamp(), *header.difficulty()))
 	}


### PR DESCRIPTION
- removed redundant `IsBlock` trait
- removed unused `LockedBlock::hash` function
- removed `ClosedBlock::hash` function, cause it caused confustion (see miner.rs)
- removed unused `OpenBlock::env_info` function