### PR TITLE
refactor: whisper aes-gcm: Add type aliases and update rustdocs in AES-GCM module

### DIFF
--- a/whisper/src/aes_gcm/mod.rs
+++ b/whisper/src/aes_gcm/mod.rs
@@ -50,7 +50,7 @@ type AuthenticationTagLength = usize;
 /// Plaintext message data to seal.
 type Plaintext = Vec<u8>;
 
-/// Cyphertext.
+/// Ciphertext.
 type Ciphertext = Vec<u8>;
 
 /// AES-GCM encryptor provides the authenticated encryption operation.

--- a/whisper/src/aes_gcm/mod.rs
+++ b/whisper/src/aes_gcm/mod.rs
@@ -38,20 +38,16 @@ use ring;
 /// appropriate for the underlying block cipher.
 type SecretKey = [u8; 32];
 
-/// Initialization Vector (IV) whose purpose is to be a nonce that is used during
-/// the sealing process, whose number of bits are between ??? (1 to 2^64 is the
-/// value used for for 128-bit block ciphers, (cf. [[2]])).
+/// Initialization Vector (IV) is a nonce used during the sealing process.
 /// It must be distinct for each invocation of the encryption
 /// operation for a fixed value of the Secret Key. It is authenticated but it is
 /// not necessary to include it in the Additional Authenticated Data (AAD) field.
 type Nonce = [u8; 12];
 
-/// Authentication Tag Length that determines the authentication strength and may be
-/// between 0 and 256 bits.
+/// Authentication Tag Length that determines the authentication strength.
 type AuthenticationTagLength = usize;
 
-/// Plaintext message data to seal, whose number of bits may be between ???
-/// (0 to 2^39 - 256 is the value used for for 128-bit block ciphers, see (cf. [[2]])).
+/// Plaintext message data to seal.
 type Plaintext = Vec<u8>;
 
 /// Cyphertext.


### PR DESCRIPTION
* [x] Add types aliases to AES-GCM module and update Rustdocs
* **HELP** How many bits for the `Nonce` type definition (i.e. currently rustdocs says bits are between ???, noting that 1 to 2^64 is the value used for for 128-bit block ciphers, but we are using 256-bit)
* **HELP** What is range of bits for plaintext `Plaintext` type definition (i.e. currently the rustdocs says bits are between ???, noting that 0 to 2^39 - 256 is the value used for for 128-bit block ciphers, but we are using 256-bit.
* **HELP** Is the Authentication Tag Length between 0 and 256 bits

## Preview changes

```
cargo doc -p parity-whisper --open  --no-deps --document-private-items
```

Note: On Debian 9 it may be necessary to run `RUSTFLAGS="-C target-feature=+aes,+ssse3" cargo doc -p parity-whisper --open  --no-deps --document-private-items`