### PR TITLE
refactor: evmbin: CLI flag for coloured log levels. CLI flag for output to log file 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,6 +2316,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "argon2rs"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +321,16 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cgmath"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "chainspec"
 version = "0.1.0"
 dependencies = [
@@ -330,6 +345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -382,6 +398,15 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "colored"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1434,6 +1459,7 @@ dependencies = [
 name = "evmbin"
 version = "0.1.0"
 dependencies = [
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "common-types 0.1.0",
  "docopt 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1441,6 +1467,8 @@ dependencies = [
  "ethereum-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethjson 0.1.0",
  "evm 0.1.0",
+ "fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic_hook 0.1.0",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1510,6 +1538,15 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fern"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3598,6 +3635,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ring"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4755,6 +4797,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "winconsole"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rgb 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4793,6 +4846,7 @@ dependencies = [
 "checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum app_dirs 1.2.1 (git+https://github.com/paritytech/app-dirs-rs)" = "<none>"
+"checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
@@ -4825,11 +4879,13 @@ dependencies = [
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cesu8 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
+"checksum cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64a4b57c8f4e3a2e9ac07e0f6abc9c24b6fc9e1b54c3478cfb598f3d0023e51c"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0e37fba0087d9f3f4e269827a55dc511abf3e440cc097a0c154ff4e6584f988"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "6ec65ee4f9c9d16f335091d23693457ed4928657ba4982289d7fafee03bc614a"
+"checksum colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cdb90b60f2927f8d76139c72dbde7e10c3a2bc47c8594c9c7a66529f2687c03"
 "checksum combine 3.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fc1d011beeed29187b8db2ac3925c8dd4d3e87db463dc9d2d2833985388fc5bc"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum criterion 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c47d2b548c5647e1a436dc0cb78d4ebf51b6bf7ab101ed76662828bdd4d3a24a"
@@ -4877,6 +4933,7 @@ dependencies = [
 "checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fdlimit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1ee15a7050e5580b3712877157068ea713b245b080ff302ae2ca973cfcd9baa"
+"checksum fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "29d26fa0f4d433d1956746e66ec10d6bf4d6c8b93cd39965cceea7f7cc78c7dd"
 "checksum fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d1a683d1234507e4f3bf2736eeddf0de1dc65996dc0164d57eba0a74bcf29489"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -5056,6 +5113,7 @@ dependencies = [
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 "checksum relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum rgb 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)" = "4f089652ca87f5a82a62935ec6172a534066c7b97be003cc8f702ee9a7a59c92"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
 "checksum ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a"
 "checksum rlp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b0d56c1450bfbef1181fdeb78b902dc1d23178de77c23d705317508e03d1b7c"
@@ -5184,6 +5242,7 @@ dependencies = [
 "checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
+"checksum winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef84b96d10db72dd980056666d7f1e7663ce93d82fa33b63e71c966f4cf5032"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"

--- a/evmbin/Cargo.toml
+++ b/evmbin/Cargo.toml
@@ -18,7 +18,7 @@ ethereum-types = "0.6.0"
 ethjson = { path = "../json" }
 evm = { path = "../ethcore/evm" }
 fern = { version = "0.5", features = ["colored"] }
-log = { version = "0.4" }
+log = { version = "0.4", features = ["std", "serde", "max_level_trace", "release_max_level_info"] }
 panic_hook = { path = "../util/panic-hook" }
 parity-bytes = "0.1"
 rustc-hex = "1.0"

--- a/evmbin/Cargo.toml
+++ b/evmbin/Cargo.toml
@@ -10,12 +10,15 @@ path = "./src/main.rs"
 
 [dependencies]
 common-types = { path = "../ethcore/types" }
+chrono = { version = "0.4.6", features = ["serde"] }
 docopt = "1.0"
 env_logger = "0.5"
 ethcore = { path = "../ethcore", features = ["test-helpers", "json-tests", "to-pod-full"] }
 ethereum-types = "0.6.0"
 ethjson = { path = "../json" }
 evm = { path = "../ethcore/evm" }
+fern = { version = "0.5", features = ["colored"] }
+log = { version = "0.4" }
 panic_hook = { path = "../util/panic-hook" }
 parity-bytes = "0.1"
 rustc-hex = "1.0"

--- a/evmbin/README.md
+++ b/evmbin/README.md
@@ -9,7 +9,7 @@ EVM implementation for Parity.
   Copyright 2015-2019 Parity Technologies (UK) Ltd.
 
 Usage:
-    parity-evm state-test <file> [--json --std-json --std-dump-json --only NAME --chain CHAIN --std-out-only --std-err-only]
+    parity-evm state-test <file> [--json --logging LEVEL --logging-to-file --std-json --std-dump-json --only NAME --chain CHAIN --std-out-only --std-err-only]
     parity-evm stats [options]
     parity-evm stats-jsontests-vm <file>
     parity-evm [options]
@@ -35,6 +35,11 @@ State test options:
 
 General options:
     --json             Display verbose results in JSON.
+    --logging LEVEL    Log level verbosity configuration choice
+                       from highest to lowest priority (error 0, warn 1,
+                       info 2, debug 3, trace 4). Must conform to the
+                       same format as RUST_LOG [default: 0]
+    --logging-to-file  Record logs to output.log file.
     --std-json         Display results in standardized JSON format.
     --std-err-only     With --std-json redirect to err output only.
     --std-out-only     With --std-json redirect to out output only.

--- a/evmbin/res/create2callPrecompiles.json
+++ b/evmbin/res/create2callPrecompiles.json
@@ -1,0 +1,140 @@
+{
+  "create2callPrecompiles": {
+      "_info": {
+          "comment": "CALL precompiles during init code of CREATE2 contract ",
+          "filledwith": "testeth 1.5.0.dev2-73+commit.1bcd29e5",
+          "lllcversion": "Version: 0.4.26-develop.2018.9.19+commit.785cbf40.Linux.g++",
+          "source": "src/GeneralStateTestsFiller/stCreate2/create2callPrecompilesFiller.json",
+          "sourceHash": "0dcd6d7b5819f61399ecfba9a67b7518c92c426866bd5b599516c184d194e51c"
+      },
+      "env": {
+          "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+          "currentDifficulty": "0x20000",
+          "currentGasLimit": "0xe8d4a51000",
+          "currentNumber": "0x01",
+          "currentTimestamp": "0x03e8",
+          "previousHash": "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+      },
+      "post": {
+          "Constantinople": [
+              {
+                  "hash": "0x3dfdcd1d19badbbba8b0c953504e8b4685270ee5b86e155350b6ef1042c9ce43",
+                  "indexes": {
+                      "data": 0,
+                      "gas": 0,
+                      "value": 0
+                  },
+                  "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+              },
+              {
+                  "hash": "0x88803085d3420aec76078e215f67fc5f7b6f297fbe19d85c2236ad685d0fc7fc",
+                  "indexes": {
+                      "data": 1,
+                      "gas": 0,
+                      "value": 0
+                  },
+                  "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+              },
+              {
+                  "hash": "0x57181dda5c067cb31f084c4118791b40d5028c39071e83e60e7f7403d683527e",
+                  "indexes": {
+                      "data": 2,
+                      "gas": 0,
+                      "value": 0
+                  },
+                  "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+              },
+              {
+                  "hash": "0xf04c1039893eb6959354c3c16e9fe025d4b9dc3981362f79c56cc427dca0d544",
+                  "indexes": {
+                      "data": 3,
+                      "gas": 0,
+                      "value": 0
+                  },
+                  "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+              },
+              {
+                  "hash": "0x5d5db3d6c4377b34b74ecf8638f684acb220cc7ce286ae5f000ffa74faf38bae",
+                  "indexes": {
+                      "data": 4,
+                      "gas": 0,
+                      "value": 0
+                  },
+                  "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+              },
+              {
+                  "hash": "0xf8343b2e05ae120bf25947de840cedf1ca2c1bcda1cdb89d218427d8a84d4798",
+                  "indexes": {
+                      "data": 5,
+                      "gas": 0,
+                      "value": 0
+                  },
+                  "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+              },
+              {
+                  "hash": "0x305a8a8a7d9da97d14ed2259503d9373d803ea4b7fbf8c360f50b1b30a3d04ed",
+                  "indexes": {
+                      "data": 6,
+                      "gas": 0,
+                      "value": 0
+                  },
+                  "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+              },
+              {
+                  "hash": "0xde1d3953b508913c6e3e9bd412cd50daf60bb177517e5d1e8ccb0dab193aed03",
+                  "indexes": {
+                      "data": 7,
+                      "gas": 0,
+                      "value": 0
+                  },
+                  "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+              }
+          ]
+      },
+      "pre": {
+          "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+              "balance": "0x0de0b6b3a7640000",
+              "code": "",
+              "nonce": "0x00",
+              "storage": {
+              }
+          },
+          "0xaddf5374fce5edbc8e2a8697c15331677e6ebf0b": {
+              "balance": "0x00",
+              "code": "0x600035600052602035602052604035604052606035606052604060c860806000600060066207a120f260005560c85160015560e851600255",
+              "nonce": "0x00",
+              "storage": {
+              }
+          },
+          "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+              "balance": "0x00",
+              "code": "0x60003560005260203560205260403560405260603560605260803560805260a03560a05260c03560c052604061012c60806000600060066207a120f2600055604061019060606080600060076207a120f260015561012c51600a5561014c51600b55610190516014556101b051601555601454600a5414600255601554600b5414600355",
+              "nonce": "0x00",
+              "storage": {
+              }
+          }
+      },
+      "transaction": {
+          "data": [
+              "0x6000609a80601260003960006000f55000fe7f18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c600052601c6020527f73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75f6040527feeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549606052602060806080600060006001620493e0f160025560a060020a60805106600055600054321460015500",
+              "0x6000602380601260003960006000f55000fe64f34578907f6005526020600060256000600060026101f4f160025560005160005500",
+              "0x6000601a80601260003960006000f55000fe602060006000600060006003610258f160025560005160005500",
+              "0x6000602380601260003960006000f55000fe64f34578907f6000526020600060256000600060046101f4f160025560005160005500",
+              "0x6000609580601260003960006000f55000fe6001600052602060205260206040527f03fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc6060527f2efffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc6080527f2f0000000000000000000000000000000000000000000000000000000000000060965260206103e860976000600060055af26001556103e85160025500",
+              "0x6000602180601260003960006000f55000fe600160005260206000610100600060006006620927c0f160025560005160005500",
+              "0x600060b680601260003960006000f55000fe7f0f25929bcb43d5a57391564615c9e70a992b10eafa4db109709649cf48c50dd26000527f16da2f5cb6be7a0aa72c440c53c9bbdfec6c36c7d515536431b3a865468acbba6020527f1de49a4b0233273bba8146af82042d004f2085ec982397db0d97da17204cc2866040527f0217327ffc463919bef80cc166d09c6172639d8589799928761bcd9f22c903d46060526000600060806000600073addf5374fce5edbc8e2a8697c15331677e6ebf0b6207a120f25000",
+              "0x600060c580601260003960006000f55000fe7f1de49a4b0233273bba8146af82042d004f2085ec982397db0d97da17204cc2866000527f0217327ffc463919bef80cc166d09c6172639d8589799928761bcd9f22c903d4602052600060405260006060527f1de49a4b0233273bba8146af82042d004f2085ec982397db0d97da17204cc2866080527f0217327ffc463919bef80cc166d09c6172639d8589799928761bcd9f22c903d460a052600160c0526000600060e06000600073b94f5374fce5edbc8e2a8697c15331677e6ebf0b6207a120f25000"
+          ],
+          "gasLimit": [
+              "0xe4e1c0"
+          ],
+          "gasPrice": "0x01",
+          "nonce": "0x00",
+          "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+          "to": "",
+          "value": [
+              "0x01"
+          ]
+      }
+  }
+}

--- a/evmbin/res/teststate.json
+++ b/evmbin/res/teststate.json
@@ -1,0 +1,144 @@
+{
+	"add11": {
+		"env": {
+			"currentCoinbase": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+			"currentDifficulty": "0x0100",
+			"currentGasLimit": "0x01c9c380",
+			"currentNumber": "0x00",
+			"currentTimestamp": "0x01",
+			"previousHash": "5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+		},
+		"post": {
+			"EIP150": [
+				{
+					"hash": "3e6dacc1575c6a8c76422255eca03529bbf4c0dda75dfc110b22d6dc4152396f",
+					"indexes": { "data": 0, "gas": 0, "value": 0 }
+				},
+				{
+					"hash": "99a450d8ce5b987a71346d8a0a1203711f770745c7ef326912e46761f14cd764",
+					"indexes": { "data": 0, "gas": 0, "value": 1 }
+				}
+			],
+			"EIP158": [
+				{
+					"hash": "3e6dacc1575c6a8c76422255eca03529bbf4c0dda75dfc110b22d6dc4152396f",
+					"indexes": { "data": 0, "gas": 0, "value": 0 }
+				},
+				{
+					"hash": "99a450d8ce5b987a71346d8a0a1203711f770745c7ef326912e46761f14cd764",
+					"indexes": { "data": 0, "gas": 0, "value": 1 }
+				}
+			]
+		},
+		"pre": {
+			"1000000000000000000000000000000000000000": {
+				"balance": "0x0de0b6b3a7640000",
+				"code": "0x6040600060406000600173100000000000000000000000000000000000000162055730f1600055",
+				"nonce": "0x00",
+				"storage": {
+				}
+			},
+			"1000000000000000000000000000000000000001": {
+				"balance": "0x0de0b6b3a7640000",
+				"code": "0x604060006040600060027310000000000000000000000000000000000000026203d090f1600155",
+				"nonce": "0x00",
+				"storage": {
+				}
+			},
+			"1000000000000000000000000000000000000002": {
+				"balance": "0x00",
+				"code": "0x600160025533600455346007553060e6553260e8553660ec553860ee553a60f055",
+				"nonce": "0x00",
+				"storage": {
+				}
+			},
+			"a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+				"balance": "0x0de0b6b3a7640000",
+				"code": "0x",
+				"nonce": "0x00",
+				"storage": {
+				}
+			}
+		},
+		"transaction": {
+			"data": [ "" ],
+			"gasLimit": [ "285000", "100000", "6000" ],
+			"gasPrice": "0x01",
+			"nonce": "0x00",
+			"secretKey": "45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+			"to": "095e7baea6a6c7c4c2dfeb977efac326af552d87",
+			"value": [ "10", "0" ]
+		}
+	},
+	"add12": {
+		"env": {
+			"currentCoinbase": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+			"currentDifficulty": "0x0100",
+			"currentGasLimit": "0x01c9c380",
+			"currentNumber": "0x00",
+			"currentTimestamp": "0x01",
+			"previousHash": "5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+		},
+		"post": {
+			"EIP150": [
+				{
+					"hash": "3e6dacc1575c6a8c76422255eca03529bbf4c0dda75dfc110b22d6dc4152396f",
+					"indexes": { "data": 0, "gas": 0, "value": 0 }
+				},
+				{
+					"hash": "99a450d8ce5b987a71346d8a0a1203711f770745c7ef326912e46761f14cd764",
+					"indexes": { "data": 0, "gas": 0, "value": 1 }
+				}
+			],
+			"EIP158": [
+				{
+					"hash": "3e6dacc1575c6a8c76422255eca03529bbf4c0dda75dfc110b22d6dc4152396f",
+					"indexes": { "data": 0, "gas": 0, "value": 0 }
+				},
+				{
+					"hash": "99a450d8ce5b987a71346d8a0a1203711f770745c7ef326912e46761f14cd764",
+					"indexes": { "data": 0, "gas": 0, "value": 1 }
+				}
+			]
+		},
+		"pre": {
+			"1000000000000000000000000000000000000000": {
+				"balance": "0x0de0b6b3a7640000",
+				"code": "0x6040600060406000600173100000000000000000000000000000000000000162055730f1600055",
+				"nonce": "0x00",
+				"storage": {
+				}
+			},
+			"1000000000000000000000000000000000000001": {
+				"balance": "0x0de0b6b3a7640000",
+				"code": "0x604060006040600060027310000000000000000000000000000000000000026203d090f1600155",
+				"nonce": "0x00",
+				"storage": {
+				}
+			},
+			"1000000000000000000000000000000000000002": {
+				"balance": "0x00",
+				"code": "0x600160025533600455346007553060e6553260e8553660ec553860ee553a60f055",
+				"nonce": "0x00",
+				"storage": {
+				}
+			},
+			"a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+				"balance": "0x0de0b6b3a7640000",
+				"code": "0x",
+				"nonce": "0x00",
+				"storage": {
+				}
+			}
+		},
+		"transaction": {
+			"data": [ "" ],
+			"gasLimit": [ "285000", "100000", "6000" ],
+			"gasPrice": "0x01",
+			"nonce": "0x00",
+			"secretKey": "45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+			"to": "095e7baea6a6c7c4c2dfeb977efac326af552d87",
+			"value": [ "10", "0" ]
+		}
+	}
+}

--- a/evmbin/src/config/logger.rs
+++ b/evmbin/src/config/logger.rs
@@ -18,7 +18,7 @@ use fern::colors::{Color, ColoredLevelConfig};
 use log::{LevelFilter};
 use std::io;
 
-fn setup_logger(verbosity: u32, log_to_file: bool) -> Result<(), fern::InitError> {
+fn setup_logger(verbosity: u32, logging_to_file: bool) -> Result<(), fern::InitError> {
     let colors_line = ColoredLevelConfig::new()
         .error(Color::Red)
         .warn(Color::Yellow)
@@ -87,7 +87,7 @@ fn setup_logger(verbosity: u32, log_to_file: bool) -> Result<(), fern::InitError
         // We must only print to `stdout` (not `stderr`) by default.
         .chain(io::stdout());
 
-    if log_to_file {
+    if logging_to_file {
         let file_config = fern::Dispatch::new()
             .format(|out, message, record| {
                 out.finish(format_args!(
@@ -111,17 +111,17 @@ fn setup_logger(verbosity: u32, log_to_file: bool) -> Result<(), fern::InitError
 /// Initialisation of the [Log Crate](https://crates.io/crates/log) and [Fern Crate](https://docs.rs/fern/0.5.5/fern/)
 ///
 /// - Choice of log level verbosity from CLI: error (0), warn (1), info (2), debug (3), or trace (4).
-/// - Fallback to default log level that is defined in evmbin/src/main.rs.
+/// - Fallback to default logging level that is defined in evmbin/src/main.rs.
 /// - Use of logging level macros from highest priority to lowest: `error!`, `warn!`, `info!`, `debug!` and `trace!`.
 /// - [Compile time filters](https://docs.rs/log/0.4.1/log/#compile-time-filters) that override the evmbin CLI log levels
 /// are configured in evmbin/Cargo.toml. In production max log level is `info!`, whereas in development max is `trace!`.
-/// - Output to output.log when log_to_file is true.
-pub fn init_logger(pattern: &str, log_to_file: bool) -> () {
+/// - Output to output.log when logging_to_file is true.
+pub fn init_logger(pattern: &str, logging_to_file: bool) -> () {
     let verbosity: u32 = pattern.parse::<u32>().expect("parsing cannot fail; qed");
 
-    match setup_logger(verbosity, log_to_file) {
+    match setup_logger(verbosity, logging_to_file) {
         Ok(_) => {
-            println!("Success initializing logger. Verbosity: {:?}. Log to file: {}", verbosity, &log_to_file); ()
+            println!("Success initializing logger. Verbosity: {:?}. Log to file: {}", verbosity, &logging_to_file); ()
         }
         Err(e) => { println!("Error initializing logger: {}", e); }
     }

--- a/evmbin/src/config/logger.rs
+++ b/evmbin/src/config/logger.rs
@@ -1,15 +1,29 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity Ethereum.
+
+// Parity Ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
+
 use fern::colors::{Color, ColoredLevelConfig};
-
 use log::{LevelFilter};
-
 use std::io;
 
 fn setup_logger(verbosity: u32, log_to_file: bool) -> Result<(), fern::InitError> {
     let colors_line = ColoredLevelConfig::new()
         .error(Color::Red)
         .warn(Color::Yellow)
-        .info(Color::White)
-        .debug(Color::White)
+        .info(Color::BrightBlack)
+        .debug(Color::BrightBlack)
         .trace(Color::BrightBlack);
 
     let colors_level = colors_line.clone()
@@ -96,7 +110,7 @@ fn setup_logger(verbosity: u32, log_to_file: bool) -> Result<(), fern::InitError
 
 /// Initialisation of the [Log Crate](https://crates.io/crates/log) and [Fern Crate](https://docs.rs/fern/0.5.5/fern/)
 ///
-/// - Choice of log level verbosity from evmbin CLI: error (0), warn (1), info (2), debug (3), or trace (4).
+/// - Choice of log level verbosity from CLI: error (0), warn (1), info (2), debug (3), or trace (4).
 /// - Fallback to default log level that is defined in evmbin/src/main.rs.
 /// - Use of logging level macros from highest priority to lowest: `error!`, `warn!`, `info!`, `debug!` and `trace!`.
 /// - [Compile time filters](https://docs.rs/log/0.4.1/log/#compile-time-filters) that override the evmbin CLI log levels

--- a/evmbin/src/config/logger.rs
+++ b/evmbin/src/config/logger.rs
@@ -1,0 +1,101 @@
+use fern::colors::{Color, ColoredLevelConfig};
+
+use log::{LevelFilter};
+
+use std::io;
+
+fn setup_logger(verbosity: u32, log_to_file: bool) -> Result<(), fern::InitError> {
+    let colors_line = ColoredLevelConfig::new()
+        .error(Color::Red)
+        .warn(Color::Yellow)
+        .info(Color::White)
+        .debug(Color::White)
+        .trace(Color::BrightBlack);
+
+    let colors_level = colors_line.clone()
+        .info(Color::Green);
+
+    let mut base_config = fern::Dispatch::new();
+
+    base_config = match verbosity {
+        0 => {
+            base_config
+            .level(LevelFilter::Error)
+            .level_for("pretty_colored", LevelFilter::Error)
+            // .chain(io::stderr())
+        }
+        1 => {
+            base_config
+            .level(LevelFilter::Warn)
+            .level_for("pretty_colored", LevelFilter::Warn)
+        },
+        2 => {
+            base_config
+            .level(LevelFilter::Info)
+            .level_for("pretty_colored", LevelFilter::Info)
+        },
+        3 => {
+            base_config
+            .level(LevelFilter::Debug)
+            .level_for("pretty_colored", LevelFilter::Debug)
+        },
+        _ => {
+            base_config
+            .level(LevelFilter::Trace)
+            .level_for("pretty_colored", LevelFilter::Trace)
+        },
+    };
+
+    let format_config = fern::Dispatch::new()
+        .format(move |out, message, record| {
+            out.finish(format_args!(
+                "{color_line}[{date}][{target}][{level}{color_line}] {message}\x1B[0m",
+                color_line = format_args!("\x1B[{}m", colors_line.get_color(&record.level()).to_fg_str()),
+                date = chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+                level = colors_level.color(record.level()),
+                target = record.target(),
+                message = message
+            ))
+        })
+        .chain(io::stdout());
+
+    if (log_to_file) {
+        let file_config = fern::Dispatch::new()
+            .format(|out, message, record| {
+                out.finish(format_args!(
+                    "{}[{}][{}] {}",
+                    chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+                    record.level(),
+                    record.target(),
+                    message
+                ))
+            })
+            .chain(fern::log_file("output.log")?);
+
+        base_config.chain(file_config).chain(format_config).apply()?;
+    } else {
+        base_config.chain(format_config).apply()?;
+    }
+
+    Ok(())
+}
+
+/// Initialisation of the [Log Crate](https://crates.io/crates/log) and [Fern Crate](https://docs.rs/fern/0.5.5/fern/)
+///
+/// Choice of log level verbosity from evmbin CLI: error (0), warn (1), info (2), debug (3), or trace (4).
+/// Fallback to default log level that is defined in evmbin/src/main.rs.
+/// Use of logging level macros from highest priority to lowest: `error!`, `warn!`, `info!`, `debug!` and `trace!`.
+/// Errors configured to go to stderr, whilst others go to stdout.
+/// [Compile time filters](https://docs.rs/log/0.4.1/log/#compile-time-filters) that override the evmbin CLI log levels
+/// are configured in evmbin/Cargo.toml.
+/// i.e. `log = { version = "0.4", features = ["max_level_debug", "release_max_level_warn"] }`
+pub fn init_logger(pattern: &str, log_to_file: bool) -> () {
+    let verbosity: u32 = pattern.parse::<u32>().expect("parsing cannot fail; qed");
+
+    match setup_logger(verbosity, log_to_file) {
+        Ok(_) => {
+            println!("Success initializing logger. Verbosity: {:?}. Log to file: {}", verbosity, &log_to_file); ()
+        }
+        Err(e) => { println!("Error initializing logger: {}", e); }
+    }
+}

--- a/evmbin/src/config/logger.rs
+++ b/evmbin/src/config/logger.rs
@@ -59,7 +59,7 @@ fn setup_logger(verbosity: u32, log_to_file: bool) -> Result<(), fern::InitError
         })
         .chain(io::stdout());
 
-    if (log_to_file) {
+    if log_to_file {
         let file_config = fern::Dispatch::new()
             .format(|out, message, record| {
                 out.finish(format_args!(

--- a/evmbin/src/config/mod.rs
+++ b/evmbin/src/config/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity Ethereum.
+
+// Parity Ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
+
+//! VM logger configuration.
+
+pub mod logger;

--- a/evmbin/src/display/json.rs
+++ b/evmbin/src/display/json.rs
@@ -23,6 +23,7 @@ use ethereum_types::{U256, H256, BigEndianHash};
 use bytes::ToPretty;
 use ethcore::trace;
 
+use config::{logger};
 use display;
 use info as vm;
 
@@ -62,7 +63,7 @@ pub struct TraceData<'a> {
 }
 
 #[derive(Serialize, Debug)]
-pub struct InitMessage<'a> {
+pub struct MessageInitial<'a> {
 	action: &'a str,
 	test: &'a str,
 }
@@ -117,15 +118,15 @@ impl vm::Informant for Informant {
 	type Sink = ();
 
 	fn before_test(&mut self, name: &str, action: &str) {
-		let init_message =
-			InitMessage {
+		let message_init =
+			MessageInitial {
 				action,
 				test: &name,
 			}
 		;
 
-		let s = serde_json::to_string(&init_message).expect("serialization cannot fail; qed");
-		println!("{}", s);
+		let serialized_message_init = serde_json::to_string(&message_init).expect("serialization cannot fail; qed");
+		info!("Message initial: {}", serialized_message_init);
 	}
 
 	fn set_gas(&mut self, gas: U256) {
@@ -138,7 +139,7 @@ impl vm::Informant for Informant {
 		match result {
 			Ok(success) => {
 				for trace in success.traces.unwrap_or_else(Vec::new) {
-					println!("{}", trace);
+					trace!("Trace success: {}", trace);
 				}
 
 				let message_success =
@@ -149,11 +150,12 @@ impl vm::Informant for Informant {
 					}
 				;
 
-				println!("{:?}", message_success);
+				let serialized_message_success = serde_json::to_string(&message_success).expect("serialization cannot fail; qed");
+				info!("Message success: {}", serialized_message_success);
 			},
 			Err(failure) => {
 				for trace in failure.traces.unwrap_or_else(Vec::new) {
-					println!("{}", trace);
+					trace!("Trace failure: {}", trace);
 				}
 
 				let message_failure =
@@ -164,7 +166,8 @@ impl vm::Informant for Informant {
 					}
 				;
 
-				println!("{:?}", message_failure);
+				let serialized_message_failure = serde_json::to_string(&message_failure).expect("serialization cannot fail; qed");
+				error!("Message failure: {}", serialized_message_failure);
 			},
 		}
 	}

--- a/evmbin/src/display/json.rs
+++ b/evmbin/src/display/json.rs
@@ -138,7 +138,7 @@ impl vm::Informant for Informant {
 		match result {
 			Ok(success) => {
 				for trace in success.traces.unwrap_or_else(Vec::new) {
-					trace!("{}", trace);
+					info!("{}", trace);
 				}
 
 				let message_success =
@@ -154,7 +154,7 @@ impl vm::Informant for Informant {
 			},
 			Err(failure) => {
 				for trace in failure.traces.unwrap_or_else(Vec::new) {
-					warn!("{}", trace);
+					error!("{}", trace);
 				}
 
 				let message_failure =

--- a/evmbin/src/display/json.rs
+++ b/evmbin/src/display/json.rs
@@ -23,7 +23,6 @@ use ethereum_types::{U256, H256, BigEndianHash};
 use bytes::ToPretty;
 use ethcore::trace;
 
-use config::{logger};
 use display;
 use info as vm;
 

--- a/evmbin/src/display/json.rs
+++ b/evmbin/src/display/json.rs
@@ -138,7 +138,7 @@ impl vm::Informant for Informant {
 		match result {
 			Ok(success) => {
 				for trace in success.traces.unwrap_or_else(Vec::new) {
-					trace!("Trace success: {}", trace);
+					trace!("{}", trace);
 				}
 
 				let message_success =
@@ -154,7 +154,7 @@ impl vm::Informant for Informant {
 			},
 			Err(failure) => {
 				for trace in failure.traces.unwrap_or_else(Vec::new) {
-					trace!("Trace failure: {}", trace);
+					warn!("{}", trace);
 				}
 
 				let message_failure =

--- a/evmbin/src/display/simple.rs
+++ b/evmbin/src/display/simple.rs
@@ -19,7 +19,6 @@
 use ethcore::trace;
 use bytes::ToPretty;
 
-use config::{logger};
 use display;
 use info as vm;
 

--- a/evmbin/src/display/simple.rs
+++ b/evmbin/src/display/simple.rs
@@ -39,9 +39,9 @@ impl vm::Informant for Informant {
 	fn finish(result: vm::RunResult<Self::Output>, _sink: &mut Self::Sink) {
 		match result {
 			Ok(success) => {
-        info!("Output: 0x{}", success.output.to_hex());
-        info!("Gas used: {:x}", success.gas_used);
-        info!("Time: {}", display::format_time(&success.time));
+				info!("Output: 0x{}", success.output.to_hex());
+				info!("Gas used: {:x}", success.gas_used);
+				info!("Time: {}", display::format_time(&success.time));
 			},
 			Err(failure) => {
 				error!("Error: {}", failure.error);

--- a/evmbin/src/display/simple.rs
+++ b/evmbin/src/display/simple.rs
@@ -19,6 +19,7 @@
 use ethcore::trace;
 use bytes::ToPretty;
 
+use config::{logger};
 use display;
 use info as vm;
 
@@ -26,12 +27,41 @@ use info as vm;
 #[derive(Default)]
 pub struct Informant;
 
+#[derive(Serialize, Debug)]
+pub struct MessageInitial<'a> {
+	action: &'a str,
+	test: &'a str,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageSuccess<'a> {
+	output: &'a str,
+	gas_used: &'a str,
+	time: &'a u64,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageFailure<'a> {
+	error: &'a str,
+	time: &'a u64,
+}
+
 impl vm::Informant for Informant {
 
 	type Sink = ();
 
 	fn before_test(&mut self, name: &str, action: &str) {
-		println!("Test: {} ({})", name, action);
+		let message_init =
+			MessageInitial {
+				action,
+				test: &name,
+			}
+		;
+
+		let serialized_message_init = serde_json::to_string(&message_init).expect("serialization cannot fail; qed");
+		info!("Message initial: {}", serialized_message_init);
 	}
 
 	fn clone_sink(&self) -> Self::Sink { () }
@@ -39,13 +69,27 @@ impl vm::Informant for Informant {
 	fn finish(result: vm::RunResult<Self::Output>, _sink: &mut Self::Sink) {
 		match result {
 			Ok(success) => {
-				println!("Output: 0x{}", success.output.to_hex());
-				println!("Gas used: {:x}", success.gas_used);
-				println!("Time: {}", display::format_time(&success.time));
+				let message_success =
+					MessageSuccess {
+						output: &format!("0x{}", success.output.to_hex()),
+						gas_used: &format!("{:#x}", success.gas_used),
+						time: &display::as_micros(&success.time),
+					}
+				;
+
+				let serialized_message_success = serde_json::to_string(&message_success).expect("serialization cannot fail; qed");
+				info!("Message success: {}", serialized_message_success);
 			},
 			Err(failure) => {
-				println!("Error: {}", failure.error);
-				println!("Time: {}", display::format_time(&failure.time));
+				let message_failure =
+					MessageFailure {
+						error: &failure.error.to_string(),
+						time: &display::as_micros(&failure.time),
+					}
+				;
+
+				let serialized_message_failure = serde_json::to_string(&message_failure).expect("serialization cannot fail; qed");
+				error!("Message failure: {}", serialized_message_failure);
 			},
 		}
 	}

--- a/evmbin/src/display/simple.rs
+++ b/evmbin/src/display/simple.rs
@@ -31,7 +31,7 @@ impl vm::Informant for Informant {
 	type Sink = ();
 
 	fn before_test(&mut self, name: &str, action: &str) {
-    info!("Test: {} ({})", name, action);
+		info!("Test: {} ({})", name, action);
 	}
 
 	fn clone_sink(&self) -> Self::Sink { () }

--- a/evmbin/src/display/std_json.rs
+++ b/evmbin/src/display/std_json.rs
@@ -164,8 +164,7 @@ impl<Trace: Writer, Out: Writer> Informant<Trace, Out> {
 				}
 			;
 
-			let serialized_dump_data = serde_json::to_string(&dump_data).expect("serialization cannot fail; qed");
-			info!("Dump data: {}", serialized_dump_data);
+			writeln!(trace_sink, "{:?}", dump_data).expect("The sink must be writeable.");
 		}
 	}
 
@@ -183,8 +182,7 @@ impl<Trace: Writer, Out: Writer> vm::Informant for Informant<Trace, Out> {
 			}
 		;
 
-		let serialized_message_init = serde_json::to_string(&message_init).expect("serialization cannot fail; qed");
-		info!("Message initial: {}", serialized_message_init);
+		writeln!(&mut self.out_sink, "{:?}", message_init).expect("The sink must be writeable.");
 	}
 
 	fn set_gas(&mut self, _gas: U256) {}
@@ -203,9 +201,8 @@ impl<Trace: Writer, Out: Writer> vm::Informant for Informant<Trace, Out> {
 					}
 				;
 
-				// TODO - do we need `trace_sink` with this change?
-				let serialized_trace_data_state_root = serde_json::to_string(&trace_data_state_root).expect("serialization cannot fail; qed");
-				info!("State root: {}", serialized_trace_data_state_root);
+				writeln!(trace_sink, "{:?}", trace_data_state_root)
+					.expect("The sink must be writeable.");
 
 				Self::dump_state_into(trace_sink, success.state_root, &success.end_state);
 
@@ -217,9 +214,7 @@ impl<Trace: Writer, Out: Writer> vm::Informant for Informant<Trace, Out> {
 					}
 				;
 
-				// TODO - do we need `out_sink` with this change?
-				let serialized_message_success = serde_json::to_string(&message_success).expect("serialization cannot fail; qed");
-				info!("Message success: {}", serialized_message_success);
+				writeln!(out_sink, "{:?}", message_success).expect("The sink must be writeable.");
 			},
 			Err(failure) => {
 				let message_failure =
@@ -232,9 +227,7 @@ impl<Trace: Writer, Out: Writer> vm::Informant for Informant<Trace, Out> {
 
 				Self::dump_state_into(trace_sink, failure.state_root, &failure.end_state);
 
-				// TODO - do we need `out_sink` with this change?
-				let serialized_message_failure = serde_json::to_string(&message_failure).expect("serialization cannot fail; qed");
-				info!("Message failure: {}", serialized_message_failure);
+				writeln!(out_sink, "{:?}", message_failure).expect("The sink must be writeable.");
 			},
 		}
 	}
@@ -261,9 +254,9 @@ impl<Trace: Writer, Out: Writer> trace::VMTracer for Informant<Trace, Out> {
 				}
 			;
 
-			// TODO - do we need `informant.trace_sink` with this change?
 			let serialized_trace_data = serde_json::to_string(&trace_data).expect("serialization cannot fail; qed");
-			info!("Trace data: {}", serialized_trace_data);
+
+			writeln!(&mut informant.trace_sink, "{}", serialized_trace_data).expect("The sink must be writeable.");
 		});
 		true
 	}

--- a/evmbin/src/display/std_json.rs
+++ b/evmbin/src/display/std_json.rs
@@ -15,6 +15,13 @@
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Standardized JSON VM output.
+//!
+//! - Sinks are used because we may be representing nested calls that need to be buffered until the calls are complete
+//! so the state after each call is printed in order (i.e. contract A calls contract B using opcode `CALL (A, B)`
+//! with an amount of gas left). This is the reason why we need to write to the buffer with `writeln` instead of using
+//! macros like `info!` that print directly to stdout, otherwise tests associated with `trace_next_instruction` fail.
+//! - Raw JSON must be printed to stdout.
+//! - In `before_test` we may write directly to stdout since all data is already in order.
 
 use std::collections::HashMap;
 use std::io;

--- a/evmbin/src/display/std_json.rs
+++ b/evmbin/src/display/std_json.rs
@@ -23,7 +23,6 @@ use ethereum_types::{H256, U256, BigEndianHash};
 use bytes::ToPretty;
 use ethcore::{trace, pod_state};
 
-use config::{logger};
 use display;
 use info as vm;
 

--- a/evmbin/src/main.rs
+++ b/evmbin/src/main.rs
@@ -111,7 +111,8 @@ General options:
     --json             Display verbose results in JSON.
     --log-level LEVEL  Log level verbosity configuration choice
                        from highest to lowest priority (error 0, warn 1,
-                       info 2, debug 3, trace 4).
+                       info 2, debug 3, trace 4). Must conform to the
+                       same format as RUST_LOG [default: 0]
     --log-to-file      Record logs to output.log file.
     --std-json         Display results in standardized JSON format.
     --std-err-only     With --std-json redirect to err output only.
@@ -128,8 +129,7 @@ fn main() {
 
 	let args: Args = Docopt::new(USAGE).and_then(|d| d.deserialize()).unwrap_or_else(|e| e.exit());
 
-	let default_log_level: &str = &String::from("2");
-	let log_pattern = args.clone().flag_log_level.unwrap_or(default_log_level.to_string());
+	let log_pattern = args.clone().flag_log_level;
 	let log_to_file = args.clone().flag_log_to_file;
 	config::logger::init_logger(&log_pattern, log_to_file);
 
@@ -290,7 +290,7 @@ struct Args {
 	flag_input: Option<String>,
 	flag_chain: Option<String>,
 	flag_json: bool,
-	flag_log_level: Option<String>,
+	flag_log_level: String,
 	flag_log_to_file: bool,
 	flag_std_json: bool,
 	flag_std_dump_json: bool,

--- a/evmbin/src/main.rs
+++ b/evmbin/src/main.rs
@@ -83,7 +83,7 @@ EVM implementation for Parity.
   Copyright 2015-2019 Parity Technologies (UK) Ltd.
 
 Usage:
-    parity-evm state-test <file> [--json --log-level LEVEL --log-to-file --std-json --std-dump-json --only NAME --chain CHAIN --std-out-only --std-err-only]
+    parity-evm state-test <file> [--json --logging LEVEL --logging-to-file --std-json --std-dump-json --only NAME --chain CHAIN --std-out-only --std-err-only]
     parity-evm stats [options]
     parity-evm stats-jsontests-vm <file>
     parity-evm [options]
@@ -109,11 +109,11 @@ State test options:
 
 General options:
     --json             Display verbose results in JSON.
-    --log-level LEVEL  Log level verbosity configuration choice
+    --logging LEVEL    Log level verbosity configuration choice
                        from highest to lowest priority (error 0, warn 1,
                        info 2, debug 3, trace 4). Must conform to the
                        same format as RUST_LOG [default: 0]
-    --log-to-file      Record logs to output.log file.
+    --logging-to-file  Record logs to output.log file.
     --std-json         Display results in standardized JSON format.
     --std-err-only     With --std-json redirect to err output only.
     --std-out-only     With --std-json redirect to out output only.
@@ -129,9 +129,9 @@ fn main() {
 
 	let args: Args = Docopt::new(USAGE).and_then(|d| d.deserialize()).unwrap_or_else(|e| e.exit());
 
-	let log_pattern = args.clone().flag_log_level;
-	let log_to_file = args.clone().flag_log_to_file;
-	config::logger::init_logger(&log_pattern, log_to_file);
+	let logging_level = args.clone().flag_logging;
+	let logging_to_file = args.clone().flag_logging_to_file;
+	config::logger::init_logger(&logging_level, logging_to_file);
 
 	if args.cmd_state_test {
 		run_state_test(args)
@@ -290,8 +290,8 @@ struct Args {
 	flag_input: Option<String>,
 	flag_chain: Option<String>,
 	flag_json: bool,
-	flag_log_level: String,
-	flag_log_to_file: bool,
+	flag_logging: String,
+	flag_logging_to_file: bool,
 	flag_std_json: bool,
 	flag_std_dump_json: bool,
 	flag_std_err_only: bool,
@@ -393,6 +393,8 @@ mod tests {
 			"--to", "0000000000000000000000000000000000000004",
 			"--code", "05",
 			"--input", "06",
+			"--logging", "0",
+			"--logging-to-file",
 			"--chain", "./testfile", "--std-err-only", "--std-out-only"
 		]);
 
@@ -407,6 +409,8 @@ mod tests {
 		assert_eq!(args.to(), Ok(Address::from_low_u64_be(4)));
 		assert_eq!(args.code(), Ok(Some(vec![05])));
 		assert_eq!(args.data(), Ok(Some(vec![06])));
+		assert_eq!(args.flag_logging, "0".to_string());
+		assert_eq!(args.flag_logging_to_file, true);
 		assert_eq!(args.flag_chain, Some("./testfile".to_owned()));
 	}
 

--- a/evmbin/src/main.rs
+++ b/evmbin/src/main.rs
@@ -128,7 +128,7 @@ fn main() {
 
 	let args: Args = Docopt::new(USAGE).and_then(|d| d.deserialize()).unwrap_or_else(|e| e.exit());
 
-	let default_log_level: &str = &String::from("4");
+	let default_log_level: &str = &String::from("2");
 	let log_pattern = args.clone().flag_log_level.unwrap_or(default_log_level.to_string());
 	let log_to_file = args.clone().flag_log_to_file;
 	config::logger::init_logger(&log_pattern, log_to_file);


### PR DESCRIPTION
Extension of PR https://github.com/paritytech/parity-ethereum/pull/10657.
Not to be merged prior to https://github.com/paritytech/parity-ethereum/pull/10657 and https://github.com/paritytech/parity-ethereum/pull/10742

- [x] Temporarily added evmbin/res/create2callPrecompiles.json  and evmbin/res/teststate.json  just as input files for testing the code with CLI commands
- [x] Use fern crate for log level colours
- [x] Add CLI flag `--logging` to choose log level (consistent with parity-ethereum CLI)
- [x] Add CLI flag `--logging-to-file` to save outputs to output.log
- [x] Restrict use of logging levels in production (i.e. `cargo build -p evmbin --release`) to `info!` in Cargo.toml. In development users may use `debug!` or `trace!`. 
- [x] **Question 1** I made changes that to std_json.rs to add colours and log levels, but the tests failed so I reverted the changes in commit https://github.com/paritytech/parity-ethereum/commit/a687150c41af5fb6c8d12ca7cdde4588bf860e81. Were those changes on the right track? 
**ANS: Note that we cannot convert writing to the stdout buffer with `writeln!` in std_json.rs to writing directly to stdout by use of macros with color like `info!`. See the module doc comments in std_json.rs**

The changes may be tested as follows:

**std-json**
```
cargo build -p evmbin --release;
./target/release/parity-evm state-test ./evmbin/res/create2callPrecompiles.json --only create2callPrecompiles --chain Constantinople --logging 2 --std-json --std-dump-json
```

**json**
```
cargo build -p evmbin --release;
./target/release/parity-evm state-test ./evmbin/res/create2callPrecompiles.json --only create2callPrecompiles --chain Constantinople --logging 2 --json
```

**output to a file output.log**
```
cargo build -p evmbin --release;
./target/release/parity-evm state-test ./evmbin/res/create2callPrecompiles.json --only create2callPrecompiles --chain Constantinople --logging 2 --json --logging-to-file
```