### PR TITLE
Use fewer threads for snapshotting

### DIFF
--- a/ethcore/src/snapshot/mod.rs
+++ b/ethcore/src/snapshot/mod.rs
@@ -107,7 +107,7 @@ impl Default for SnapshotConfiguration {
 	fn default() -> Self {
 		SnapshotConfiguration {
 			no_periodic: false,
-			processing_threads: ::std::cmp::max(1, num_cpus::get() / 2),
+			processing_threads: ::std::cmp::max(1, num_cpus::get_physical() / 2),
 		}
 	}
 }

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -934,7 +934,7 @@ impl Configuration {
 			no_periodic: self.args.flag_no_periodic_snapshot,
 			processing_threads: match self.args.arg_snapshot_threads {
 				Some(threads) if threads > 0 => threads,
-				_ => ::std::cmp::max(1, num_cpus::get() / 2),
+				_ => ::std::cmp::max(1, num_cpus::get_physical() / 2),
 			},
 		};
 


### PR DESCRIPTION
When taking a snapshot the current default number of threads is equal to half the number of **logical** CPUs in the system. On HT enabled CPUs this value seems a bit high, e.g. 6 snapshotting threads on a 6/12 core/hyperthread CPU. Maybe a better default value is half the number of physical cores?