### PR TITLE
Stop breaking out of loop if a non-canonical hash is found

### DIFF
--- a/ethcore/blockchain/src/blockchain.rs
+++ b/ethcore/blockchain/src/blockchain.rs
@@ -970,6 +970,7 @@ impl BlockChain {
 	/// Iterate over all epoch transitions.
 	/// This will only return transitions within the canonical chain.
 	pub fn epoch_transitions(&self) -> EpochTransitionIter {
+		trace!(target: "blockchain", "Iterating over all epoch transitions");
 		let iter = self.db.key_value().iter_from_prefix(db::COL_EXTRA, &EPOCH_KEY_PREFIX[..]);
 		EpochTransitionIter {
 			chain: self,
@@ -995,7 +996,9 @@ impl BlockChain {
 	pub fn epoch_transition_for(&self, parent_hash: H256) -> Option<EpochTransition> {
 		// slow path: loop back block by block
 		for hash in self.ancestry_iter(parent_hash)? {
+			trace!(target: "blockchain", "Got hash {} from ancestry_iter", hash);
 			let details = self.block_details(&hash)?;
+			trace!(target: "blockchain", "Got block details for block #{}", details.number);
 
 			// look for transition in database.
 			if let Some(transition) = self.epoch_transition(details.number, hash) {
@@ -1007,11 +1010,15 @@ impl BlockChain {
 			//
 			// if `block_hash` is canonical it will only return transitions up to
 			// the parent.
-			if self.block_hash(details.number)? == hash {
-				return self.epoch_transitions()
-					.map(|(_, t)| t)
-					.take_while(|t| t.block_number <= details.number)
-					.last()
+			match self.block_hash(details.number) {
+				Some(h) if h == hash => {
+					return self.epoch_transitions()
+						.map(|(_, t)| t)
+						.take_while(|t| t.block_number <= details.number)
+						.last()
+				},
+				Some(h) => trace!(target: "blockchain", "Found non-canonical block hash {}", h),
+				None => trace!(target: "blockchain", "Block hash not found in cache or DB"),
 			}
 		}
 


### PR DESCRIPTION
Currently investigating #10085 with the help of @tomusdrw. We have a couple theories floating around, but we aren't sure how to reproduce them on our own.

We've narrowed down the cause to one of three function calls within `Blockchain::epoch_transition_for`. This PR handles the `None` case of what we think is the most suspect function call better, as well as adds some additional logging so we can track where we are the loop.