### PR TITLE
Constantinople HF on POA Core

### DIFF
--- a/ethcore/res/ethereum/poacore.json
+++ b/ethcore/res/ethereum/poacore.json
@@ -35,7 +35,6 @@
 		"eip211Transition": "0x0",
 		"eip214Transition": "0x0",
 		"eip658Transition": "0x0",
-
 		"eip145Transition": 8582254,
 		"eip1014Transition": 8582254,
 		"eip1052Transition": 8582254

--- a/ethcore/res/ethereum/poacore.json
+++ b/ethcore/res/ethereum/poacore.json
@@ -34,7 +34,11 @@
 		"eip140Transition": "0x0",
 		"eip211Transition": "0x0",
 		"eip214Transition": "0x0",
-		"eip658Transition": "0x0"
+		"eip658Transition": "0x0",
+
+		"eip145Transition": 8582254,
+		"eip1014Transition": 8582254,
+		"eip1052Transition": 8582254
 	},
 	"genesis": {
 		"seal": {


### PR DESCRIPTION
Enable Fixed Constantinople/St.Petersfork Hard Fork on POA Core network at block 8582254 (~ April 29, 2019).
Original PR in POA repository: https://github.com/poanetwork/poa-chain-spec/pull/110
