### PR TITLE
Updated Bn128PairingImpl to use optimized batch pairing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,11 +264,13 @@ dependencies = [
 [[package]]
 name = "bn"
 version = "0.4.4"
-source = "git+https://github.com/paritytech/bn#2a71dbde5ca93451c8da2135767896a64483759e"
+source = "git+https://github.com/paritytech/bn#6beba2ed6c9351622f9e948ccee4063846b2b39a"
 dependencies = [
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crunchy 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/ethcore/src/builtin.rs
+++ b/ethcore/src/builtin.rs
@@ -498,7 +498,7 @@ impl Impl for Bn128PairingImpl {
 
 impl Bn128PairingImpl {
 	fn execute_with_error(&self, input: &[u8], output: &mut BytesRef) -> Result<(), Error> {
-		use bn::{AffineG1, AffineG2, Fq, Fq2, pairing, G1, G2, Gt, Group};
+		use bn::{AffineG1, AffineG2, Fq, Fq2, pairing_batch, G1, G2, Gt, Group};
 
 		let elements = input.len() / 192; // (a, b_a, b_b - each 64-byte affine coordinates)
 		let ret_val = if input.len() == 0 {
@@ -539,7 +539,7 @@ impl Bn128PairingImpl {
 				vals.push((a, b));
 			};
 
-			let mul = vals.into_iter().fold(Gt::one(), |s, (a, b)| s * pairing(a, b));
+			let mul = pairing_batch(&vals);
 
 			if mul == Gt::one() {
 				U256::one()


### PR DESCRIPTION
Hello!  

This is a small change to the `Bn128PairingImpl` method that takes advantage of the new `pairing_batch` method in the `bn` crate (added in [commit 67df95d06683b99d4308af20f9adc31497afcece](https://github.com/paritytech/bn/commit/67df95d06683b99d4308af20f9adc31497afcece).  

This provides an approximate 2x increase in the speed of the algorithm, when multiple pairings are being computed at once.