### PR TITLE
Attempt to reset on bad block (rel #10085) 

### DIFF
--- a/ethcore/src/client/bad_blocks.rs
+++ b/ethcore/src/client/bad_blocks.rs
@@ -22,6 +22,7 @@ use itertools::Itertools;
 use memory_cache::MemoryLruCache;
 use parking_lot::RwLock;
 use verification::queue::kind::blocks::Unverified;
+use client::BlockChainReset;
 
 /// Recently seen bad blocks.
 pub struct BadBlocks {
@@ -41,7 +42,7 @@ impl BadBlocks {
 	pub fn report(&self, raw: Bytes, message: String) {
 		match Unverified::from_rlp(raw) {
 			Ok(unverified) => {
-				error!(
+				/*error!(
 					target: "client",
 					"\nBad block detected: {}\nRLP: {}\nHeader: {:?}\nUncles: {}\nTransactions:{}\n",
 					message,
@@ -57,8 +58,10 @@ impl BadBlocks {
 						.enumerate()
 						.map(|(index, tx)| format!("[Tx {}] {:?}", index, tx))
 						.join("\n"),
-				);
+				);*/
 				self.last_blocks.write().insert(unverified.header.hash(), (unverified, message));
+				let num: u32 = 3;
+				BlockChainReset::reset(num);
 			},
 			Err(err) => {
 				error!(target: "client", "Bad undecodable block detected: {}\n{:?}", message, err);

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -364,7 +364,7 @@ impl Importer {
 		let parent = match client.block_header_decoded(BlockId::Hash(*header.parent_hash())) {
 			Some(h) => h,
 			None => {
-				warn!(target: "client", "Block import failed for #{} ({}): Parent not found ({}) ", header.number(), header.hash(), header.parent_hash());
+				warn!(target: "client", "Block import failed for #{} ({}): Parent not found ({})", header.number(), header.hash(), header.parent_hash());
 				return Err("Parent not found".into());
 			}
 		};
@@ -383,13 +383,13 @@ impl Importer {
 		);
 
 		if let Err(e) = verify_family_result {
-			warn!(target: "client", "Stage 3 block verification failed for #{} ({})\nError: {:?}", header.number(), header.hash(), e);
+			warn!(target: "client", "Stage 3 block verification failed for #{} ({})", header.number(), header.hash());
 			return Err(e.into());
 		};
 
 		let verify_external_result = self.verifier.verify_block_external(&header, engine);
 		if let Err(e) = verify_external_result {
-			warn!(target: "client", "Stage 4 block verification failed for #{} ({})\nError: {:?}", header.number(), header.hash(), e);
+			warn!(target: "client", "Stage 4 block verification failed for #{} ({})", header.number(), header.hash());
 			return Err(e.into());
 		};
 
@@ -414,7 +414,7 @@ impl Importer {
 		let mut locked_block = match enact_result {
 			Ok(b) => b,
 			Err(e) => {
-				warn!(target: "client", "Block import failed for #{} ({})\nError: {:?}", header.number(), header.hash(), e);
+				warn!(target: "client", "Block import failed for #{} ({})", header.number(), header.hash());
 				return Err(e.into());
 			}
 		};
@@ -430,7 +430,7 @@ impl Importer {
 
 		// Final Verification
 		if let Err(e) = self.verifier.verify_block_final(&header, &locked_block.header) {
-			warn!(target: "client", "Stage 5 block verification failed for #{} ({})\nError: {:?}", header.number(), header.hash(), e);
+			warn!(target: "client", "Stage 5 block verification failed for #{} ({})", header.number(), header.hash());
 			return Err(e.into());
 		}
 


### PR DESCRIPTION
  - What does it do?

Removes the block validation/RequiresClient duplicate error messages, as well as the bad block error messages.  It also resets the blockchain to minus 3 blocks, whenever the invalid block detected.

  - What important points reviewers should know?

The logic for creating the collection of invalid blocks is still implemented.  The `check_and_lock_block` function in `ethcore/src/client/client.rs` was printing the error and, in the case of an error, calling `report` function in `ethcore/src/client/bad_block.rs` which accepted the error message and printed the message again inside it's own error for the case of something unverified.  I commented out the `report` error printing because the header hash is ultimately still used to create a read/write lock and track the bad block.  Additionally, someone may want to use the information within the error message in the future.  

Whenever the `report` is called, the `BlockChainReset::reset` used in the CLI is also called with a parameter of `u32` 3.  We chose 3 because the issue discussion dictated such.  We were unsure if there was a way to hardcode a resync after the reset, however it seems to be a non issue due to a resync required whenever new chunks are added to the snapshot.

- Is there something left for follow-up PRs?

I don't think so.

Fixes/Related #10085 

✄ -----------------------------------------------------------------------------
