### PR TITLE
removed redundant fmt::Display implementations

### DIFF
--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -2678,7 +2678,7 @@ mod tests {
 		state.kill_account(&a);
 
 		let diff = state.diff_from(original).unwrap();
-		let diff_map = diff.get();
+		let diff_map = diff.raw;
 		assert_eq!(diff_map.len(), 1);
 		assert!(diff_map.get(&a).is_some());
 		assert_eq!(diff_map.get(&a),
@@ -2709,7 +2709,7 @@ mod tests {
 		state.set_storage(&a, BigEndianHash::from_uint(&U256::from(1u64)), BigEndianHash::from_uint(&U256::from(100u64))).unwrap();
 
 		let diff = state.diff_from(original).unwrap();
-		let diff_map = diff.get();
+		let diff_map = diff.raw;
 		assert_eq!(diff_map.len(), 1);
 		assert!(diff_map.get(&a).is_some());
 		assert_eq!(diff_map.get(&a),

--- a/ethcore/types/src/state_diff.rs
+++ b/ethcore/types/src/state_diff.rs
@@ -16,11 +16,9 @@
 
 //! State diff module.
 
-use std::fmt;
-use std::ops::*;
 use std::collections::BTreeMap;
+use account_diff::AccountDiff;
 use ethereum_types::Address;
-use account_diff::*;
 
 /// Expression for the delta between two system states. Encoded the
 /// delta of every altered account.
@@ -28,28 +26,4 @@ use account_diff::*;
 pub struct StateDiff {
 	/// Raw diff key-value
 	pub raw: BTreeMap<Address, AccountDiff>
-}
-
-impl StateDiff {
-	/// Get the actual data.
-	pub fn get(&self) -> &BTreeMap<Address, AccountDiff> {
-		&self.raw
-	}
-}
-
-impl fmt::Display for StateDiff {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		for (add, acc) in &self.raw {
-			write!(f, "{} {}: {}", acc.existance(), add, acc)?;
-		}
-		Ok(())
-	}
-}
-
-impl Deref for StateDiff {
-	type Target = BTreeMap<Address, AccountDiff>;
-
-	fn deref(&self) -> &Self::Target {
-		&self.raw
-	}
 }

--- a/ethcore/types/src/verification_queue_info.rs
+++ b/ethcore/types/src/verification_queue_info.rs
@@ -37,15 +37,6 @@ impl VerificationQueueInfo {
 	/// The total size of the queues.
 	pub fn total_queue_size(&self) -> usize { self.unverified_queue_size + self.verified_queue_size + self.verifying_queue_size }
 
-	/// The size of the unverified and verifying queues.
-	pub fn incomplete_queue_size(&self) -> usize { self.unverified_queue_size + self.verifying_queue_size }
-
-	/// Indicates that queue is full
-	pub fn is_full(&self) -> bool {
-		self.unverified_queue_size + self.verified_queue_size + self.verifying_queue_size > self.max_queue_size ||
-			self.mem_used > self.max_mem_use
-	}
-
 	/// Indicates that queue is empty
 	pub fn is_empty(&self) -> bool {
 		self.unverified_queue_size + self.verified_queue_size + self.verifying_queue_size == 0

--- a/ethcore/types/src/verification_queue_info.rs
+++ b/ethcore/types/src/verification_queue_info.rs
@@ -37,6 +37,12 @@ impl VerificationQueueInfo {
 	/// The total size of the queues.
 	pub fn total_queue_size(&self) -> usize { self.unverified_queue_size + self.verified_queue_size + self.verifying_queue_size }
 
+	/// Indicates that queue is full
+	pub fn is_full(&self) -> bool {
+		self.unverified_queue_size + self.verified_queue_size + self.verifying_queue_size > self.max_queue_size ||
+			self.mem_used > self.max_mem_use
+	}
+
 	/// Indicates that queue is empty
 	pub fn is_empty(&self) -> bool {
 		self.unverified_queue_size + self.verified_queue_size + self.verifying_queue_size == 0


### PR DESCRIPTION
removed a bunch of code that is not used for years. Also `Debug` printing using `{:#?}` is more readable