### PR TITLE
[whisper] Move needed aes_gcm crypto in-crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,7 +2504,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2861,9 +2861,9 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memzero 0.1.0",
  "ordered-float 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3370,13 +3370,15 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.14.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3482,7 +3484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sct 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3521,7 +3523,7 @@ name = "sct"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ring 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3656,6 +3658,11 @@ dependencies = [
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stable_deref_trait"
@@ -4399,7 +4406,7 @@ name = "webpki"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ring 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4752,7 +4759,7 @@ dependencies = [
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 "checksum relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-"checksum ring 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)" = "be5386a5f59e5f5bcaea38b50ad26c09e3918a0abc0610640b3be5cfd85d6894"
+"checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
 "checksum rlp 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "524c5ad554859785dfc8469df3ed5e0b5784d4d335877ed47c8d90fc0eb238fe"
 "checksum rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "16d1effe9845d54f90e7be8420ee49e5c94623140b97ee4bc6fb5bfddb745720"
 "checksum rpassword 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b273c91bd242ca03ad6d71c143b6f17a48790e61f21a6c78568fa2b6774a24a4"
@@ -4788,6 +4795,7 @@ dependencies = [
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d"
 "checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
+"checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00caf261d6f90f588f8450b8e1230fa0d5be49ee6140fdfbcb55335aff350970"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"

--- a/whisper/Cargo.toml
+++ b/whisper/Cargo.toml
@@ -9,7 +9,7 @@ bitflags = "0.9"
 byteorder = "1.0.0"
 ethereum-types = "0.4"
 ethcore-network = { path = "../util/network" }
-parity-crypto = "0.3.0"
+ring = "0.14.6"
 ethkey = { path = "../accounts/ethkey" }
 hex = "0.2"
 log = "0.4"

--- a/whisper/src/aes_gcm/mod.rs
+++ b/whisper/src/aes_gcm/mod.rs
@@ -1,0 +1,113 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+use ring;
+
+/// AES GCM encryptor.
+pub struct Encryptor<'a> {
+    key: ring::aead::SealingKey,
+    ad: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Encryptor<'a> {
+    pub fn aes_256_gcm(key: &[u8; 32]) -> Result<Encryptor<'a>, ring::error::Unspecified> {
+        let sk = ring::aead::SealingKey::new(&ring::aead::AES_256_GCM, key)?;
+        Ok(Encryptor {
+            key: sk,
+            ad: &[],
+            offset: 0,
+        })
+    }
+
+    /// Optional offset value. Only the slice `[offset..]` will be encrypted.
+    pub fn offset(&mut self, off: usize) -> &mut Self {
+        self.offset = off;
+        self
+    }
+
+    /// Please note that the pair (key, nonce) must never be reused. Using random nonces
+    /// limits the number of messages encrypted with the same key to 2^32 (cf. [[1]])
+    ///
+    /// [1]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
+    pub fn encrypt(&self, nonce: &[u8; 12], mut data: Vec<u8>) -> Result<Vec<u8>, ring::error::Unspecified> {
+        if self.offset > data.len() {
+            return Err(ring::error::Unspecified)
+        }
+        let tag_len = ring::aead::AES_256_GCM.tag_len();
+        data.extend(::std::iter::repeat(0).take(tag_len));
+        let nonce = ring::aead::Nonce::assume_unique_for_key(*nonce);
+        let aad = ring::aead::Aad::from(self.ad);
+        let len = ring::aead::seal_in_place(&self.key, nonce, aad, &mut data[self.offset ..], tag_len)?;
+        data.truncate(self.offset + len);
+        Ok(data)
+    }
+}
+
+/// AES GCM decryptor.
+pub struct Decryptor<'a> {
+    key: ring::aead::OpeningKey,
+    ad: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Decryptor<'a> {
+    pub fn aes_256_gcm(key: &[u8; 32]) -> Result<Decryptor<'a>, ring::error::Unspecified> {
+        let ok = ring::aead::OpeningKey::new(&ring::aead::AES_256_GCM, key)?;
+        Ok(Decryptor {
+            key: ok,
+            ad: &[],
+            offset: 0,
+        })
+    }
+
+    pub fn decrypt(&self, nonce: &[u8; 12], mut data: Vec<u8>) -> Result<Vec<u8>, ring::error::Unspecified> {
+        if self.offset > data.len() {
+            return Err(ring::error::Unspecified)
+        }
+        let nonce = ring::aead::Nonce::assume_unique_for_key(*nonce);
+        let aad = ring::aead::Aad::from(self.ad);
+        let len = ring::aead::open_in_place(&self.key, nonce, aad, 0, &mut data[self.offset ..])?.len();
+        data.truncate(self.offset + len);
+        Ok(data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Encryptor, Decryptor};
+
+    #[test]
+    fn aes_gcm_256() {
+        let secret = b"12345678901234567890123456789012";
+        let nonce = b"123456789012";
+        let message = b"So many books, so little time";
+
+        let ciphertext = Encryptor::aes_256_gcm(secret)
+            .unwrap()
+            .encrypt(nonce, message.to_vec())
+            .unwrap();
+
+        assert!(ciphertext != message);
+
+        let plaintext = Decryptor::aes_256_gcm(secret)
+            .unwrap()
+            .decrypt(nonce, ciphertext)
+            .unwrap();
+
+        assert_eq!(plaintext, message)
+    }
+}

--- a/whisper/src/lib.rs
+++ b/whisper/src/lib.rs
@@ -20,7 +20,6 @@
 #![cfg_attr(feature = "time_checked_add", feature(time_checked_add))]
 
 extern crate byteorder;
-extern crate parity_crypto as crypto;
 extern crate ethcore_network as network;
 extern crate ethereum_types;
 extern crate ethkey;
@@ -29,6 +28,7 @@ extern crate memzero;
 extern crate ordered_float;
 extern crate parking_lot;
 extern crate rand;
+extern crate ring;
 extern crate rlp;
 extern crate serde;
 extern crate slab;
@@ -60,3 +60,5 @@ pub use self::net::{Network, MessageHandler};
 pub mod message;
 pub mod net;
 pub mod rpc;
+
+mod aes_gcm;

--- a/whisper/src/rpc/crypto.rs
+++ b/whisper/src/rpc/crypto.rs
@@ -16,7 +16,7 @@
 
 //! Encryption schemes supported by RPC layer.
 
-use crypto::aes_gcm::{Encryptor, Decryptor};
+use aes_gcm::{Encryptor, Decryptor};
 use ethkey::crypto::ecies;
 use ethereum_types::H256;
 use ethkey::{self, Public, Secret};
@@ -77,7 +77,7 @@ impl EncryptionInstance {
 			EncryptionInner::AES(key, nonce, encode) => {
 				match encode {
 					AesEncode::AppendedNonce => {
-						let mut enc = Encryptor::aes_256_gcm(&*key).ok()?;
+						let enc = Encryptor::aes_256_gcm(&*key).ok()?;
 						let mut buf = enc.encrypt(&nonce, plain.to_vec()).ok()?;
 						buf.extend(&nonce[..]);
 						Some(buf)


### PR DESCRIPTION
In the latest `parity-crypto` release (upcoming 0.4), the aes GCM features were removed (done to remove the dependency on `ring`).
This PR adds the bare minimum crypto needed for Whisper directly to the crate itself and as those were the only features needed from `parity-crypto`, removes the dependency on that crate altogether.

Fixes (part of) #10645.