### PR TITLE
Initial support sccache for windows build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,7 +152,9 @@ build-windows:
   only:                            *releaseable_branches
   variables:
     CARGO_TARGET:                  x86_64-pc-windows-msvc
-    CARGO_HOME:                      "${CI_PROJECT_DIR}/.cargo"
+    CARGO_HOME:                    "C:/cargo/${CI_JOB_NAME}"
+    RUSTC_WRAPPER:                 sccache
+    SCCACHE_DIR:                   "C:/sccache"
   script:
     - sh scripts/gitlab/build-windows.sh
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -156,9 +156,7 @@ build-windows:
     RUSTC_WRAPPER:                 sccache
     SCCACHE_DIR:                   "C:/ci-cache/parity-ethereum/sccache"
   script:
-    - sccache -s
     - sh scripts/gitlab/build-windows.sh
-    - sccache -s
   tags:
     - rust-windows
   <<:                              *collect_artifacts
@@ -173,9 +171,7 @@ build-windows:
 #       RUSTC_WRAPPER:                 sccache
 #       SCCACHE_DIR:                   C:/ci-cache/parity-ethereum/sccache
 #   script:
-#     - sccache -s
 #     - sh scripts/gitlab/test-linux.sh
-#     - sccache -s
 #   tags:
 #     - rust-windows
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ variables:
 
 .docker-cache-status:              &docker-cache-status
   variables:
-    CARGO_HOME:                    "/cargo/${CI_JOB_NAME}"
+    CARGO_HOME:                    "/ci-cache/parity-ethereum/cargo/${CI_JOB_NAME}"
   before_script:
     - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log RUST_LOG=sccache::server=debug sccache --start-server
     - sccache -s
@@ -152,14 +152,32 @@ build-windows:
   only:                            *releaseable_branches
   variables:
     CARGO_TARGET:                  x86_64-pc-windows-msvc
-    CARGO_HOME:                    "C:/cargo/${CI_JOB_NAME}"
+    CARGO_HOME:                    "C:/ci-cache/parity-ethereum/cargo/%CI_JOB_NAME%"
     RUSTC_WRAPPER:                 sccache
-    SCCACHE_DIR:                   "C:/sccache"
+    SCCACHE_DIR:                   "C:/ci-cache/parity-ethereum/sccache"
   script:
+    - sccache -s
     - sh scripts/gitlab/build-windows.sh
+    - sccache -s
   tags:
     - rust-windows
   <<:                              *collect_artifacts
+
+# test-windows:
+#   stage:                           test
+#   only:
+#     - master
+#   variables:
+#     CARGO_TARGET:                    x86_64-pc-windows-msvc
+#       CARGO_HOME:                    C:/ci-cache/parity-ethereum/cargo/%CI_JOB_NAME%
+#       RUSTC_WRAPPER:                 sccache
+#       SCCACHE_DIR:                   C:/ci-cache/parity-ethereum/sccache
+#   script:
+#     - sccache -s
+#     - sh scripts/gitlab/test-linux.sh
+#     - sccache -s
+#   tags:
+#     - rust-windows
 
 publish-docker:
   stage:                           publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,18 +102,18 @@ build-android:
     CARGO_TARGET:                  armv7-linux-androideabi
   script:
     - scripts/gitlab/build-linux.sh
+  <<:                              *collect_artifacts
   tags:
     - linux-docker
-  <<:                              *collect_artifacts
 
 build-linux:                       &build-linux
   stage:                           build
   only:                            *releaseable_branches
   <<:                              *docker-cache-status
+  <<:                              *collect_artifacts
   script:
     - scripts/gitlab/build-linux.sh
     - sccache -s
-  <<:                              *collect_artifacts
 
 build-linux-i386:
   <<:                              *build-linux
@@ -136,6 +136,7 @@ build-linux-armhf:
 build-darwin:
   stage:                           build
   only:                            *releaseable_branches
+  <<:                              *collect_artifacts
   variables:
     CARGO_TARGET:                  x86_64-apple-darwin
     CARGO_HOME:                      "${CI_PROJECT_DIR}/.cargo"
@@ -145,10 +146,10 @@ build-darwin:
     - scripts/gitlab/build-linux.sh
   tags:
     - rust-osx
-  <<:                              *collect_artifacts
 
 build-windows:
   stage:                           build
+  <<:                              *collect_artifacts
   only:                            *releaseable_branches
   variables:
     CARGO_TARGET:                  x86_64-pc-windows-msvc
@@ -159,21 +160,6 @@ build-windows:
     - sh scripts/gitlab/build-windows.sh
   tags:
     - rust-windows
-  <<:                              *collect_artifacts
-
-# test-windows:
-#   stage:                           test
-#   only:
-#     - master
-#   variables:
-#     CARGO_TARGET:                    x86_64-pc-windows-msvc
-#       CARGO_HOME:                    C:/ci-cache/parity-ethereum/cargo/%CI_JOB_NAME%
-#       RUSTC_WRAPPER:                 sccache
-#       SCCACHE_DIR:                   C:/ci-cache/parity-ethereum/sccache
-#   script:
-#     - sh scripts/gitlab/test-linux.sh
-#   tags:
-#     - rust-windows
 
 publish-docker:
   stage:                           publish
@@ -189,6 +175,7 @@ publish-docker:
 publish-snap:                      &publish-snap
   stage:                           publish
   only:                            *releaseable_branches
+  <<:                              *collect_artifacts
   image:                           snapcore/snapcraft
   variables:
     BUILD_ARCH:                    amd64
@@ -199,7 +186,6 @@ publish-snap:                      &publish-snap
     - linux-docker
   script:
     - scripts/gitlab/publish-snap.sh
-  <<:                              *collect_artifacts
 
 publish-snap-i386:
   <<:                              *publish-snap

--- a/scripts/gitlab/build-windows.sh
+++ b/scripts/gitlab/build-windows.sh
@@ -4,11 +4,14 @@ set -u # treat unset variables as error
 
 set INCLUDE="C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Include;C:\vs2015\VC\include;C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt"
 set LIB="C:\vs2015\VC\lib;C:\Program Files (x86)\Windows Kits\10\Lib\10.0.10240.0\ucrt\x64"
+sccache -s
 
 echo "__________Show ENVIROMENT__________"
 echo "CI_SERVER_NAME:   " $CI_SERVER_NAME
 echo "CARGO_HOME:       " $CARGO_HOME
 echo "CARGO_TARGET:     " $CARGO_TARGET
+echo "RUSTC_WRAPPER:    " $RUSTC_WRAPPER
+echo "SCCACHE_DIR:      " $SCCACHE_DIR
 
 echo "_____ Building target: "$CARGO_TARGET" _____"
 time cargo build --target $CARGO_TARGET --release --features final
@@ -44,3 +47,5 @@ do
 done
 cp parity.exe.sha256 parity.sha256
 cp parity.exe.sha3 parity.sha3
+
+sccache -s


### PR DESCRIPTION
On build machines you need to pre-install the [sccache](https://github.com/mozilla/sccache) and create working folders `C:\sccache\` & `C:\cargo\`