### PR TITLE
feat: whisper: CLI flag for coloured log levels. CLI flag for output to log file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "argon2rs"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +331,16 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cgmath"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "chainspec"
 version = "0.1.0"
 dependencies = [
@@ -340,6 +355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -400,6 +416,15 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "colored"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1528,6 +1553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fern"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fetch"
 version = "0.1.0"
 dependencies = [
@@ -2256,6 +2290,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3589,6 +3624,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ring"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4623,11 +4663,13 @@ dependencies = [
 name = "whisper-cli"
 version = "0.1.0"
 dependencies = [
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-network 1.12.0",
  "ethcore-network-devp2p 1.12.0",
  "ethkey 0.3.0",
+ "fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-pubsub 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4686,6 +4728,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "winconsole"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rgb 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4723,6 +4776,7 @@ dependencies = [
 "checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum app_dirs 1.2.1 (git+https://github.com/paritytech/app-dirs-rs)" = "<none>"
+"checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
@@ -4757,12 +4811,14 @@ dependencies = [
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cesu8 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64a4b57c8f4e3a2e9ac07e0f6abc9c24b6fc9e1b54c3478cfb598f3d0023e51c"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0e37fba0087d9f3f4e269827a55dc511abf3e440cc097a0c154ff4e6584f988"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "6ec65ee4f9c9d16f335091d23693457ed4928657ba4982289d7fafee03bc614a"
+"checksum colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cdb90b60f2927f8d76139c72dbde7e10c3a2bc47c8594c9c7a66529f2687c03"
 "checksum combine 3.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fc1d011beeed29187b8db2ac3925c8dd4d3e87db463dc9d2d2833985388fc5bc"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum criterion 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c47d2b548c5647e1a436dc0cb78d4ebf51b6bf7ab101ed76662828bdd4d3a24a"
@@ -4810,6 +4866,7 @@ dependencies = [
 "checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fdlimit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1ee15a7050e5580b3712877157068ea713b245b080ff302ae2ca973cfcd9baa"
+"checksum fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "29d26fa0f4d433d1956746e66ec10d6bf4d6c8b93cd39965cceea7f7cc78c7dd"
 "checksum fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d1a683d1234507e4f3bf2736eeddf0de1dc65996dc0164d57eba0a74bcf29489"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -4987,6 +5044,7 @@ dependencies = [
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum rgb 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)" = "4f089652ca87f5a82a62935ec6172a534066c7b97be003cc8f702ee9a7a59c92"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
 "checksum ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a"
 "checksum rlp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b0d56c1450bfbef1181fdeb78b902dc1d23178de77c23d705317508e03d1b7c"
@@ -5109,6 +5167,7 @@ dependencies = [
 "checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
+"checksum winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef84b96d10db72dd980056666d7f1e7663ce93d82fa33b63e71c966f4cf5032"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"

--- a/whisper/README.md
+++ b/whisper/README.md
@@ -17,9 +17,10 @@ Options:
 	-p, --port PORT                Specify which P2P port to use [default: random].
 	-a, --address ADDRESS          Specify which P2P address to use [default: 127.0.0.1].
 	-s, --secret KEYFILE           Specify which file contains the key to generate the enode.
-    -P, --rpc-port PORT            Specify which RPC port to use [default: 8545].
-    -A, --rpc-address ADDRESS      Specify which RPC address to use [default: 127.0.0.1].
-	-l, --log LEVEL                Specify the logging level. Must conform to the same format as RUST_LOG [default: Error].
+	-P, --rpc-port PORT            Specify which RPC port to use [default: 8545].
+	-A, --rpc-address ADDRESS      Specify which RPC address to use [default: 127.0.0.1].
+	-l, --logging LEVEL            Specify the logging level. Must conform to the same format as RUST_LOG [default: 0]. Log level verbosity configuration choice from highest to lowest priority (error 0, warn 1, info 2, debug 3, trace 4).
+	-L, --logging-to-file          Record logs to output.log file.
 	-h, --help                     Display this message and exit.
 ```
 

--- a/whisper/cli/Cargo.toml
+++ b/whisper/cli/Cargo.toml
@@ -6,14 +6,16 @@ authors = ["Parity Technologies <admin@parity.io>"]
 license = "GPL-3.0"
 
 [dependencies]
+chrono = { version = "0.4.6", features = ["serde"] }
 docopt = "1.0"
 env_logger = "0.5"
 ethcore-network = { path = "../../util/network" }
 ethcore-network-devp2p = { path = "../../util/network-devp2p" }
+fern = { version = "0.5", features = ["colored"] }
 jsonrpc-core = "10.0.1"
 jsonrpc-http-server = "10.0.1"
 jsonrpc-pubsub = "10.0.1"
-log = "0.4"
+log = { version = "0.4", features = ["std", "serde", "max_level_trace", "release_max_level_info"] }
 panic_hook = { path = "../../util/panic-hook" }
 parity-whisper = { path = "../" }
 serde = "1.0"

--- a/whisper/cli/src/config/logger.rs
+++ b/whisper/cli/src/config/logger.rs
@@ -26,8 +26,7 @@ fn setup_logger(verbosity: u32, logging_to_file: bool) -> Result<(), fern::InitE
 		.debug(Color::BrightBlack)
 		.trace(Color::BrightBlack);
 
-	let colors_level = colors_line.clone()
-		.info(Color::Green);
+	let colors_level = colors_line.clone().info(Color::Green);
 
 	let mut base_config = fern::Dispatch::new();
 

--- a/whisper/cli/src/config/logger.rs
+++ b/whisper/cli/src/config/logger.rs
@@ -19,76 +19,76 @@ use rlog::{LevelFilter};
 use std::io;
 
 fn setup_logger(verbosity: u32, logging_to_file: bool) -> Result<(), fern::InitError> {
-  let colors_line = ColoredLevelConfig::new()
-    .error(Color::Red)
-    .warn(Color::Yellow)
-    .info(Color::BrightBlack)
-    .debug(Color::BrightBlack)
-    .trace(Color::BrightBlack);
+	let colors_line = ColoredLevelConfig::new()
+		.error(Color::Red)
+		.warn(Color::Yellow)
+		.info(Color::BrightBlack)
+		.debug(Color::BrightBlack)
+		.trace(Color::BrightBlack);
 
-  let colors_level = colors_line.clone()
-    .info(Color::Green);
+	let colors_level = colors_line.clone()
+		.info(Color::Green);
 
-  let mut base_config = fern::Dispatch::new();
+	let mut base_config = fern::Dispatch::new();
 
-  base_config = match verbosity {
-    0 => {
-      base_config
-      .level(LevelFilter::Error)
-      .level_for("pretty_colored", LevelFilter::Error)
-    }
-    1 => {
-      base_config
-      .level(LevelFilter::Warn)
-      .level_for("pretty_colored", LevelFilter::Warn)
-    },
-    2 => {
-      base_config
-      .level(LevelFilter::Info)
-      .level_for("pretty_colored", LevelFilter::Info)
-    },
-    3 => {
-      base_config
-      .level(LevelFilter::Debug)
-      .level_for("pretty_colored", LevelFilter::Debug)
-    },
-    _ => {
-      base_config
-      .level(LevelFilter::Trace)
-      .level_for("pretty_colored", LevelFilter::Trace)
-    },
-  };
+	base_config = match verbosity {
+		0 => {
+			base_config
+			.level(LevelFilter::Error)
+			.level_for("pretty_colored", LevelFilter::Error)
+		}
+		1 => {
+			base_config
+			.level(LevelFilter::Warn)
+			.level_for("pretty_colored", LevelFilter::Warn)
+		},
+		2 => {
+			base_config
+			.level(LevelFilter::Info)
+			.level_for("pretty_colored", LevelFilter::Info)
+		},
+		3 => {
+			base_config
+			.level(LevelFilter::Debug)
+			.level_for("pretty_colored", LevelFilter::Debug)
+		},
+		_ => {
+			base_config
+			.level(LevelFilter::Trace)
+			.level_for("pretty_colored", LevelFilter::Trace)
+		},
+	};
 
-  let format_config = fern::Dispatch::new()
-    .format(move |out, message, record| {
-      out.finish(format_args!(
-        "{color_line}[{date}][{target}][{level}{color_line}] {message}\x1B[0m",
-        color_line = format_args!("\x1B[{}m", colors_line.get_color(&record.level()).to_fg_str()),
-        date = chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
-        level = colors_level.color(record.level()),
-        target = record.target(),
-        message = message
-      ))
-    })
-    .chain(io::stdout());
+	let format_config = fern::Dispatch::new()
+		.format(move |out, message, record| {
+			out.finish(format_args!(
+				"{color_line}[{date}][{target}][{level}{color_line}] {message}\x1B[0m",
+				color_line = format_args!("\x1B[{}m", colors_line.get_color(&record.level()).to_fg_str()),
+				date = chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+				level = colors_level.color(record.level()),
+				target = record.target(),
+				message = message
+			))
+		})
+		.chain(io::stdout());
 
-  if logging_to_file {
-    let file_config = fern::Dispatch::new()
-      .format(|out, message, record| {
-        out.finish(format_args!(
-          "{}[{}][{}] {}",
-          chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
-          record.level(),
-          record.target(),
-          message
-        ))
-      })
-      .chain(fern::log_file("output.log")?);
+	if logging_to_file {
+		let file_config = fern::Dispatch::new()
+			.format(|out, message, record| {
+				out.finish(format_args!(
+				"{}[{}][{}] {}",
+				chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+				record.level(),
+				record.target(),
+				message
+				))
+			})
+			.chain(fern::log_file("output.log")?);
 
-    base_config.chain(file_config).chain(format_config).apply()?;
-  } else {
-    base_config.chain(format_config).apply()?;
-  }
+		base_config.chain(file_config).chain(format_config).apply()?;
+	} else {
+		base_config.chain(format_config).apply()?;
+	}
 
   Ok(())
 }
@@ -102,13 +102,13 @@ fn setup_logger(verbosity: u32, logging_to_file: bool) -> Result<(), fern::InitE
 /// are configured in Cargo.toml. In production the max logging level may differ from in development.
 /// - Output to output.log when logging_to_file is true.
 pub fn init_logger(logging: &str, logging_to_file: bool) -> () {
-  let verbosity: u32 = logging.parse::<u32>().expect("parsing cannot fail; qed");
+	let verbosity: u32 = logging.parse::<u32>().expect("parsing cannot fail; qed");
 
-  match setup_logger(verbosity, logging_to_file) {
-    Ok(_) => {
-      println!("Success initializing logger. Verbosity: {:?}. Log to file: {}", verbosity, &logging_to_file);
-      ()
-    }
-    Err(e) => { println!("Error initializing logger: {}", e); }
-  }
+	match setup_logger(verbosity, logging_to_file) {
+		Ok(_) => {
+			println!("Success initializing logger. Verbosity: {:?}. Log to file: {}", verbosity, &logging_to_file);
+			()
+		}
+		Err(e) => { println!("Error initializing logger: {}", e); }
+	}
 }

--- a/whisper/cli/src/config/logger.rs
+++ b/whisper/cli/src/config/logger.rs
@@ -18,7 +18,7 @@ use fern::colors::{Color, ColoredLevelConfig};
 use rlog::{LevelFilter};
 use std::io;
 
-fn setup_logger(verbosity: u32, log_to_file: bool) -> Result<(), fern::InitError> {
+fn setup_logger(verbosity: u32, logging_to_file: bool) -> Result<(), fern::InitError> {
   let colors_line = ColoredLevelConfig::new()
     .error(Color::Red)
     .warn(Color::Yellow)
@@ -72,7 +72,7 @@ fn setup_logger(verbosity: u32, log_to_file: bool) -> Result<(), fern::InitError
     })
     .chain(io::stdout());
 
-  if log_to_file {
+  if logging_to_file {
     let file_config = fern::Dispatch::new()
       .format(|out, message, record| {
         out.finish(format_args!(
@@ -95,18 +95,18 @@ fn setup_logger(verbosity: u32, log_to_file: bool) -> Result<(), fern::InitError
 
 /// Initialisation of the [Log Crate](https://crates.io/crates/log) and [Fern Crate](https://docs.rs/fern/0.5.5/fern/)
 ///
-/// - Choice of log level verbosity from CLI: error (0), warn (1), info (2), debug (3), or trace (4).
-/// - Fallback to default log level that is defined.
+/// - Choice of logging level verbosity from CLI: error (0), warn (1), info (2), debug (3), or trace (4).
+/// - Fallback to default logging level that is defined.
 /// - Use of logging level macros from highest priority to lowest: `error!`, `warn!`, `info!`, `debug!` and `trace!`.
-/// - [Compile time filters](https://docs.rs/log/0.4.1/log/#compile-time-filters) that override the CLI log levels
-/// are configured in Cargo.toml. In production the max log level may differ from in development.
-/// - Output to output.log when log_to_file is true.
-pub fn init_logger(pattern: &str, log_to_file: bool) -> () {
-  let verbosity: u32 = pattern.parse::<u32>().expect("parsing cannot fail; qed");
+/// - [Compile time filters](https://docs.rs/log/0.4.1/log/#compile-time-filters) that override the CLI logging levels
+/// are configured in Cargo.toml. In production the max logging level may differ from in development.
+/// - Output to output.log when logging_to_file is true.
+pub fn init_logger(logging: &str, logging_to_file: bool) -> () {
+  let verbosity: u32 = logging.parse::<u32>().expect("parsing cannot fail; qed");
 
-  match setup_logger(verbosity, log_to_file) {
+  match setup_logger(verbosity, logging_to_file) {
     Ok(_) => {
-      println!("Success initializing logger. Verbosity: {:?}. Log to file: {}", verbosity, &log_to_file);
+      println!("Success initializing logger. Verbosity: {:?}. Log to file: {}", verbosity, &logging_to_file);
       ()
     }
     Err(e) => { println!("Error initializing logger: {}", e); }

--- a/whisper/cli/src/config/logger.rs
+++ b/whisper/cli/src/config/logger.rs
@@ -1,0 +1,114 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity Ethereum.
+
+// Parity Ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
+
+use fern::colors::{Color, ColoredLevelConfig};
+use rlog::{LevelFilter};
+use std::io;
+
+fn setup_logger(verbosity: u32, log_to_file: bool) -> Result<(), fern::InitError> {
+  let colors_line = ColoredLevelConfig::new()
+    .error(Color::Red)
+    .warn(Color::Yellow)
+    .info(Color::BrightBlack)
+    .debug(Color::BrightBlack)
+    .trace(Color::BrightBlack);
+
+  let colors_level = colors_line.clone()
+    .info(Color::Green);
+
+  let mut base_config = fern::Dispatch::new();
+
+  base_config = match verbosity {
+    0 => {
+      base_config
+      .level(LevelFilter::Error)
+      .level_for("pretty_colored", LevelFilter::Error)
+    }
+    1 => {
+      base_config
+      .level(LevelFilter::Warn)
+      .level_for("pretty_colored", LevelFilter::Warn)
+    },
+    2 => {
+      base_config
+      .level(LevelFilter::Info)
+      .level_for("pretty_colored", LevelFilter::Info)
+    },
+    3 => {
+      base_config
+      .level(LevelFilter::Debug)
+      .level_for("pretty_colored", LevelFilter::Debug)
+    },
+    _ => {
+      base_config
+      .level(LevelFilter::Trace)
+      .level_for("pretty_colored", LevelFilter::Trace)
+    },
+  };
+
+  let format_config = fern::Dispatch::new()
+    .format(move |out, message, record| {
+      out.finish(format_args!(
+        "{color_line}[{date}][{target}][{level}{color_line}] {message}\x1B[0m",
+        color_line = format_args!("\x1B[{}m", colors_line.get_color(&record.level()).to_fg_str()),
+        date = chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+        level = colors_level.color(record.level()),
+        target = record.target(),
+        message = message
+      ))
+    })
+    .chain(io::stdout());
+
+  if log_to_file {
+    let file_config = fern::Dispatch::new()
+      .format(|out, message, record| {
+        out.finish(format_args!(
+          "{}[{}][{}] {}",
+          chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+          record.level(),
+          record.target(),
+          message
+        ))
+      })
+      .chain(fern::log_file("output.log")?);
+
+    base_config.chain(file_config).chain(format_config).apply()?;
+  } else {
+    base_config.chain(format_config).apply()?;
+  }
+
+  Ok(())
+}
+
+/// Initialisation of the [Log Crate](https://crates.io/crates/log) and [Fern Crate](https://docs.rs/fern/0.5.5/fern/)
+///
+/// - Choice of log level verbosity from CLI: error (0), warn (1), info (2), debug (3), or trace (4).
+/// - Fallback to default log level that is defined.
+/// - Use of logging level macros from highest priority to lowest: `error!`, `warn!`, `info!`, `debug!` and `trace!`.
+/// - [Compile time filters](https://docs.rs/log/0.4.1/log/#compile-time-filters) that override the CLI log levels
+/// are configured in Cargo.toml. In production the max log level may differ from in development.
+/// - Output to output.log when log_to_file is true.
+pub fn init_logger(pattern: &str, log_to_file: bool) -> () {
+  let verbosity: u32 = pattern.parse::<u32>().expect("parsing cannot fail; qed");
+
+  match setup_logger(verbosity, log_to_file) {
+    Ok(_) => {
+      println!("Success initializing logger. Verbosity: {:?}. Log to file: {}", verbosity, &log_to_file);
+      ()
+    }
+    Err(e) => { println!("Error initializing logger: {}", e); }
+  }
+}

--- a/whisper/cli/src/config/mod.rs
+++ b/whisper/cli/src/config/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity Ethereum.
+
+// Parity Ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Whisper logger configuration.
+
+pub mod logger;

--- a/whisper/cli/src/main.rs
+++ b/whisper/cli/src/main.rs
@@ -83,8 +83,8 @@ Options:
 	-s, --secret KEYFILE           Specify which file contains the key to generate the enode.
 	-P, --rpc-port PORT            Specify which RPC port to use [default: 8545].
 	-A, --rpc-address ADDRESS      Specify which RPC address to use [default: 127.0.0.1].
-	-l, --log-level LEVEL          Specify the logging level. Must conform to the same format as RUST_LOG [default: Error]. Log level verbosity configuration choice from highest to lowest priority (error 0, warn 1, info 2, debug 3, trace 4).
-	--log-to-file                  Record logs to output.log file.
+	-l, --logging LEVEL            Specify the logging level. Must conform to the same format as RUST_LOG [default: 0]. Log level verbosity configuration choice from highest to lowest priority (error 0, warn 1, info 2, debug 3, trace 4).
+	-L, --logging-to-file          Record logs to output.log file.
 	-h, --help                     Display this message and exit.
 "#;
 
@@ -106,8 +106,8 @@ struct Args {
 	flag_address: String,
 	flag_rpc_port: String,
 	flag_rpc_address: String,
-	flag_log_level: String,
-	flag_log_to_file: bool,
+	flag_logging: String,
+	flag_logging_to_file: bool,
 	flag_secret: String,
 }
 
@@ -244,9 +244,9 @@ fn execute<S, I>(command: I) -> Result<(), Error> where I: IntoIterator<Item=S>,
 	let rpc_url = format!("{}:{}", args.flag_rpc_address, args.flag_rpc_port);
 
 	// Default values are defined in the CLI configuration
-	let log_pattern = args.clone().flag_log_level;
-	let log_to_file = args.clone().flag_log_to_file;
-	config::logger::init_logger(&log_pattern, log_to_file);
+	let logging_level = args.clone().flag_logging;
+	let logging_to_file = args.clone().flag_logging_to_file;
+	config::logger::init_logger(&logging_level, logging_to_file);
 	info!(target: "whisper-cli", "start");
 
 	// Filter manager that will dispatch `decryption tasks`

--- a/whisper/cli/src/main.rs
+++ b/whisper/cli/src/main.rs
@@ -249,9 +249,7 @@ fn execute<S, I>(command: I) -> Result<(), Error> where I: IntoIterator<Item=S>,
 	let rpc_url = format!("{}:{}", args.flag_rpc_address, args.flag_rpc_port);
 
 	// Default values are defined in the CLI configuration
-	let logging_level = args.clone().flag_logging;
-	let logging_to_file = args.clone().flag_logging_to_file;
-	config::logger::init_logger(&logging_level, logging_to_file);
+	config::logger::init_logger(&args.flag_logging, args.flag_logging_to_file);
 	info!(target: "whisper-cli", "start");
 
 	// Filter manager that will dispatch `decryption tasks`

--- a/whisper/cli/src/main.rs
+++ b/whisper/cli/src/main.rs
@@ -83,7 +83,7 @@ Options:
 	-s, --secret KEYFILE           Specify which file contains the key to generate the enode.
 	-P, --rpc-port PORT            Specify which RPC port to use [default: 8545].
 	-A, --rpc-address ADDRESS      Specify which RPC address to use [default: 127.0.0.1].
-	-l, --log-level LEVEL          Specify the logging level. Must conform to the same format as RUST_LOG [default: 4]. Log level verbosity configuration choice from highest to lowest priority (error 0, warn 1, info 2, debug 3, trace 4).
+	-l, --log-level LEVEL          Specify the logging level. Must conform to the same format as RUST_LOG [default: Error]. Log level verbosity configuration choice from highest to lowest priority (error 0, warn 1, info 2, debug 3, trace 4).
 	--log-to-file                  Record logs to output.log file.
 	-h, --help                     Display this message and exit.
 "#;

--- a/whisper/cli/src/main.rs
+++ b/whisper/cli/src/main.rs
@@ -22,8 +22,13 @@
 //!
 //! ## Usage
 //!
-//! Whisper is not distributed with regular Parity Ethereum releases
-//! so you need to build it from source and run it like so:
+//! Whisper is distributed with regular Parity Ethereum releases so it may be run with:
+//!
+//! ```bash
+//! whisper --help
+//! ```
+//!
+//! Alternatively build it from source like so:
 //!
 //! ```bash
 //! cargo build -p whisper-cli --release


### PR DESCRIPTION
* [x] Usage of fern crate for log levels like in https://github.com/paritytech/parity-ethereum/pull/10761
* [x] Rename CLI flag to `--log-level` instead of `--log`
* [x] Add CLI flag `--log-to-file` to save output to output.log

## Usage

### Production

```
cargo test -p whisper-cli --release
cargo build -p whisper-cli --release
./target/release/whisper --port 0 --whisper-pool-size 4 --address 127.0.0.1 --rpc-port 8545 --rpc-address 127.0.0.1
```

### Development

```
cargo test -p whisper-cli
cargo build -p whisper-cli
./target/debug/whisper --port 0 --whisper-pool-size 4 --address 127.0.0.1 --rpc-port 8545 --rpc-address 127.0.0.1
```