### PR TITLE
clique: make state backfill time measurement more accurate

### DIFF
--- a/ethcore/src/engines/clique/mod.rs
+++ b/ethcore/src/engines/clique/mod.rs
@@ -280,6 +280,13 @@ impl Clique {
 				let last_checkpoint_number = header.number() - header.number() % self.epoch_length as u64;
 				debug_assert_ne!(last_checkpoint_number, header.number());
 
+				// Catching up state, note that we don't really store block state for intermediary blocks,
+				// for speed.
+				let backfill_start = time::Instant::now();
+				trace!(target: "engine",
+						"Back-filling block state. last_checkpoint_number: {}, target: {}({}).",
+						last_checkpoint_number, header.number(), header.hash());
+
 				let mut chain: &mut VecDeque<Header> = &mut VecDeque::with_capacity(
 					(header.number() - last_checkpoint_number + 1) as usize);
 
@@ -305,13 +312,6 @@ impl Clique {
 						}
 					}
 				}
-
-				// Catching up state, note that we don't really store block state for intermediary blocks,
-				// for speed.
-				let backfill_start = time::Instant::now();
-				trace!(target: "engine",
-						"Back-filling block state. last_checkpoint_number: {}, target: {}({}).",
-						last_checkpoint_number, header.number(), header.hash());
 
 				// Get the state for last checkpoint.
 				let last_checkpoint_hash = *chain.front()


### PR DESCRIPTION
Moves the start of the measurement before the expensive chain traversal loop.