### PR TITLE
stable 2.4.6

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -255,6 +255,7 @@ publish-docs:
   except:
     - nightly
   cache:                            {}
+  dependencies:                     []
   script:
     - scripts/gitlab/publish-docs.sh
   tags:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,6 +1284,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-cache 0.1.0",
+ "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2351,6 +2352,15 @@ dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4648,6 +4658,7 @@ dependencies = [
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
+"checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,7 +2454,7 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic_hook 0.1.0",
- "parity-ethereum 2.4.5",
+ "parity-ethereum 2.4.6",
  "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "parity-ethereum"
-version = "2.4.5"
+version = "2.4.6"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2537,7 +2537,7 @@ dependencies = [
  "parity-rpc 1.12.0",
  "parity-runtime 0.1.0",
  "parity-updater 1.12.0",
- "parity-version 2.4.5",
+ "parity-version 2.4.6",
  "parity-whisper 0.1.0",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2688,7 +2688,7 @@ dependencies = [
  "parity-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-runtime 0.1.0",
  "parity-updater 1.12.0",
- "parity-version 2.4.5",
+ "parity-version 2.4.6",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2787,7 +2787,7 @@ dependencies = [
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-hash-fetch 1.12.0",
  "parity-path 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-version 2.4.5",
+ "parity-version 2.4.6",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "2.4.5"
+version = "2.4.6"
 dependencies = [
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Parity Ethereum client"
 name = "parity-ethereum"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "2.4.5"
+version = "2.4.6"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 

--- a/ethcore/evm/Cargo.toml
+++ b/ethcore/evm/Cargo.toml
@@ -14,6 +14,7 @@ vm = { path = "../vm" }
 keccak-hash = "0.1"
 parking_lot = "0.7"
 memory-cache = { path = "../../util/memory-cache" }
+num-bigint = "0.2"
 
 [dev-dependencies]
 rustc-hex = "1.0"

--- a/ethcore/evm/benches/basic.rs
+++ b/ethcore/evm/benches/basic.rs
@@ -45,7 +45,9 @@ criterion_group!(
 	mem_gas_calculation_same_usize,
 	mem_gas_calculation_same_u256,
 	mem_gas_calculation_increasing_usize,
-	mem_gas_calculation_increasing_u256
+	mem_gas_calculation_increasing_u256,
+	blockhash_mulmod_small,
+	blockhash_mulmod_large,
 );
 criterion_main!(basic);
 
@@ -147,6 +149,54 @@ fn mem_gas_calculation_increasing(gas: U256, b: &mut Bencher) {
 		let vm = factory.create(params, ext.schedule(), 0);
 
 		result(vm.exec(&mut ext).ok().unwrap())
+	});
+}
+
+fn blockhash_mulmod_small(b: &mut Criterion) {
+	b.bench_function("blockhash_mulmod_small", |b| {
+		let factory = Factory::default();
+		let mut ext = FakeExt::new();
+
+		let address = Address::from_str("0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6").unwrap();
+
+		b.iter(|| {
+			let code = black_box(
+				"6080604052348015600f57600080fd5b5060005a90505b60c881111560de5760017effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80095060017effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80095060017effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80095060017effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80095060017effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8009505a90506016565b506035806100ed6000396000f3fe6080604052600080fdfea165627a7a72305820bde4a0ac6d0fac28fc879244baf8a6a0eda514bc95fb7ecbcaaebf2556e2687c0029".from_hex().unwrap()
+			);
+
+			let mut params = ActionParams::default();
+			params.address = address.clone();
+			params.gas = U256::from(4_000u64);
+			params.code = Some(Arc::new(code.clone()));
+
+			let vm = factory.create(params, ext.schedule(), 0);
+
+			result(vm.exec(&mut ext).ok().unwrap())
+		});
+	});
+}
+
+fn blockhash_mulmod_large(b: &mut Criterion) {
+	b.bench_function("blockhash_mulmod_large", |b| {
+		let factory = Factory::default();
+		let mut ext = FakeExt::new();
+
+		let address = Address::from_str("0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6").unwrap();
+
+		b.iter(|| {
+			let code = black_box(
+				"608060405234801561001057600080fd5b5060005a90505b60c8811115610177577efffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff17efffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff08009507efffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff17efffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff08009507efffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff17efffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff08009507efffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff17efffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff08009507efffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff17efffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff08009505a9050610017565b506035806101866000396000f3fe6080604052600080fdfea165627a7a72305820dcaec306f67bb96f3044fff25c9af2ec66f01d0954d0656964f046f42f2780670029".from_hex().unwrap()
+			);
+
+			let mut params = ActionParams::default();
+			params.address = address.clone();
+			params.gas = U256::from(4_000u64);
+			params.code = Some(Arc::new(code.clone()));
+
+			let vm = factory.create(params, ext.schedule(), 0);
+
+			result(vm.exec(&mut ext).ok().unwrap())
+		});
 	});
 }
 

--- a/ethcore/evm/src/lib.rs
+++ b/ethcore/evm/src/lib.rs
@@ -24,6 +24,7 @@ extern crate vm;
 extern crate keccak_hash as hash;
 extern crate memory_cache;
 extern crate parity_bytes as bytes;
+extern crate num_bigint;
 
 #[macro_use]
 extern crate lazy_static;

--- a/ethcore/res/ethereum/kovan.json
+++ b/ethcore/res/ethereum/kovan.json
@@ -7,17 +7,31 @@
 				"stepDuration": "0x4",
 				"blockReward": "0x4563918244F40000",
 				"validators": {
-					"list": [
-						"0x00D6Cc1BA9cf89BD2e58009741f4F7325BAdc0ED",
-						"0x00427feae2419c15b89d1c21af10d1b6650a4d3d",
-						"0x4Ed9B08e6354C70fE6F8CB0411b0d3246b424d6c",
-						"0x0020ee4Be0e2027d76603cB751eE069519bA81A1",
-						"0x0010f94b296a852aaac52ea6c5ac72e03afd032d",
-						"0x007733a1FE69CF3f2CF989F81C7b4cAc1693387A",
-						"0x00E6d2b931F55a3f1701c7389d592a7778897879",
-						"0x00e4a10650e5a6D6001C38ff8E64F97016a1645c",
-						"0x00a0a24b9f0e5ec7aa4c7389b8302fd0123194de"
-					]
+					"multi": {
+						"0": {
+							"list": [
+								"0x00D6Cc1BA9cf89BD2e58009741f4F7325BAdc0ED",
+								"0x00427feae2419c15b89d1c21af10d1b6650a4d3d",
+								"0x4Ed9B08e6354C70fE6F8CB0411b0d3246b424d6c",
+								"0x0020ee4Be0e2027d76603cB751eE069519bA81A1",
+								"0x0010f94b296a852aaac52ea6c5ac72e03afd032d",
+								"0x007733a1FE69CF3f2CF989F81C7b4cAc1693387A",
+								"0x00E6d2b931F55a3f1701c7389d592a7778897879",
+								"0x00e4a10650e5a6D6001C38ff8E64F97016a1645c",
+								"0x00a0a24b9f0e5ec7aa4c7389b8302fd0123194de"
+							]
+						},
+						"10960440": {
+							"list": [
+								"0x00D6Cc1BA9cf89BD2e58009741f4F7325BAdc0ED",
+								"0x0010f94b296a852aaac52ea6c5ac72e03afd032d",
+								"0x00a0a24b9f0e5ec7aa4c7389b8302fd0123194de"
+							]
+						},
+						"10960500": {
+							"safeContract": "0xaE71807C1B0a093cB1547b682DC78316D945c9B8"
+						}
+					}
 				},
 				"validateScoreTransition": "0x41a3c4",
 				"validateStepTransition": "0x16e360",
@@ -5367,6 +5381,7 @@
 		}
 	},
 	"nodes": [
+		"enode://f6e37b943bad3a78cb8589b1798d30d210ffd39cfcd2c8f2de4f098467fd49c667980100d919da7ca46cd50505d30989abda87f0b9339377de13d6592c22caf8@34.198.49.72:30303",
 		"enode://56abaf065581a5985b8c5f4f88bd202526482761ba10be9bfdcd14846dd01f652ec33fde0f8c0fd1db19b59a4c04465681fcef50e11380ca88d25996191c52de@40.71.221.215:30303",
 		"enode://d07827483dc47b368eaf88454fb04b41b7452cf454e194e2bd4c14f98a3278fed5d819dbecd0d010407fc7688d941ee1e58d4f9c6354d3da3be92f55c17d7ce3@52.166.117.77:30303",
 		"enode://38e6e7fd416293ed120d567a2675fe078c0205ab0671abf16982ce969823bd1f3443d590c18b321dfae7dcbe1f6ba98ef8702f255c3c9822a188abb82c53adca@51.77.66.187:30303",

--- a/ethcore/res/ethereum/poacore.json
+++ b/ethcore/res/ethereum/poacore.json
@@ -34,7 +34,10 @@
 		"eip140Transition": "0x0",
 		"eip211Transition": "0x0",
 		"eip214Transition": "0x0",
-		"eip658Transition": "0x0"
+		"eip658Transition": "0x0",
+		"eip145Transition": 8582254,
+		"eip1014Transition": 8582254,
+		"eip1052Transition": 8582254
 	},
 	"genesis": {
 		"seal": {

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for Parity Ethereum version string (via env CARGO_PKG_VERSION)
-version = "2.4.5"
+version = "2.4.6"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 


### PR DESCRIPTION
should make a release for poa and kovan

- [x] fix(whisper expiry): current time + work + ttl (#10587) 
- [x] Constantinople HF on POA Core (#10606) 
- [x] evm: add some mulmod benches (#10600) 
- [x] Update kovan.json to switch validator set to POA Consensus Contracts (#10628)
- [x] Fix publish docs (#10635) 