### PR TITLE
Reset blockchain properly

### DIFF
--- a/ethcore/blockchain/src/blockchain.rs
+++ b/ethcore/blockchain/src/blockchain.rs
@@ -668,21 +668,6 @@ impl BlockChain {
 		self.db.key_value().read_with_cache(db::COL_EXTRA, &self.block_details, parent).map_or(false, |d| d.children.contains(hash))
 	}
 
-	/// fetches the list of blocks from best block to n, and n's parent hash
-	/// where n > 0
-	pub fn block_headers_from_best_block(&self, n: u32) -> Option<(Vec<encoded::Header>, H256)> {
-		let mut blocks = Vec::with_capacity(n as usize);
-		let mut hash = self.best_block_hash();
-
-		for _ in 0..n {
-			let current_hash = self.block_header_data(&hash)?;
-			hash = current_hash.parent_hash();
-			blocks.push(current_hash);
-		}
-
-		Some((blocks, hash))
-	}
-
 	/// Returns a tree route between `from` and `to`, which is a tuple of:
 	///
 	/// - a vector of hashes of all blocks, ordered from `from` to `to`.
@@ -867,6 +852,14 @@ impl BlockChain {
 			}, is_best);
 			true
 		}
+	}
+
+	/// clears all caches for testing purposes
+	pub fn clear_cache(&self) {
+		self.block_bodies.write().clear();
+		self.block_details.write().clear();
+		self.block_hashes.write().clear();
+		self.block_headers.write().clear();
 	}
 
 	/// Update the best ancient block to the given hash, after checking that

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1343,12 +1343,14 @@ impl BlockChainReset for Client {
 				(&mut db_transaction, ::db::COL_EXTRA, &hash.number());
 		}
 
-		let last_hash = blocks_to_delete.last().expect("blocks_to_delete isn't empty; qed").hash();
+		let last_hash = blocks_to_delete.last()
+			.expect("num is > 0; blocks_to_delete can't be empty; qed")
+			.hash();
 		let mut best_block_details = Readable::read::<BlockDetails, H264>(
 			&**self.db.read().key_value(),
 			::db::COL_EXTRA,
 			&best_block_hash
-		).expect("best_block_details should exist; qed");
+		).expect("block was previously imported; best_block_details should exist; qed");
 		// remove the last block as a child so that it can be re-imported
 		// ethcore/blockchain/src/blockchain.rs:667
 		best_block_details.children.retain(|h| *h != last_hash);

--- a/ethcore/src/tests/client.rs
+++ b/ethcore/src/tests/client.rs
@@ -27,7 +27,7 @@ use types::filter::Filter;
 use types::view;
 use types::views::BlockView;
 
-use client::{BlockChainClient, Client, ClientConfig, BlockId, ChainInfo, BlockInfo, PrepareOpenBlock, ImportSealedBlock, ImportBlock};
+use client::{BlockChainClient, BlockChainReset, Client, ClientConfig, BlockId, ChainInfo, BlockInfo, PrepareOpenBlock, ImportSealedBlock, ImportBlock};
 use ethereum;
 use executive::{Executive, TransactOptions};
 use miner::{Miner, PendingOrdering, MinerService};
@@ -365,4 +365,23 @@ fn transaction_proof() {
 
 	assert_eq!(state.balance(&Address::default()).unwrap(), 5.into());
 	assert_eq!(state.balance(&address).unwrap(), 95.into());
+}
+
+#[test]
+fn reset_blockchain() {
+	let client = get_test_client_with_blocks(get_good_dummy_block_seq(20));
+
+	assert!(client.block_header(BlockId::Number(20)).is_some());
+
+	assert!(client.reset(5).is_ok());
+
+	client.chain().clear_cache();
+
+	assert!(client.block_header(BlockId::Number(20)).is_none());
+	assert!(client.block_header(BlockId::Number(19)).is_none());
+	assert!(client.block_header(BlockId::Number(18)).is_none());
+	assert!(client.block_header(BlockId::Number(17)).is_none());
+	assert!(client.block_header(BlockId::Number(16)).is_none());
+
+	assert!(client.block_header(BlockId::Number(15)).is_some());
 }

--- a/ethcore/src/tests/client.rs
+++ b/ethcore/src/tests/client.rs
@@ -369,9 +369,10 @@ fn transaction_proof() {
 
 #[test]
 fn reset_blockchain() {
-	let client = get_test_client_with_blocks(get_good_dummy_block_seq(20));
-
+	let client = get_test_client_with_blocks(get_good_dummy_block_seq(19));
+	// 19 + genesis block
 	assert!(client.block_header(BlockId::Number(20)).is_some());
+	assert_eq!(client.block_header(BlockId::Number(20)).unwrap().hash(), client.best_block_header().hash());
 
 	assert!(client.reset(5).is_ok());
 

--- a/parity/blockchain.rs
+++ b/parity/blockchain.rs
@@ -730,6 +730,10 @@ fn execute_export_state(cmd: ExportState) -> Result<(), String> {
 }
 
 fn execute_reset(cmd: ResetBlockchain) -> Result<(), String> {
+	if cmd.num == 0 {
+		return Err("Invalid reset argument".into())
+	}
+
 	let service = start_client(
 		cmd.dirs,
 		cmd.spec,

--- a/parity/blockchain.rs
+++ b/parity/blockchain.rs
@@ -730,10 +730,6 @@ fn execute_export_state(cmd: ExportState) -> Result<(), String> {
 }
 
 fn execute_reset(cmd: ResetBlockchain) -> Result<(), String> {
-	if cmd.num == 0 {
-		return Err("Invalid reset argument".into())
-	}
-
 	let service = start_client(
 		cmd.dirs,
 		cmd.spec,


### PR DESCRIPTION
Previously the reset blockchain feature wrongly assumed that the block hashes were the keys for `BlockDetails` in COL_EXTRA that has been corrected.
Also, there was a known issue with the reset feature where deleted blocks wouldn't be imported again because they were a "known child" of an existing block
that has also been corrected.

Should fix #10665