### PR TITLE
CI improvements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ variables:
         exit 0;
       fi
     # collect log files
-    - mkdir -p ./artifacts
+    - mkdir -p ./logs
     - find . -name "*.log"
     - find . -name "*.log" | xargs tar --append -f ./logs/logs_"${CI_JOB_NAME}_${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}".tar
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,7 +74,7 @@ cargo-check 0 3:
   <<:                              *docker-cache-status
   <<:                              *collect_logs
   script:
-    - time cargo check --target $CARGO_TARGET --locked --no-default-features --verbose --color=auto
+    - time cargo check --target $CARGO_TARGET --locked --no-default-features --verbose --color=always
     - sccache -s
 
 cargo-check 1 3:
@@ -82,7 +82,7 @@ cargo-check 1 3:
   <<:                              *docker-cache-status
   <<:                              *collect_logs
   script:
-    - time cargo check --target $CARGO_TARGET --locked --manifest-path util/io/Cargo.toml --no-default-features --verbose --color=auto
+    - time cargo check --target $CARGO_TARGET --locked --manifest-path util/io/Cargo.toml --no-default-features --verbose --color=always
     - sccache -s
 
 cargo-check 2 3:
@@ -90,7 +90,7 @@ cargo-check 2 3:
   <<:                              *docker-cache-status
   <<:                              *collect_logs
   script:
-    - time cargo check --target $CARGO_TARGET --locked --manifest-path util/io/Cargo.toml --features "mio" --verbose --color=auto
+    - time cargo check --target $CARGO_TARGET --locked --manifest-path util/io/Cargo.toml --features "mio" --verbose --color=always
     - sccache -s
 
 cargo-audit:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,6 +36,7 @@ variables:
     CARGO_HOME:                    "/ci-cache/parity-ethereum/cargo/${CI_JOB_NAME}"
   artifacts:
     name:                          "${CI_JOB_NAME}"
+    when:                          always
     expire_in:                     7 days
     paths:
       - artifacts/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ variables:
   before_script:
     - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log
         RUST_LOG=sccache::server=debug
-        SCCACHE_CACHE_SIZE=5G
+        SCCACHE_CACHE_SIZE=3G
         sccache --start-server
     - sccache -s
   after_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,12 +39,13 @@ variables:
     when:                          always
     expire_in:                     7 days
     paths:
-      - "*.log"
+      - artifacts/
   before_script:
     # RUST_LOG=sccache::server=debug
     - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log
         RUST_LOG=sccache
         SCCACHE_CACHE_SIZE=50G
+        SCCACHE_DIR=/ci-cache/parity-ethereum/sccache/${CI_JOB_NAME}
         sccache --start-server
     - sccache -s
   after_script:
@@ -60,9 +61,9 @@ variables:
         exit 0;
       fi
     # collect log files
-    # - mkdir -p ./artifacts
-    # - find . -name "*.log"
-    # - find . -name "*.log" | xargs tar --append -f ./artifacts/logs.tar
+    - mkdir -p ./artifacts
+    - find . -name "*.log"
+    - find . -name "*.log" | xargs tar --append -f ./artifacts/logs.tar
   tags:
     # - linux-docker
     - qa

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,21 +70,21 @@ cargo-check 0 3:
   stage:                           test
   <<:                              *docker-cache-status
   script:
-    - time cargo check --target $CARGO_TARGET --locked --no-default-features
+    - time cargo check --target $CARGO_TARGET --locked --no-default-features --verbose
     - sccache -s
 
 cargo-check 1 3:
   stage:                           test
   <<:                              *docker-cache-status
   script:
-    - time cargo check --target $CARGO_TARGET --locked --manifest-path util/io/Cargo.toml --no-default-features
+    - time cargo check --target $CARGO_TARGET --locked --manifest-path util/io/Cargo.toml --no-default-features --verbose
     - sccache -s
 
 cargo-check 2 3:
   stage:                           test
   <<:                              *docker-cache-status
   script:
-    - time cargo check --target $CARGO_TARGET --locked --manifest-path util/io/Cargo.toml --features "mio"
+    - time cargo check --target $CARGO_TARGET --locked --manifest-path util/io/Cargo.toml --features "mio" --verbose
     - sccache -s
 
 cargo-audit:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,18 +43,21 @@ variables:
   before_script:
     # save just logs from sccache server: RUST_LOG=sccache::server=debug
     # set SCCACHE_DIR per job name to avoid data race condition until it'll be fixed
+        # SCCACHE_DIR=/ci-cache/parity-ethereum/sccache/${CI_JOB_NAME}
     - git status
     - ls -l
+    - find . -name "*.log"
     # ^^ debug
     - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log
         RUST_LOG=sccache::server=trace
         SCCACHE_CACHE_SIZE=50G
-        SCCACHE_DIR=/ci-cache/parity-ethereum/sccache/${CI_JOB_NAME}
+        SCCACHE_DIR=/ci-cache/parity-ethereum/sccache/
         sccache --start-server
     - sccache -s
   after_script:
     # sccache debug info
-    - echo "sccache --show-stats"
+    - echo "after script sccache --show-stats"
+    - sccache -s
     - if test -e sccache_error.log;
       then
         echo "All crate-types:";

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,8 +112,25 @@ test-linux:
   stage:                           build
   <<:                              *docker-cache-status
   script:
-    - ./scripts/gitlab/test-linux.sh
+    - ./scripts/gitlab/test-linux.sh stable
     - sccache -s
+
+test-linux-beta:
+  stage:                           build
+  # only:                            *releaseable_branches
+  <<:                              *docker-cache-status
+  script:
+    - ./scripts/gitlab/test-linux.sh beta
+    - sccache -s
+
+test-linux-nightly:
+  stage:                           build
+  # only:                            *releaseable_branches
+  <<:                              *docker-cache-status
+  script:
+    - ./scripts/gitlab/test-linux.sh nightly
+    - sccache -s
+  allow_failure:                   true
 
 build-android:
   stage:                           build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,11 +48,14 @@ variables:
     - echo "All crate-types:"
     - grep 'parse_arguments.*--crate-type' sccache_error.log | sed -re 's/.*"--crate-type", "([^"]+)".*/\1/' | sort | uniq -c
     - echo "Non-cacheable reasons:"
-    - test -x sccache_error.log && grep CannotCache sccache_error.log | sed -re 's/.*CannotCache\((.+)\).*/\1/' | sort | uniq -c
+    - test -e sccache_error.log &&
+        grep CannotCache sccache_error.log | sed -re 's/.*CannotCache\((.+)\).*/\1/' | sort | uniq -c || true
     # collect log files
     - pwd
+    - find . -name "*.log"
+    - find . -name "*.log" | xargs tar --append -f ./artifacts/logs.tar
+    - echo "ls artifacts"
     - ls ./artifacts
-    - find . -name "*.log" | xargs  tar --append -f ./artifacts/logs.tar
   tags:
     # - linux-docker
     - qa

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,18 +37,13 @@ variables:
     when:                          always
     expire_in:                     7 days
     paths:
-      - logs/
+      - artifacts/
 
 .docker-cache-status:              &docker-cache-status
   variables:
     CARGO_HOME:                    "/ci-cache/parity-ethereum/cargo/${CI_JOB_NAME}"
-  <<:                              *collect_logs
   dependencies:                    []
   before_script:
-    - git status
-    - ls -l
-    - find . -name "*.log"
-    # ^^ debug
     - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_debug.log
         RUST_LOG=sccache::server=debug
         SCCACHE_CACHE_SIZE=50G
@@ -57,8 +52,6 @@ variables:
     - sccache -s
   after_script:
     # sccache debug info
-    - sccache --start-server
-    - sccache -s
     - if test -e sccache_debug.log;
       then
         echo "All crate-types:";
@@ -70,15 +63,16 @@ variables:
         exit 0;
       fi
     # collect log files
-    - mkdir -p ./logs
+    - mkdir -p ./artifacts
     - find . -name "*.log"
-    - find . -name "*.log" | xargs tar --append -f ./logs/logs_"${CI_JOB_NAME}_${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}".tar
+    - find . -name "*.log" | xargs tar --append -f ./artifacts/logs_"${CI_JOB_NAME}_${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}".tar
   tags:
     - linux-docker
 
 cargo-check 0 3:
   stage:                           test
   <<:                              *docker-cache-status
+  <<:                              *collect_logs
   script:
     - time cargo check --target $CARGO_TARGET --locked --no-default-features --verbose
     - sccache -s
@@ -86,6 +80,7 @@ cargo-check 0 3:
 cargo-check 1 3:
   stage:                           test
   <<:                              *docker-cache-status
+  <<:                              *collect_logs
   script:
     - time cargo check --target $CARGO_TARGET --locked --manifest-path util/io/Cargo.toml --no-default-features --verbose
     - sccache -s
@@ -93,6 +88,7 @@ cargo-check 1 3:
 cargo-check 2 3:
   stage:                           test
   <<:                              *docker-cache-status
+  <<:                              *collect_logs
   script:
     - time cargo check --target $CARGO_TARGET --locked --manifest-path util/io/Cargo.toml --features "mio" --verbose
     - sccache -s
@@ -107,6 +103,7 @@ cargo-audit:
 validate-chainspecs:
   stage:                           test
   <<:                              *docker-cache-status
+  <<:                              *collect_logs
   script:
     - ./scripts/gitlab/validate-chainspecs.sh
     - sccache -s
@@ -114,6 +111,7 @@ validate-chainspecs:
 test-cpp:
   stage:                           build
   <<:                              *docker-cache-status
+  <<:                              *collect_logs
   script:
     - ./scripts/gitlab/test-cpp.sh
     - sccache -s
@@ -121,6 +119,7 @@ test-cpp:
 test-linux:
   stage:                           build
   <<:                              *docker-cache-status
+  <<:                              *collect_logs
   script:
     - ./scripts/gitlab/test-linux.sh stable
     - sccache -s
@@ -129,6 +128,7 @@ test-linux-beta:
   stage:                           build
   # only:                            *releaseable_branches
   <<:                              *docker-cache-status
+  <<:                              *collect_logs
   script:
     - ./scripts/gitlab/test-linux.sh beta
     - sccache -s
@@ -137,6 +137,7 @@ test-linux-nightly:
   stage:                           build
   # only:                            *releaseable_branches
   <<:                              *docker-cache-status
+  <<:                              *collect_logs
   script:
     - ./scripts/gitlab/test-linux.sh nightly
     - sccache -s
@@ -156,7 +157,7 @@ build-android:
 
 build-linux:                       &build-linux
   stage:                           build
-  only:                            *releaseable_branches
+  # only:                            *releaseable_branches
   <<:                              *docker-cache-status
   <<:                              *collect_artifacts
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,9 +41,10 @@ variables:
     - echo "All crate-types:"
     - grep 'parse_arguments.*--crate-type' sccache_error.log | sed -re 's/.*"--crate-type", "([^"]+)".*/\1/' | sort | uniq -c
     - echo "Non-cacheable reasons:"
-    - grep CannotCache sccache_error.log | sed -re 's/.*CannotCache\((.+)\).*/\1/' | sort | uniq -c
+    - test -x sccache_error.log && grep CannotCache sccache_error.log | sed -re 's/.*CannotCache\((.+)\).*/\1/' | sort | uniq -c
   tags:
-    - linux-docker
+    # - linux-docker
+    - qa
 
 
 cargo-check 0 3:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,15 +41,17 @@ variables:
     paths:
       - artifacts/
   before_script:
-    # RUST_LOG=sccache::server=debug
+    # save just logs from sccache server: RUST_LOG=sccache::server=debug
+    # set SCCACHE_DIR per job name to avoid data race condition until it'll be fixed
     - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log
-        RUST_LOG=sccache
+        RUST_LOG=sccache::server=trace
         SCCACHE_CACHE_SIZE=50G
         SCCACHE_DIR=/ci-cache/parity-ethereum/sccache/${CI_JOB_NAME}
         sccache --start-server
     - sccache -s
   after_script:
     # sccache debug info
+    - echo "sccache --show-stats"
     - if test -e sccache_error.log;
       then
         echo "All crate-types:";
@@ -65,9 +67,7 @@ variables:
     - find . -name "*.log"
     - find . -name "*.log" | xargs tar --append -f ./artifacts/logs.tar
   tags:
-    # - linux-docker
-    - qa
-
+    - linux-docker
 
 cargo-check 0 3:
   stage:                           test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,12 +36,14 @@ variables:
     CARGO_HOME:                    "/ci-cache/parity-ethereum/cargo/${CI_JOB_NAME}"
   artifacts:
     name:                          "${CI_JOB_NAME}"
-    # when:                          on_failure
     expire_in:                     7 days
     paths:
       - artifacts/
   before_script:
-    - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log RUST_LOG=sccache::server=debug sccache --start-server
+    - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log
+        RUST_LOG=sccache::server=debug
+        SCCACHE_CACHE_SIZE=50G
+        sccache --start-server
     - sccache -s
   after_script:
     # sccache debug info

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,11 +56,9 @@ variables:
         exit 0;
       fi
     # collect log files
-    - pwd
+    - mkdir -p ./artifacts
     - find . -name "*.log"
     - find . -name "*.log" | xargs tar --append -f ./artifacts/logs.tar
-    - echo "ls artifacts"
-    - ls ./artifacts
   tags:
     # - linux-docker
     - qa

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,6 +77,7 @@ variables:
     - scripts/gitlab/build-linux.sh
     - sccache -s
 
+
 cargo-check 0 3:
   stage:                           test
   <<:                              *docker-cache-status

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,8 +41,9 @@ variables:
     paths:
       - artifacts/
   before_script:
+    # RUST_LOG=sccache::server=debug
     - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log
-        RUST_LOG=sccache::server=debug
+        RUST_LOG=sccache
         SCCACHE_CACHE_SIZE=3G
         sccache --start-server
     - sccache -s

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,10 +34,19 @@ variables:
 .docker-cache-status:              &docker-cache-status
   variables:
     CARGO_HOME:                    "/ci-cache/parity-ethereum/cargo/${CI_JOB_NAME}"
+  artifacts:
+    name:                          "${CI_JOB_NAME}"
+    # when:                          on_failure
+    expire_in:                     7 days
+    paths:
+      - artifacts/
   before_script:
     - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log RUST_LOG=sccache::server=debug sccache --start-server
     - sccache -s
   after_script:
+    # collect log files
+    - find . -name "*.log" | xargs  tar --append -f ./artifacts/logs.tar
+    # sccache debug info
     - echo "All crate-types:"
     - grep 'parse_arguments.*--crate-type' sccache_error.log | sed -re 's/.*"--crate-type", "([^"]+)".*/\1/' | sort | uniq -c
     - echo "Non-cacheable reasons:"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,7 +74,7 @@ cargo-check 0 3:
   <<:                              *docker-cache-status
   <<:                              *collect_logs
   script:
-    - time cargo check --target $CARGO_TARGET --locked --no-default-features --verbose
+    - time cargo check --target $CARGO_TARGET --locked --no-default-features --verbose --color=auto
     - sccache -s
 
 cargo-check 1 3:
@@ -82,7 +82,7 @@ cargo-check 1 3:
   <<:                              *docker-cache-status
   <<:                              *collect_logs
   script:
-    - time cargo check --target $CARGO_TARGET --locked --manifest-path util/io/Cargo.toml --no-default-features --verbose
+    - time cargo check --target $CARGO_TARGET --locked --manifest-path util/io/Cargo.toml --no-default-features --verbose --color=auto
     - sccache -s
 
 cargo-check 2 3:
@@ -90,7 +90,7 @@ cargo-check 2 3:
   <<:                              *docker-cache-status
   <<:                              *collect_logs
   script:
-    - time cargo check --target $CARGO_TARGET --locked --manifest-path util/io/Cargo.toml --features "mio" --verbose
+    - time cargo check --target $CARGO_TARGET --locked --manifest-path util/io/Cargo.toml --features "mio" --verbose --color=auto
     - sccache -s
 
 cargo-audit:
@@ -98,7 +98,6 @@ cargo-audit:
   <<:                              *docker-cache-status
   script:
     - cargo audit
-    - sccache -s
 
 validate-chainspecs:
   stage:                           test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,14 +150,15 @@ test-linux-nightly:
     - scripts/gitlab/build-linux.sh
     - sccache -s
 
-build-linux:
-  <<:                              *build-on-linux
-
 build-android:
   <<:                              *build-on-linux
   image:                           parity/rust-parity-ethereum-android-build:stretch
   variables:
     CARGO_TARGET:                  armv7-linux-androideabi
+
+build-linux:
+  <<:                              *build-on-linux
+  only:                            *releaseable_branches
 
 build-linux-i386:
   <<:                              *build-on-linux

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,9 @@ variables:
   before_script:
     # save just logs from sccache server: RUST_LOG=sccache::server=debug
     # set SCCACHE_DIR per job name to avoid data race condition until it'll be fixed
+    - git status
+    - ls -l
+    # ^^ debug
     - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log
         RUST_LOG=sccache::server=trace
         SCCACHE_CACHE_SIZE=50G

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ variables:
   before_script:
     - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log
         RUST_LOG=sccache::server=debug
-        SCCACHE_CACHE_SIZE=50G
+        SCCACHE_CACHE_SIZE=5G
         sccache --start-server
     - sccache -s
   after_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,6 +69,14 @@ variables:
   tags:
     - linux-docker
 
+.build-on-linux:                   &build-on-linux
+  stage:                           build
+  <<:                              *docker-cache-status
+  <<:                              *collect_artifacts
+  script:
+    - scripts/gitlab/build-linux.sh
+    - sccache -s
+
 cargo-check 0 3:
   stage:                           test
   <<:                              *docker-cache-status
@@ -141,14 +149,6 @@ test-linux-nightly:
     - ./scripts/gitlab/test-linux.sh nightly
     - sccache -s
   allow_failure:                   true
-
-.build-on-linux:                   &build-on-linux
-  stage:                           build
-  <<:                              *docker-cache-status
-  <<:                              *collect_artifacts
-  script:
-    - scripts/gitlab/build-linux.sh
-    - sccache -s
 
 build-android:
   <<:                              *build-on-linux

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,13 +44,15 @@ variables:
     - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log RUST_LOG=sccache::server=debug sccache --start-server
     - sccache -s
   after_script:
-    # collect log files
-    - find . -name "*.log" | xargs  tar --append -f ./artifacts/logs.tar
     # sccache debug info
     - echo "All crate-types:"
     - grep 'parse_arguments.*--crate-type' sccache_error.log | sed -re 's/.*"--crate-type", "([^"]+)".*/\1/' | sort | uniq -c
     - echo "Non-cacheable reasons:"
     - test -x sccache_error.log && grep CannotCache sccache_error.log | sed -re 's/.*CannotCache\((.+)\).*/\1/' | sort | uniq -c
+    # collect log files
+    - pwd
+    - ls ./artifacts
+    - find . -name "*.log" | xargs  tar --append -f ./artifacts/logs.tar
   tags:
     # - linux-docker
     - qa

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ variables:
   variables:
     CARGO_HOME:                    "/ci-cache/parity-ethereum/cargo/${CI_JOB_NAME}"
   artifacts:
-    name:                          "${CI_JOB_NAME}"
+    name:                          "${CI_JOB_NAME}_${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}"
     when:                          always
     expire_in:                     7 days
     paths:
@@ -44,7 +44,7 @@ variables:
     # RUST_LOG=sccache::server=debug
     - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log
         RUST_LOG=sccache
-        SCCACHE_CACHE_SIZE=3G
+        SCCACHE_CACHE_SIZE=50G
         sccache --start-server
     - sccache -s
   after_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,11 +45,16 @@ variables:
     - sccache -s
   after_script:
     # sccache debug info
-    - echo "All crate-types:"
-    - grep 'parse_arguments.*--crate-type' sccache_error.log | sed -re 's/.*"--crate-type", "([^"]+)".*/\1/' | sort | uniq -c
-    - echo "Non-cacheable reasons:"
-    - test -e sccache_error.log &&
-        grep CannotCache sccache_error.log | sed -re 's/.*CannotCache\((.+)\).*/\1/' | sort | uniq -c || true
+    - if test -e sccache_error.log;
+      then
+        echo "All crate-types:";
+        grep 'parse_arguments.*--crate-type' sccache_error.log | sed -re 's/.*"--crate-type", "([^"]+)".*/\1/' | sort | uniq -c;
+        echo "Non-cacheable reasons:";
+        grep CannotCache sccache_error.log | sed -re 's/.*CannotCache\((.+)\).*/\1/' | sort | uniq -c;
+      else
+        echo "No logs from sccache";
+        exit 0;
+      fi
     # collect log files
     - pwd
     - find . -name "*.log"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,39 +31,40 @@ variables:
     paths:
       - artifacts/
 
-.docker-cache-status:              &docker-cache-status
-  variables:
-    CARGO_HOME:                    "/ci-cache/parity-ethereum/cargo/${CI_JOB_NAME}"
+.collect_logs:                     &collect_logs
   artifacts:
     name:                          "${CI_JOB_NAME}_${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}"
     when:                          always
     expire_in:                     7 days
     paths:
-      - artifacts/
+      - logs/
+
+.docker-cache-status:              &docker-cache-status
+  variables:
+    CARGO_HOME:                    "/ci-cache/parity-ethereum/cargo/${CI_JOB_NAME}"
+  <<:                              *collect_logs
+  dependencies:                    []
   before_script:
-    # save just logs from sccache server: RUST_LOG=sccache::server=debug
-    # set SCCACHE_DIR per job name to avoid data race condition until it'll be fixed
-        # SCCACHE_DIR=/ci-cache/parity-ethereum/sccache/${CI_JOB_NAME}
     - git status
     - ls -l
     - find . -name "*.log"
     # ^^ debug
-    - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log
-        RUST_LOG=sccache::server=trace
+    - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_debug.log
+        RUST_LOG=sccache::server=debug
         SCCACHE_CACHE_SIZE=50G
         SCCACHE_DIR=/ci-cache/parity-ethereum/sccache/
         sccache --start-server
     - sccache -s
   after_script:
     # sccache debug info
-    - echo "after script sccache --show-stats"
+    - sccache --start-server
     - sccache -s
-    - if test -e sccache_error.log;
+    - if test -e sccache_debug.log;
       then
         echo "All crate-types:";
-        grep 'parse_arguments.*--crate-type' sccache_error.log | sed -re 's/.*"--crate-type", "([^"]+)".*/\1/' | sort | uniq -c;
+        grep 'parse_arguments.*--crate-type' sccache_debug.log | sed -re 's/.*"--crate-type", "([^"]+)".*/\1/' | sort | uniq -c;
         echo "Non-cacheable reasons:";
-        grep CannotCache sccache_error.log | sed -re 's/.*CannotCache\((.+)\).*/\1/' | sort | uniq -c;
+        grep CannotCache sccache_debug.log | sed -re 's/.*CannotCache\((.+)\).*/\1/' | sort | uniq -c;
       else
         echo "No logs from sccache";
         exit 0;
@@ -71,7 +72,7 @@ variables:
     # collect log files
     - mkdir -p ./artifacts
     - find . -name "*.log"
-    - find . -name "*.log" | xargs tar --append -f ./artifacts/logs.tar
+    - find . -name "*.log" | xargs tar --append -f ./logs/logs_"${CI_JOB_NAME}_${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}".tar
   tags:
     - linux-docker
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,7 @@ variables:
     when:                          always
     expire_in:                     7 days
     paths:
-      - artifacts/
+      - "*.log"
   before_script:
     # RUST_LOG=sccache::server=debug
     - SCCACHE_ERROR_LOG=/builds/parity/parity-ethereum/sccache_error.log
@@ -60,9 +60,9 @@ variables:
         exit 0;
       fi
     # collect log files
-    - mkdir -p ./artifacts
-    - find . -name "*.log"
-    - find . -name "*.log" | xargs tar --append -f ./artifacts/logs.tar
+    # - mkdir -p ./artifacts
+    # - find . -name "*.log"
+    # - find . -name "*.log" | xargs tar --append -f ./artifacts/logs.tar
   tags:
     # - linux-docker
     - qa

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,7 +125,7 @@ test-linux:
 
 test-linux-beta:
   stage:                           build
-  # only:                            *releaseable_branches
+  only:                            *releaseable_branches
   <<:                              *docker-cache-status
   <<:                              *collect_logs
   script:
@@ -134,7 +134,7 @@ test-linux-beta:
 
 test-linux-nightly:
   stage:                           build
-  # only:                            *releaseable_branches
+  only:                            *releaseable_branches
   <<:                              *docker-cache-status
   <<:                              *collect_logs
   script:
@@ -142,52 +142,51 @@ test-linux-nightly:
     - sccache -s
   allow_failure:                   true
 
-build-android:
+.build-on-linux:                   &build-on-linux
   stage:                           build
-  image:                           parity/rust-parity-ethereum-android-build:stretch
-  variables:
-    CARGO_TARGET:                  armv7-linux-androideabi
-  <<:                              *docker-cache-status
-  <<:                              *collect_artifacts
-  script:
-    - scripts/gitlab/build-linux.sh
-  tags:
-    - linux-docker
-
-build-linux:                       &build-linux
-  stage:                           build
-  # only:                            *releaseable_branches
   <<:                              *docker-cache-status
   <<:                              *collect_artifacts
   script:
     - scripts/gitlab/build-linux.sh
     - sccache -s
 
+build-linux:
+  <<:                              *build-on-linux
+
+build-android:
+  <<:                              *build-on-linux
+  image:                           parity/rust-parity-ethereum-android-build:stretch
+  variables:
+    CARGO_TARGET:                  armv7-linux-androideabi
+
 build-linux-i386:
-  <<:                              *build-linux
+  <<:                              *build-on-linux
+  only:                            *releaseable_branches
   image:                           parity/rust-parity-ethereum-build:i386
   variables:
     CARGO_TARGET:                  i686-unknown-linux-gnu
 
 build-linux-arm64:
-  <<:                              *build-linux
+  <<:                              *build-on-linux
+  only:                            *releaseable_branches
   image:                           parity/rust-parity-ethereum-build:arm64
   variables:
     CARGO_TARGET:                  aarch64-unknown-linux-gnu
 
 build-linux-armhf:
-  <<:                              *build-linux
+  <<:                              *build-on-linux
+  only:                            *releaseable_branches
   image:                           parity/rust-parity-ethereum-build:armhf
   variables:
     CARGO_TARGET:                  armv7-unknown-linux-gnueabihf
 
 build-darwin:
   stage:                           build
-  only:                            *releaseable_branches
   <<:                              *collect_artifacts
+  only:                            *releaseable_branches
   variables:
     CARGO_TARGET:                  x86_64-apple-darwin
-    CARGO_HOME:                      "${CI_PROJECT_DIR}/.cargo"
+    CARGO_HOME:                    "${CI_PROJECT_DIR}/.cargo"
     CC:                            gcc
     CXX:                           g++
   script:

--- a/parity-clib/examples/cpp/CMakeLists.txt
+++ b/parity-clib/examples/cpp/CMakeLists.txt
@@ -9,7 +9,7 @@ ExternalProject_Add(
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
-    COMMAND cargo build -p parity-clib --verbose --color=auto    # Note: use --release in a real project
+    COMMAND cargo build -p parity-clib --verbose --color=always    # Note: use --release in a real project
     BINARY_DIR "${CMAKE_SOURCE_DIR}/../../../target"
     INSTALL_COMMAND ""
     LOG_BUILD ON)

--- a/parity-clib/examples/cpp/CMakeLists.txt
+++ b/parity-clib/examples/cpp/CMakeLists.txt
@@ -9,7 +9,7 @@ ExternalProject_Add(
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
-    COMMAND cargo build -p parity-clib --verbose     # Note: use --release in a real project
+    COMMAND cargo build -p parity-clib --verbose --color=auto    # Note: use --release in a real project
     BINARY_DIR "${CMAKE_SOURCE_DIR}/../../../target"
     INSTALL_COMMAND ""
     LOG_BUILD ON)

--- a/parity-clib/examples/cpp/CMakeLists.txt
+++ b/parity-clib/examples/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 include(ExternalProject)
 include_directories("${CMAKE_SOURCE_DIR}/../..")
-set (CMAKE_CXX_STANDARD 11) # Enfore C++11
+set (CMAKE_CXX_STANDARD 11) # Enforce C++11
 add_executable(parity-example main.cpp)
 
 ExternalProject_Add(
@@ -9,7 +9,7 @@ ExternalProject_Add(
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
-    COMMAND cargo build -p parity-clib      # Note: use --release in a real project
+    COMMAND cargo build -p parity-clib --verbose     # Note: use --release in a real project
     BINARY_DIR "${CMAKE_SOURCE_DIR}/../../../target"
     INSTALL_COMMAND ""
     LOG_BUILD ON)

--- a/parity/delme.rs
+++ b/parity/delme.rs
@@ -1,0 +1,1 @@
+# someshit

--- a/parity/delme.rs
+++ b/parity/delme.rs
@@ -1,1 +1,2 @@
 # someshit
+# even more

--- a/parity/delme.rs
+++ b/parity/delme.rs
@@ -1,2 +1,0 @@
-# someshit
-# even more

--- a/scripts/gitlab/build-linux.sh
+++ b/scripts/gitlab/build-linux.sh
@@ -18,13 +18,13 @@ cat .cargo/config
 echo "_____ Building target: "$CARGO_TARGET" _____"
 if [ "${CARGO_TARGET}" = "armv7-linux-androideabi" ]
 then
-  time cargo build --target $CARGO_TARGET --verbose --release -p parity-clib --features final
+  time cargo build --target $CARGO_TARGET --verbose --color=auto --release -p parity-clib --features final
 else
-  time cargo build --target $CARGO_TARGET --verbose --release --features final
-  time cargo build --target $CARGO_TARGET --verbose --release -p evmbin
-  time cargo build --target $CARGO_TARGET --verbose --release -p ethstore-cli
-  time cargo build --target $CARGO_TARGET --verbose --release -p ethkey-cli
-  time cargo build --target $CARGO_TARGET --verbose --release -p whisper-cli
+  time cargo build --target $CARGO_TARGET --verbose --color=auto --release --features final
+  time cargo build --target $CARGO_TARGET --verbose --color=auto --release -p evmbin
+  time cargo build --target $CARGO_TARGET --verbose --color=auto --release -p ethstore-cli
+  time cargo build --target $CARGO_TARGET --verbose --color=auto --release -p ethkey-cli
+  time cargo build --target $CARGO_TARGET --verbose --color=auto --release -p whisper-cli
 fi
 
 echo "_____ Post-processing binaries _____"

--- a/scripts/gitlab/build-linux.sh
+++ b/scripts/gitlab/build-linux.sh
@@ -18,13 +18,13 @@ cat .cargo/config
 echo "_____ Building target: "$CARGO_TARGET" _____"
 if [ "${CARGO_TARGET}" = "armv7-linux-androideabi" ]
 then
-  time cargo build --target $CARGO_TARGET --release -p parity-clib --features final
+  time cargo build --target $CARGO_TARGET --verbose --release -p parity-clib --features final
 else
-  time cargo build --target $CARGO_TARGET --release --features final
-  time cargo build --target $CARGO_TARGET --release -p evmbin
-  time cargo build --target $CARGO_TARGET --release -p ethstore-cli
-  time cargo build --target $CARGO_TARGET --release -p ethkey-cli
-  time cargo build --target $CARGO_TARGET --release -p whisper-cli
+  time cargo build --target $CARGO_TARGET --verbose --release --features final
+  time cargo build --target $CARGO_TARGET --verbose --release -p evmbin
+  time cargo build --target $CARGO_TARGET --verbose --release -p ethstore-cli
+  time cargo build --target $CARGO_TARGET --verbose --release -p ethkey-cli
+  time cargo build --target $CARGO_TARGET --verbose --release -p whisper-cli
 fi
 
 echo "_____ Post-processing binaries _____"

--- a/scripts/gitlab/build-linux.sh
+++ b/scripts/gitlab/build-linux.sh
@@ -18,13 +18,13 @@ cat .cargo/config
 echo "_____ Building target: "$CARGO_TARGET" _____"
 if [ "${CARGO_TARGET}" = "armv7-linux-androideabi" ]
 then
-  time cargo build --target $CARGO_TARGET --verbose --color=auto --release -p parity-clib --features final
+  time cargo build --target $CARGO_TARGET --verbose --color=always --release -p parity-clib --features final
 else
-  time cargo build --target $CARGO_TARGET --verbose --color=auto --release --features final
-  time cargo build --target $CARGO_TARGET --verbose --color=auto --release -p evmbin
-  time cargo build --target $CARGO_TARGET --verbose --color=auto --release -p ethstore-cli
-  time cargo build --target $CARGO_TARGET --verbose --color=auto --release -p ethkey-cli
-  time cargo build --target $CARGO_TARGET --verbose --color=auto --release -p whisper-cli
+  time cargo build --target $CARGO_TARGET --verbose --color=always --release --features final
+  time cargo build --target $CARGO_TARGET --verbose --color=always --release -p evmbin
+  time cargo build --target $CARGO_TARGET --verbose --color=always --release -p ethstore-cli
+  time cargo build --target $CARGO_TARGET --verbose --color=always --release -p ethkey-cli
+  time cargo build --target $CARGO_TARGET --verbose --color=always --release -p whisper-cli
 fi
 
 echo "_____ Post-processing binaries _____"

--- a/scripts/gitlab/build-windows.sh
+++ b/scripts/gitlab/build-windows.sh
@@ -14,11 +14,11 @@ echo "RUSTC_WRAPPER:    " $RUSTC_WRAPPER
 echo "SCCACHE_DIR:      " $SCCACHE_DIR
 
 echo "_____ Building target: "$CARGO_TARGET" _____"
-time cargo build --target $CARGO_TARGET --release --features final
-time cargo build --target $CARGO_TARGET --release -p evmbin
-time cargo build --target $CARGO_TARGET --release -p ethstore-cli
-time cargo build --target $CARGO_TARGET --release -p ethkey-cli
-time cargo build --target $CARGO_TARGET --release -p whisper-cli
+time cargo build --target $CARGO_TARGET --verbose --release --features final
+time cargo build --target $CARGO_TARGET --verbose --release -p evmbin
+time cargo build --target $CARGO_TARGET --verbose --release -p ethstore-cli
+time cargo build --target $CARGO_TARGET --verbose --release -p ethkey-cli
+time cargo build --target $CARGO_TARGET --verbose --release -p whisper-cli
 
 echo "__________Sign binaries__________"
 scripts/gitlab/sign-win.cmd $keyfile $certpass target/$CARGO_TARGET/release/parity.exe

--- a/scripts/gitlab/test-linux.sh
+++ b/scripts/gitlab/test-linux.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# ARGUMENT $1 Rust flavor to run test with (stable/beta/nightly)
+
 echo "________Running test-linux.sh________"
 set -e # fail on any error
 set -u # treat unset variables as error
@@ -7,6 +9,9 @@ FEATURES="json-tests,ci-skip-tests"
 OPTIONS="--release"
 #use nproc `linux only
 THREADS=$(nproc)
+
+rustup default $1
+rustup show
 
 echo "________Running Parity Full Test Suite________"
 time cargo test $OPTIONS --features "$FEATURES" --locked --all --target $CARGO_TARGET --verbose -- --test-threads $THREADS

--- a/scripts/gitlab/test-linux.sh
+++ b/scripts/gitlab/test-linux.sh
@@ -14,4 +14,4 @@ rustup default $1
 rustup show
 
 echo "________Running Parity Full Test Suite________"
-time cargo test $OPTIONS --features "$FEATURES" --locked --all --target $CARGO_TARGET --verbose --color=auto -- --test-threads $THREADS
+time cargo test $OPTIONS --features "$FEATURES" --locked --all --target $CARGO_TARGET --verbose --color=always -- --test-threads $THREADS

--- a/scripts/gitlab/test-linux.sh
+++ b/scripts/gitlab/test-linux.sh
@@ -9,4 +9,4 @@ OPTIONS="--release"
 THREADS=$(nproc)
 
 echo "________Running Parity Full Test Suite________"
-time cargo test $OPTIONS --features "$FEATURES" --locked --all --target $CARGO_TARGET -- --test-threads $THREADS
+time cargo test $OPTIONS --features "$FEATURES" --locked --all --target $CARGO_TARGET --verbose -- --test-threads $THREADS

--- a/scripts/gitlab/test-linux.sh
+++ b/scripts/gitlab/test-linux.sh
@@ -14,4 +14,4 @@ rustup default $1
 rustup show
 
 echo "________Running Parity Full Test Suite________"
-time cargo test $OPTIONS --features "$FEATURES" --locked --all --target $CARGO_TARGET --verbose -- --test-threads $THREADS
+time cargo test $OPTIONS --features "$FEATURES" --locked --all --target $CARGO_TARGET --verbose --color=auto -- --test-threads $THREADS

--- a/scripts/gitlab/validate-chainspecs.sh
+++ b/scripts/gitlab/validate-chainspecs.sh
@@ -6,7 +6,7 @@ echo "________Running validate_chainspecs.sh________"
 ERR=0
 
 echo "________Validate chainspecs________"
-time cargo build --release -p chainspec
+time cargo build --release -p chainspec --verbose
 
 for spec in ethcore/res/*.json; do
     if ! ./target/release/chainspec "$spec"; then ERR=1; fi

--- a/scripts/gitlab/validate-chainspecs.sh
+++ b/scripts/gitlab/validate-chainspecs.sh
@@ -6,7 +6,7 @@ echo "________Running validate_chainspecs.sh________"
 ERR=0
 
 echo "________Validate chainspecs________"
-time cargo build --release -p chainspec --verbose --color=auto
+time cargo build --release -p chainspec --verbose --color=always
 
 for spec in ethcore/res/*.json; do
     if ! ./target/release/chainspec "$spec"; then ERR=1; fi

--- a/scripts/gitlab/validate-chainspecs.sh
+++ b/scripts/gitlab/validate-chainspecs.sh
@@ -6,7 +6,7 @@ echo "________Running validate_chainspecs.sh________"
 ERR=0
 
 echo "________Validate chainspecs________"
-time cargo build --release -p chainspec --verbose
+time cargo build --release -p chainspec --verbose --color=auto
 
 for spec in ethcore/res/*.json; do
     if ! ./target/release/chainspec "$spec"; then ERR=1; fi


### PR DESCRIPTION
- Rust nightly and beta tests are back and shiny, will run during the nightly build
- all test and build jobs changed to run with `--verbose --color=always`
- max cache size raised to 50 Gib
- log files are collected for linux jobs and uploaded to GitLab artifacts. But I didn't figure out how to have two `artifacts:` sections in one job, so for `build` stage logs will still be uploaded, but with the `&collect_artifacts` rule (`on_success` and `1 mos`).

> So I was testing pipelines with per-job `sccache` caching, thinking it was a last resort.
It turned out it was not necessary to resort to such extreme measures:
Random compilation failure bug seems to appear only when the max cache size allocated is exceeded, and fail happens when one job removes an arbitrary artifact and then the next job wants to remove the same one, but doesn't find it.

Another problem I thought was connected with caching, some tests were failing. At first I thought it's due to caching, but per-job isolation showed that it's not the caching problem.

As a bonus, we (with Niklas help) have found 2 flaky tests.