### PR TITLE
Revert "enable lto for release builds (#10717)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,13 +119,8 @@ name = "parity"
 
 [profile.dev]
 
-[profile.test]
-lto = false
-opt-level = 3 # makes tests slower to compile, but faster to run
-
 [profile.release]
 debug = false
-lto = true
 
 [workspace]
 # This should only list projects that are not

--- a/scripts/gitlab/test-linux.sh
+++ b/scripts/gitlab/test-linux.sh
@@ -6,7 +6,7 @@ set -e # fail on any error
 set -u # treat unset variables as error
 
 FEATURES="json-tests,ci-skip-tests"
-OPTIONS=""
+OPTIONS="--release"
 #use nproc `linux only
 THREADS=$(nproc)
 


### PR DESCRIPTION
This reverts commit 44161874ffb4959c35f60a358e648e1830ea58ed.

related https://github.com/paritytech/parity-ethereum/pull/10717