### PR TITLE
removed additional_params method

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -16,7 +16,6 @@
 
 use std::cmp;
 use std::collections::{HashSet, BTreeMap, VecDeque};
-use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering as AtomicOrdering};
 use std::sync::{Arc, Weak};
 use std::time::{Instant, Duration};
@@ -753,7 +752,7 @@ impl Client {
 
 		let importer = Importer::new(&config, engine.clone(), message_channel.clone(), miner)?;
 
-		let registrar_address = engine.additional_params().get("registrar").and_then(|s| Address::from_str(s).ok());
+		let registrar_address = engine.machine().params().registrar;
 		if let Some(ref addr) = registrar_address {
 			trace!(target: "client", "Found registrar at {}", addr);
 		}
@@ -1980,10 +1979,6 @@ impl BlockChainClient for Client {
 
 	fn clear_queue(&self) {
 		self.importer.block_queue.clear();
-	}
-
-	fn additional_params(&self) -> BTreeMap<String, String> {
-		self.engine.additional_params().into_iter().collect()
 	}
 
 	fn logs(&self, filter: Filter) -> Result<Vec<LocalizedLogEntry>, BlockId> {

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -841,10 +841,6 @@ impl BlockChainClient for TestBlockChainClient {
 	fn clear_queue(&self) {
 	}
 
-	fn additional_params(&self) -> BTreeMap<String, String> {
-		Default::default()
-	}
-
 	fn filter_traces(&self, _filter: TraceFilter) -> Option<Vec<LocalizedTrace>> {
 		self.traces.read().clone()
 	}

--- a/ethcore/src/client/traits.rs
+++ b/ethcore/src/client/traits.rs
@@ -296,9 +296,6 @@ pub trait BlockChainClient : Sync + Send + AccountData + BlockChain + CallContra
 	/// Clear block queue and abort all import activity.
 	fn clear_queue(&self);
 
-	/// Get the registrar address, if it exists.
-	fn additional_params(&self) -> BTreeMap<String, String>;
-
 	/// Returns logs matching given filter. If one of the filtering block cannot be found, returns the block id that caused the error.
 	fn logs(&self, filter: Filter) -> Result<Vec<LocalizedLogEntry>, BlockId>;
 

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -38,7 +38,7 @@ pub use types::engines::ForkChoice;
 pub use types::engines::epoch::{self, Transition as EpochTransition};
 
 use std::sync::{Weak, Arc};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::{fmt, error};
 
 use builtin::Builtin;
@@ -541,11 +541,6 @@ pub trait Engine: Sync + Send {
 	/// TODO: consider including State in the params.
 	fn verify_transaction_basic(&self, t: &UnverifiedTransaction, header: &Header) -> Result<(), transaction::Error> {
 		self.machine().verify_transaction_basic(t, header)
-	}
-
-	/// Additional information.
-	fn additional_params(&self) -> HashMap<String, String> {
-		self.machine().additional_params()
 	}
 
 	/// Performs pre-validation of RLP decoded transaction before other processing

--- a/ethcore/src/machine.rs
+++ b/ethcore/src/machine.rs
@@ -16,7 +16,7 @@
 
 //! Ethereum-like state machine definition.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::cmp;
 use std::sync::Arc;
 
@@ -383,13 +383,6 @@ impl Machine {
 		}
 
 		Ok(())
-	}
-
-	/// Additional params.
-	pub fn additional_params(&self) -> HashMap<String, String> {
-		hash_map![
-			"registrar".to_owned() => format!("{:x}", self.params.registrar)
-		]
 	}
 
 	/// Performs pre-validation of RLP decoded transaction before other processing

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -138,7 +138,7 @@ pub struct CommonParams {
 	/// Gas limit bound divisor (how much gas limit can change per block)
 	pub gas_limit_bound_divisor: U256,
 	/// Registrar contract address.
-	pub registrar: Address,
+	pub registrar: Option<Address>,
 	/// Node permission managing contract address.
 	pub node_permission_contract: Option<Address>,
 	/// Maximum contract code size that can be deployed.
@@ -315,7 +315,7 @@ impl From<ethjson::spec::Params> for CommonParams {
 			nonce_cap_increment: p.nonce_cap_increment.map_or(64, Into::into),
 			remove_dust_contracts: p.remove_dust_contracts.unwrap_or(false),
 			gas_limit_bound_divisor: p.gas_limit_bound_divisor.into(),
-			registrar: p.registrar.map_or_else(Address::zero, Into::into),
+			registrar: p.registrar.map(Into::into),
 			node_permission_contract: p.node_permission_contract.map(Into::into),
 			max_code_size: p.max_code_size.map_or(u64::max_value(), Into::into),
 			max_transaction_size: p.max_transaction_size.map_or(MAX_TRANSACTION_SIZE, Into::into),

--- a/ethcore/src/tests/client.rs
+++ b/ethcore/src/tests/client.rs
@@ -69,11 +69,8 @@ fn should_return_registrar() {
 		Arc::new(Miner::new_for_tests(&spec, None)),
 		IoChannel::disconnected(),
 	).unwrap();
-	let params = client.additional_params();
-	let address = &params["registrar"];
-
-	assert_eq!(address.len(), 40);
-	assert!(U256::from_str(address).is_ok());
+	let address = client.registrar_address();
+	assert_eq!(address, Some("52dff57a8a1532e6afb3dc07e2af58bb9eb05b3d".parse().unwrap()));
 }
 
 #[test]

--- a/rpc/src/v1/impls/light/parity.rs
+++ b/rpc/src/v1/impls/light/parity.rs
@@ -163,12 +163,7 @@ where
 	}
 
 	fn registry_address(&self) -> Result<Option<H160>> {
-		let reg = self.light_dispatch.client.engine().params().registrar;
-		if reg == Default::default() {
-			Ok(None)
-		} else {
-			Ok(Some(reg))
-		}
+		Ok(self.light_dispatch.client.engine().params().registrar)
 	}
 
 	fn rpc_settings(&self) -> Result<RpcSettings> {

--- a/rpc/src/v1/impls/parity.rs
+++ b/rpc/src/v1/impls/parity.rs
@@ -16,11 +16,10 @@
 
 //! Parity-specific rpc implementation.
 use std::sync::Arc;
-use std::str::FromStr;
 use std::collections::BTreeMap;
 
 use crypto::DEFAULT_MAC;
-use ethereum_types::{Address, H64, H160, H256, H512, U64, U256};
+use ethereum_types::{H64, H160, H256, H512, U64, U256};
 use ethcore::client::{BlockChainClient, StateClient, Call};
 use ethcore::miner::{self, MinerService, FilterOptions};
 use ethcore::snapshot::{SnapshotService, RestorationStatus};
@@ -165,12 +164,7 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 	}
 
 	fn registry_address(&self) -> Result<Option<H160>> {
-		Ok(
-			self.client
-				.additional_params()
-				.get("registrar")
-				.and_then(|s| Address::from_str(s).ok())
-		)
+		Ok(self.client.registrar_address())
 	}
 
 	fn rpc_settings(&self) -> Result<RpcSettings> {


### PR DESCRIPTION
- `additional_params` method is redundant as it contains only 1 param `registrar_address`
- `registrar_address` was converted from and to string with no reason