### PR TITLE
verbose flag for cpp tests

### DIFF
--- a/scripts/gitlab/test-cpp.sh
+++ b/scripts/gitlab/test-cpp.sh
@@ -10,7 +10,7 @@ DIR=parity-clib/examples/cpp/build
 mkdir -p $DIR
 cd $DIR
 cmake ..
-make -j $THREADS
+make VERBOSE=1 -j $THREADS
 # Note: we don't try to run the example because it tries to sync Kovan, and we don't want
 #       that to happen on CI
 cd -


### PR DESCRIPTION
Asked to to that in https://github.com/paritytech/parity-ethereum/pull/10521

This `test-cpp` is not clear to me.
Latest thing happened to it before: when during FOSDEM we were fixing some critical stuff, ran into this test was launching Kovan sync and it took a long time, so we got rid of it and just left it there.

My opinion is the whole test should be revisited.