### PR TITLE
Don't reimplement the logic from the Default impl

### DIFF
--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -933,13 +933,13 @@ impl Configuration {
 	}
 
 	fn snapshot_config(&self) -> Result<SnapshotConfiguration, String> {
-		let conf = SnapshotConfiguration {
-			no_periodic: self.args.flag_no_periodic_snapshot,
-			processing_threads: match self.args.arg_snapshot_threads {
-				Some(threads) if threads > 0 => threads,
-				_ => ::std::cmp::max(1, num_cpus::get_physical() / 2),
-			},
-		};
+		let mut conf = SnapshotConfiguration::default();
+		conf.no_periodic = self.args.flag_no_periodic_snapshot;
+		if let Some(threads) = self.args.arg_snapshot_threads {
+			if threads > 0 {
+				conf.processing_threads = threads;
+			}
+		}
 
 		Ok(conf)
 	}


### PR DESCRIPTION
Use the Default impl for SnapshotConfig and only overwrite when the value is correct.