### PR TITLE
Do not drop the peer with None difficulty

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,7 +153,7 @@ build-android:
 
 build-linux:
   <<:                              *build-on-linux
-  only:                            *releaseable_branches
+  # only:                            *releaseable_branches
 
 build-linux-i386:
   <<:                              *build-on-linux

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -994,7 +994,7 @@ impl ChainSync {
 					}
 
 					// Only ask for old blocks if the peer has an equal or higher difficulty
-					let equal_or_higher_difficulty = peer_difficulty.map_or(false, |pd| pd >= syncing_difficulty);
+					let equal_or_higher_difficulty = peer_difficulty.map_or(true, |pd| pd >= syncing_difficulty);
 
 					if force || equal_or_higher_difficulty {
 						if let Some(request) = self.old_blocks.as_mut().and_then(|d| d.request_blocks(peer_id, io, num_active_peers)) {


### PR DESCRIPTION
Several issues about archive nodes behavior were created with similar description: archive node starts loosing peers and stops sync. Sometimes the sync is restored after some period, sometimes no.
See: #10724 #10763 #10626 

The analysis shows one suspicious place, that leads to loosing peers (cut from the logs follows):
...
2019-06-24 06:27:03  IO Worker #1 TRACE sync  Skipping peer 312, force=false, td=Some(10728254029006356954158), our td=10728254029006356954158, state=Idle
...
2019-06-24 06:27:04  IO Worker #0 DEBUG sync  312 -> Dispatching packet: 1
2019-06-24 06:27:04  IO Worker #0 TRACE sync  312 -> NewHashes (1 entries)
2019-06-24 06:27:04  IO Worker #0 TRACE sync  New hash block already queued 0xef843f3c9be62b47228ae6b7819713117e3449dbdf73f8e644e057fe420fe289
2019-06-24 06:27:04  IO Worker #0 TRACE sync  Considering peer 312, force=false, td=None, our td=10728254029006356954158, latest=0xef84…e289, have_latest=true, state=Idle
2019-06-24 06:27:04  IO Worker #0 TRACE sync  peer 312 is not suitable for requesting old blocks, syncing_difficulty=10728254029006356954158, peer_difficulty=None
2019-06-24 06:27:04  IO Worker #0 TRACE sync  Deactivating peer 312
....

As you can see, the peer 312 was deactivated because its difficulty was defined as None. From my point of view it's an erroneous decision and this peer should be treated as legit. For example, compare this logic to the same several LOCs before: https://github.com/paritytech/parity-ethereum/blob/master/ethcore/sync/src/chain/mod.rs#L963
