### PR TITLE
fix issue with compilation when 'slow-blocks' feature enabled

### DIFF
--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -271,7 +271,7 @@ impl<'x> OpenBlock<'x> {
 			let took = start.elapsed();
 			let took_ms = took.as_secs() * 1000 + took.subsec_nanos() as u64 / 1000000;
 			if took > time::Duration::from_millis(slow_tx) {
-				warn!("Heavy ({} ms) transaction in block {:?}: {:?}", took_ms, self.block.header().number(), hash);
+				warn!("Heavy ({} ms) transaction in block {:?}: {:?}", took_ms, self.block.header.number(), hash);
 			}
 			debug!(target: "tx", "Transaction {:?} took: {} ms", hash, took_ms);
 		}


### PR DESCRIPTION
While debugging an unrelated issue, came across this when I wasn't able to run the tests for 'slow-blocks'


- change call to a `header()` function to the field `header`