### PR TITLE
fix: aura don't add `SystemTime::now()`

### DIFF
--- a/ethcore/src/engines/clique/block_state.rs
+++ b/ethcore/src/engines/clique/block_state.rs
@@ -24,12 +24,10 @@ use engines::clique::{VoteType, DIFF_INTURN, DIFF_NOTURN, NULL_AUTHOR, SIGNING_D
 use error::{Error, BlockError};
 use ethereum_types::{Address, H64};
 use rand::Rng;
+use time_utils::CheckedSystemTime;
 use types::BlockNumber;
 use types::header::Header;
 use unexpected::Mismatch;
-
-#[cfg(not(feature = "time_checked_add"))]
-use time_utils::CheckedSystemTime;
 
 /// Type that keeps track of the state for a given vote
 // Votes that go against the proposal aren't counted since it's equivalent to not voting
@@ -268,7 +266,7 @@ impl CliqueBlockState {
 	// This is a quite bad API because we must mutate both variables even when already `inturn` fails
 	// That's why we can't return early and must have the `if-else` in the end
 	pub fn calc_next_timestamp(&mut self, timestamp: u64, period: u64) -> Result<(), Error> {
-		let inturn = UNIX_EPOCH.checked_add(Duration::from_secs(timestamp.saturating_add(period)));
+		let inturn = CheckedSystemTime::checked_add(UNIX_EPOCH, Duration::from_secs(timestamp.saturating_add(period)));
 
 		self.next_timestamp_inturn = inturn;
 

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -15,7 +15,6 @@
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 #![warn(missing_docs, unused_extern_crates)]
-#![cfg_attr(feature = "time_checked_add", feature(time_checked_add))]
 
 //! Ethcore library
 //!
@@ -101,6 +100,7 @@ extern crate rlp;
 extern crate rustc_hex;
 extern crate serde;
 extern crate stats;
+extern crate time_utils;
 extern crate triehash_ethereum as triehash;
 extern crate unexpected;
 extern crate using_queue;
@@ -150,9 +150,6 @@ extern crate fetch;
 
 #[cfg(all(test, feature = "price-info"))]
 extern crate parity_runtime;
-
-#[cfg(not(time_checked_add))]
-extern crate time_utils;
 
 pub mod block;
 pub mod builtin;

--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -40,7 +40,6 @@ use types::{BlockNumber, header::Header};
 use types::transaction::SignedTransaction;
 use verification::queue::kind::blocks::Unverified;
 
-#[cfg(not(time_checked_add))]
 use time_utils::CheckedSystemTime;
 
 /// Preprocessed block data gathered in `verify_block_unordered` call
@@ -310,7 +309,7 @@ pub fn verify_header_params(header: &Header, engine: &dyn EthEngine, is_full: bo
 		// this will resist overflow until `year 2037`
 		let max_time = SystemTime::now() + ACCEPTABLE_DRIFT;
 		let invalid_threshold = max_time + ACCEPTABLE_DRIFT * 9;
-		let timestamp = UNIX_EPOCH.checked_add(Duration::from_secs(header.timestamp()))
+		let timestamp = CheckedSystemTime::checked_add(UNIX_EPOCH, Duration::from_secs(header.timestamp()))
 			.ok_or(BlockError::TimestampOverflow)?;
 
 		if timestamp > invalid_threshold {
@@ -334,9 +333,9 @@ fn verify_parent(header: &Header, parent: &Header, engine: &dyn EthEngine) -> Re
 
 	if !engine.is_timestamp_valid(header.timestamp(), parent.timestamp()) {
 		let now = SystemTime::now();
-		let min = now.checked_add(Duration::from_secs(parent.timestamp().saturating_add(1)))
+		let min = CheckedSystemTime::checked_add(now, Duration::from_secs(parent.timestamp().saturating_add(1)))
 			.ok_or(BlockError::TimestampOverflow)?;
-		let found = now.checked_add(Duration::from_secs(header.timestamp()))
+		let found = CheckedSystemTime::checked_add(now, Duration::from_secs(header.timestamp()))
 			.ok_or(BlockError::TimestampOverflow)?;
 		return Err(From::from(BlockError::InvalidTimestamp(OutOfBounds { max: None, min: Some(min), found }.into())))
 	}


### PR DESCRIPTION
Attempt to close https://github.com/paritytech/parity-ethereum/issues/10688

In AURA we add`SystemTime::now` again which cases a Timestamp Overflow which this fixes