### PR TITLE
Remove excessive warning

### DIFF
--- a/rpc/src/v1/helpers/engine_signer.rs
+++ b/rpc/src/v1/helpers/engine_signer.rs
@@ -37,10 +37,7 @@ impl ethcore::engines::EngineSigner for EngineSigner {
 	fn sign(&self, message: ethkey::Message) -> Result<ethkey::Signature, ethkey::Error> {
 		match self.accounts.sign(self.address, Some(self.password.clone()), message) {
 			Ok(ok) => Ok(ok),
-			Err(e) => {
-				warn!("Unable to sign consensus message: {:?}", e);
-				Err(ethkey::Error::InvalidSecret)
-			},
+			Err(e) => Err(ethkey::Error::InvalidSecret),
 		}
 	}
 


### PR DESCRIPTION
This warning is a excessive, because calling sign method of EngineSigner with incorrect password is legit situation. For example, it's being done on the start in order to define proper engine-signer account (all passwords are looped through and tried for signing test message, as result warnings about all incorrect passwords are shown in the console).
Also unifies the logic of  EngineSigner because all other components in this layer (rpc/v1/helpers) silently return the result or error.

Relates to #10695 