### PR TITLE
Move Engine::register_client to be before other I/O handler registration

### DIFF
--- a/ethcore/light/src/client/service.rs
+++ b/ethcore/light/src/client/service.rs
@@ -75,9 +75,8 @@ impl<T: ChainDataFetcher> Service<T> {
 			io_service.channel(),
 			cache,
 		)?);
-
-		io_service.register_handler(Arc::new(ImportBlocks(client.clone()))).map_err(Error::Io)?;
 		spec.engine.register_client(Arc::downgrade(&client) as _);
+		io_service.register_handler(Arc::new(ImportBlocks(client.clone()))).map_err(Error::Io)?;
 
 		Ok(Service {
 			client,

--- a/ethcore/service/src/service.rs
+++ b/ethcore/service/src/service.rs
@@ -113,6 +113,7 @@ impl ClientService {
 			miner.clone(),
 			io_service.channel(),
 		)?;
+		spec.engine.register_client(Arc::downgrade(&client) as _);
 		miner.set_io_channel(io_service.channel());
 		miner.set_in_chain_checker(&client.clone());
 
@@ -147,8 +148,6 @@ impl ClientService {
 			snapshot: snapshot.clone(),
 		});
 		io_service.register_handler(client_io)?;
-
-		spec.engine.register_client(Arc::downgrade(&client) as _);
 
 		Ok(ClientService {
 			io_service: Arc::new(io_service),


### PR DESCRIPTION
This moves `Engine::register_client` to be right after client instantiation. Previously we register some I/O handlers first. Those I/O handlers may be triggered before the service finished `Engine::register_client`, thus results in `RequiresClient` error.

Might help #10085, but I'm not sure, as I have never reproduced it.