### PR TITLE
Initialize private tx logger only if private tx functionality is enabled

### DIFF
--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -1461,7 +1461,7 @@ mod tests {
 			private_provider_conf: ProviderConfig {
 				validator_accounts: Default::default(),
 				signer_account: Default::default(),
-				logs_path: Some(Directories::default().base),
+				logs_path: None,
 			},
 			private_encryptor_conf: Default::default(),
 			private_tx_enabled: false,

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -1458,11 +1458,7 @@ mod tests {
 			net_settings: Default::default(),
 			ipfs_conf: Default::default(),
 			secretstore_conf: Default::default(),
-			private_provider_conf: ProviderConfig {
-				validator_accounts: Default::default(),
-				signer_account: Default::default(),
-				logs_path: None,
-			},
+			private_provider_conf: Default::default(),
 			private_encryptor_conf: Default::default(),
 			private_tx_enabled: false,
 			name: "".into(),

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -917,7 +917,10 @@ impl Configuration {
 		let provider_conf = ProviderConfig {
 			validator_accounts: to_addresses(&self.args.arg_private_validators)?,
 			signer_account: self.args.arg_private_signer.clone().and_then(|account| to_address(Some(account)).ok()),
-			logs_path: Some(dirs.base),
+			logs_path: match self.args.flag_private_enabled {
+				true => Some(dirs.base),
+				false => None,
+			}
 		};
 
 		let encryptor_conf = EncryptorConfig {


### PR DESCRIPTION
Private tx logger tried to open log file even for the case, when private tx functionality was disabled.

Closes #10726 