### PR TITLE
Don't panic if extra_data is longer than VANITY_LENGTH

### DIFF
--- a/ethcore/src/engines/clique/mod.rs
+++ b/ethcore/src/engines/clique/mod.rs
@@ -713,7 +713,7 @@ impl Engine<EthereumMachine> for Clique {
 					}
 				}
 
-				let zero_padding_len = VANITY_LENGTH - header.extra_data().len();
+				let zero_padding_len = VANITY_LENGTH.checked_sub(header.extra_data().len()).unwrap_or(0);
 				if zero_padding_len > 0 {
 					let mut resized_extra_data = header.extra_data().clone();
 					resized_extra_data.resize(VANITY_LENGTH, 0);

--- a/ethcore/src/engines/clique/mod.rs
+++ b/ethcore/src/engines/clique/mod.rs
@@ -713,7 +713,7 @@ impl Engine<EthereumMachine> for Clique {
 					}
 				}
 
-				let zero_padding_len = VANITY_LENGTH.checked_sub(header.extra_data().len()).unwrap_or(0);
+				let zero_padding_len = VANITY_LENGTH.saturating_sub(header.extra_data().len());
 				if zero_padding_len > 0 {
 					let mut resized_extra_data = header.extra_data().clone();
 					resized_extra_data.resize(VANITY_LENGTH, 0);


### PR DESCRIPTION
Seems like `extra_data().len()` can be longer than 32 (was 39 here) so this fixes that panic.