### PR TITLE
Treat empty account the same as non-exist accounts in EIP-1052

### DIFF
--- a/ethcore/src/externalities.rs
+++ b/ethcore/src/externalities.rs
@@ -315,7 +315,11 @@ impl<'a, T: 'a, V: 'a, B: 'a> Ext for Externalities<'a, T, V, B>
 	}
 
 	fn extcodehash(&self, address: &Address) -> vm::Result<Option<H256>> {
-		Ok(self.state.code_hash(address)?)
+		if self.state.exists_and_not_null(address)? {
+			Ok(self.state.code_hash(address)?)
+		} else {
+			Ok(None)
+		}
 	}
 
 	fn extcodesize(&self, address: &Address) -> vm::Result<Option<usize>> {


### PR DESCRIPTION
rel https://github.com/ethereum/EIPs/pull/2144

When an account is empty, return `0x0` for `EXTCODEHASH`. This matches the behavior of Geth/Aleth.