### PR TITLE
ethcore does not use byteorder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,6 @@ dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blooms-db 0.1.0",
  "bn 0.4.4 (git+https://github.com/paritytech/bn)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "common-types 0.1.0",
  "criterion 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -10,7 +10,6 @@ authors = ["Parity Technologies <admin@parity.io>"]
 ansi_term = "0.11"
 blooms-db = { path = "../util/blooms-db", optional = true }
 bn = { git = "https://github.com/paritytech/bn", default-features = false }
-byteorder = "1.0"
 common-types = { path = "types" }
 crossbeam = "0.4"
 derive_more = "0.14.0"

--- a/ethcore/src/builtin.rs
+++ b/ethcore/src/builtin.rs
@@ -19,7 +19,6 @@
 use std::cmp::{max, min};
 use std::io::{self, Read};
 
-use byteorder::{ByteOrder, BigEndian};
 use parity_crypto::digest;
 use num::{BigUint, Zero, One};
 
@@ -369,7 +368,9 @@ impl Impl for ModexpImpl {
 		// but so would running out of addressable memory!
 		let mut read_len = |reader: &mut io::Chain<&[u8], io::Repeat>| {
 			reader.read_exact(&mut buf[..]).expect("reading from zero-extended memory cannot fail; qed");
-			BigEndian::read_u64(&buf[24..]) as usize
+			let mut len_bytes = [0u8; 8];
+			len_bytes.copy_from_slice(&buf[24..]);
+			u64::from_be_bytes(len_bytes) as usize
 		};
 
 		let base_len = read_len(&mut reader);

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -55,7 +55,6 @@
 
 extern crate ansi_term;
 extern crate bn;
-extern crate byteorder;
 extern crate common_types as types;
 extern crate crossbeam;
 extern crate ethabi;


### PR DESCRIPTION
endianess is now a part of standard library so there is no reason to use `byteorder`