### PR TITLE
Break circular dependency between Client and Engine (part 1)

### DIFF
--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -103,7 +103,7 @@ pub struct ExecutedBlock {
 	pub receipts: Vec<Receipt>,
 	/// Hashes of already executed transactions.
 	pub transactions_set: HashSet<H256>,
-	/// Underlaying state.
+	/// Underlying state.
 	pub state: State<StateDB>,
 	/// Transaction traces.
 	pub traces: Tracing,
@@ -120,13 +120,13 @@ impl ExecutedBlock {
 			uncles: Default::default(),
 			receipts: Default::default(),
 			transactions_set: Default::default(),
-			state: state,
+			state,
 			traces: if tracing {
 				Tracing::enabled()
 			} else {
 				Tracing::Disabled
 			},
-			last_hashes: last_hashes,
+			last_hashes,
 		}
 	}
 

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -407,7 +407,6 @@ impl Importer {
 			last_hashes,
 			client.factories.clone(),
 			is_epoch_begin,
-			&mut chain.ancestry_with_metadata_iter(*header.parent_hash()),
 		);
 
 		let mut locked_block = match enact_result {
@@ -2361,7 +2360,6 @@ impl PrepareOpenBlock for Client {
 			gas_range_target,
 			extra_data,
 			is_epoch_begin,
-			chain.ancestry_with_metadata_iter(best_header.hash()),
 		)?;
 
 		// Add uncles

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2315,15 +2315,7 @@ impl IoClient for Client {
 impl ReopenBlock for Client {
 	fn reopen_block(&self, block: ClosedBlock) -> OpenBlock {
 		let engine = &*self.engine;
-		let parent = match self.block_header_decoded(BlockId::Hash(*block.header.parent_hash())) {
-			Some(h) => h,
-			None => {
-				warn!(target: "client", "reopen block #{} failed: Parent not found ({}) ", block.header.number(), block.header.parent_hash());
-				panic!("TODO: say something proper here – or return error and panic further up?");
-			}
-		};
-
-		let mut block = block.reopen(engine, parent);
+		let mut block = block.reopen(engine);
 		let max_uncles = engine.maximum_uncle_count(block.header.number());
 		if block.uncles.len() < max_uncles {
 			let chain = self.chain.read();

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -417,7 +417,6 @@ impl PrepareOpenBlock for TestBlockChainClient {
 			gas_range_target,
 			extra_data,
 			false,
-			None,
 		)?;
 		// TODO [todr] Override timestamp for predictability
 		open_block.set_timestamp(*self.latest_block_timestamp.read());

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -395,7 +395,9 @@ pub fn get_temp_state_db() -> StateDB {
 
 impl ReopenBlock for TestBlockChainClient {
 	fn reopen_block(&self, block: ClosedBlock) -> OpenBlock {
-		block.reopen(&*self.spec.engine)
+		let parent = self.block_header(BlockId::Hash(*block.header.parent_hash())).expect("todo say something proper; qed");
+		let parent = parent.decode().expect("todo say something proper; qed");
+		block.reopen(&*self.spec.engine, parent)
 	}
 }
 

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -395,9 +395,7 @@ pub fn get_temp_state_db() -> StateDB {
 
 impl ReopenBlock for TestBlockChainClient {
 	fn reopen_block(&self, block: ClosedBlock) -> OpenBlock {
-		let parent = self.block_header(BlockId::Hash(*block.header.parent_hash())).expect("todo say something proper; qed");
-		let parent = parent.decode().expect("todo say something proper; qed");
-		block.reopen(&*self.spec.engine, parent)
+		block.reopen(&*self.spec.engine)
 	}
 }
 

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -1698,9 +1698,9 @@ mod tests {
 		let db1 = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
 		let db2 = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
-		let b1 = OpenBlock::new(engine, Default::default(), false, db1, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b1 = OpenBlock::new(engine, Default::default(), false, db1, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let b1 = b1.close_and_lock().unwrap();
-		let b2 = OpenBlock::new(engine, Default::default(), false, db2, &genesis_header, last_hashes, addr2, (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b2 = OpenBlock::new(engine, Default::default(), false, db2, &genesis_header, last_hashes, addr2, (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let b2 = b2.close_and_lock().unwrap();
 
 		engine.set_signer(Box::new((tap.clone(), addr1, "1".into())));
@@ -1732,9 +1732,9 @@ mod tests {
 		let db2 = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 
-		let b1 = OpenBlock::new(engine, Default::default(), false, db1, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b1 = OpenBlock::new(engine, Default::default(), false, db1, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let b1 = b1.close_and_lock().unwrap();
-		let b2 = OpenBlock::new(engine, Default::default(), false, db2, &genesis_header, last_hashes, addr2, (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b2 = OpenBlock::new(engine, Default::default(), false, db2, &genesis_header, last_hashes, addr2, (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let b2 = b2.close_and_lock().unwrap();
 
 		engine.set_signer(Box::new((tap.clone(), addr1, "1".into())));
@@ -1982,7 +1982,7 @@ mod tests {
 
 		engine.set_signer(Box::new((tap.clone(), addr1, "1".into())));
 
-		let b1 = OpenBlock::new(engine, Default::default(), false, db1, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b1 = OpenBlock::new(engine, Default::default(), false, db1, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let b1 = b1.close_and_lock().unwrap();
 
 		// the block is empty so we don't seal and instead broadcast an empty step message
@@ -2020,7 +2020,7 @@ mod tests {
 		engine.register_client(Arc::downgrade(&client) as _);
 
 		// step 2
-		let b1 = OpenBlock::new(engine, Default::default(), false, db1, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b1 = OpenBlock::new(engine, Default::default(), false, db1, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let b1 = b1.close_and_lock().unwrap();
 
 		// since the block is empty it isn't sealed and we generate empty steps
@@ -2029,7 +2029,7 @@ mod tests {
 		engine.step();
 
 		// step 3
-		let mut b2 = OpenBlock::new(engine, Default::default(), false, db2, &genesis_header, last_hashes.clone(), addr2, (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let mut b2 = OpenBlock::new(engine, Default::default(), false, db2, &genesis_header, last_hashes.clone(), addr2, (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		b2.push_transaction(Transaction {
 			action: Action::Create,
 			nonce: U256::from(0),
@@ -2073,7 +2073,7 @@ mod tests {
 		engine.register_client(Arc::downgrade(&client) as _);
 
 		// step 2
-		let b1 = OpenBlock::new(engine, Default::default(), false, db1, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b1 = OpenBlock::new(engine, Default::default(), false, db1, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let b1 = b1.close_and_lock().unwrap();
 
 		// since the block is empty it isn't sealed and we generate empty steps
@@ -2082,7 +2082,7 @@ mod tests {
 		engine.step();
 
 		// step 3
-		let b2 = OpenBlock::new(engine, Default::default(), false, db2, &genesis_header, last_hashes.clone(), addr2, (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b2 = OpenBlock::new(engine, Default::default(), false, db2, &genesis_header, last_hashes.clone(), addr2, (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let b2 = b2.close_and_lock().unwrap();
 		engine.set_signer(Box::new((tap.clone(), addr2, "0".into())));
 		assert_eq!(engine.generate_seal(&b2, &genesis_header), Seal::None);
@@ -2090,7 +2090,7 @@ mod tests {
 
 		// step 4
 		// the spec sets the maximum_empty_steps to 2 so we will now seal an empty block and include the empty step messages
-		let b3 = OpenBlock::new(engine, Default::default(), false, db3, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b3 = OpenBlock::new(engine, Default::default(), false, db3, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let b3 = b3.close_and_lock().unwrap();
 
 		engine.set_signer(Box::new((tap.clone(), addr1, "1".into())));
@@ -2123,7 +2123,7 @@ mod tests {
 		engine.register_client(Arc::downgrade(&client) as _);
 
 		// step 2
-		let b1 = OpenBlock::new(engine, Default::default(), false, db1, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b1 = OpenBlock::new(engine, Default::default(), false, db1, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let b1 = b1.close_and_lock().unwrap();
 
 		// since the block is empty it isn't sealed and we generate empty steps
@@ -2133,7 +2133,7 @@ mod tests {
 
 		// step 3
 		// the signer of the accumulated empty step message should be rewarded
-		let b2 = OpenBlock::new(engine, Default::default(), false, db2, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b2 = OpenBlock::new(engine, Default::default(), false, db2, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let addr1_balance = b2.state.balance(&addr1).unwrap();
 
 		// after closing the block `addr1` should be reward twice, one for the included empty step message and another for block creation
@@ -2233,7 +2233,6 @@ mod tests {
 			(3141562.into(), 31415620.into()),
 			vec![],
 			false,
-			None,
 		).unwrap();
 		let b1 = b1.close_and_lock().unwrap();
 
@@ -2255,7 +2254,6 @@ mod tests {
 			(3141562.into(), 31415620.into()),
 			vec![],
 			false,
-			None,
 		).unwrap();
 		let addr1_balance = b2.state.balance(&addr1).unwrap();
 

--- a/ethcore/src/engines/basic_authority.rs
+++ b/ethcore/src/engines/basic_authority.rs
@@ -268,7 +268,7 @@ mod tests {
 		let genesis_header = spec.genesis_header();
 		let db = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
-		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, addr, (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, addr, (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let b = b.close_and_lock().unwrap();
 		if let Seal::Regular(seal) = engine.generate_seal(&b, &genesis_header) {
 			assert!(b.try_seal(engine, seal).is_ok());

--- a/ethcore/src/engines/clique/mod.rs
+++ b/ethcore/src/engines/clique/mod.rs
@@ -368,13 +368,16 @@ impl Engine for Clique {
 		&self,
 		_block: &mut ExecutedBlock,
 		_epoch_begin: bool,
-		_ancestry: &mut dyn Iterator<Item=ExtendedHeader>,
 	) -> Result<(), Error> {
 		Ok(())
 	}
 
 	// Clique has no block reward.
-	fn on_close_block(&self, _block: &mut ExecutedBlock) -> Result<(), Error> {
+	fn on_close_block(
+		&self,
+		_block: &mut ExecutedBlock,
+		_parent_header: &Header
+	) -> Result<(), Error> {
 		Ok(())
 	}
 

--- a/ethcore/src/engines/clique/tests.rs
+++ b/ethcore/src/engines/clique/tests.rs
@@ -111,7 +111,7 @@ impl CliqueTester {
 
 	/// Get signers after a certain state
 	// This is generally used to fetch the state after a test has been executed and checked against
-	// the intial list of signers provided in the test
+	// the initial list of signers provided in the test
 	pub fn clique_signers(&self, hash: &H256) -> impl Iterator<Item = Address> {
 		self.get_state_at_block(hash).signers().clone().into_iter()
 	}
@@ -171,7 +171,6 @@ impl CliqueTester {
 			(3141562.into(), 31415620.into()),
 			extra_data,
 			false,
-			None,
 		).unwrap();
 
 		{

--- a/ethcore/src/engines/instant_seal.rs
+++ b/ethcore/src/engines/instant_seal.rs
@@ -110,7 +110,7 @@ mod tests {
 		let db = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
 		let genesis_header = spec.genesis_header();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
-		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let b = b.close_and_lock().unwrap();
 		if let Seal::Regular(seal) = engine.generate_seal(&b, &genesis_header) {
 			assert!(b.try_seal(engine, seal).is_ok());

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -304,13 +304,16 @@ pub trait Engine: Sync + Send {
 		&self,
 		_block: &mut ExecutedBlock,
 		_epoch_begin: bool,
-		_ancestry: &mut dyn Iterator<Item = ExtendedHeader>,
 	) -> Result<(), Error> {
 		Ok(())
 	}
 
 	/// Block transformation functions, after the transactions.
-	fn on_close_block(&self, _block: &mut ExecutedBlock) -> Result<(), Error> {
+	fn on_close_block(
+		&self,
+		_block: &mut ExecutedBlock,
+		_parent_header: &Header,
+	) -> Result<(), Error> {
 		Ok(())
 	}
 

--- a/ethcore/src/engines/null_engine.rs
+++ b/ethcore/src/engines/null_engine.rs
@@ -61,7 +61,11 @@ impl Engine for NullEngine {
 
 	fn machine(&self) -> &Machine { &self.machine }
 
-	fn on_close_block(&self, block: &mut ExecutedBlock) -> Result<(), Error> {
+	fn on_close_block(
+		&self,
+		block: &mut ExecutedBlock,
+		_parent_header: &Header
+	) -> Result<(), Error> {
 		use std::ops::Shr;
 
 		let author = *block.header.author();

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -540,7 +540,7 @@ mod tests {
 		let genesis_header = spec.genesis_header();
 		let db = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
-		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let b = b.close().unwrap();
 		assert_eq!(b.state.balance(&Address::zero()).unwrap(), U256::from_str("4563918244f40000").unwrap());
 	}
@@ -589,7 +589,7 @@ mod tests {
 		let genesis_header = spec.genesis_header();
 		let db = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
-		let mut b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let mut b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let mut uncle = Header::new();
 		let uncle_author = Address::from_str("ef2d6d194084c2de36e0dabfce45d046b37d1106").unwrap();
 		uncle.set_author(uncle_author);
@@ -607,7 +607,7 @@ mod tests {
 		let genesis_header = spec.genesis_header();
 		let db = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
-		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![], false, None).unwrap();
+		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![], false).unwrap();
 		let b = b.close().unwrap();
 
 		let ubi_contract = Address::from_str("00efdd5883ec628983e9063c7d969fe268bbf310").unwrap();

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -239,7 +239,7 @@ impl Engine for Arc<Ethash> {
 
 	/// Apply the block reward on finalisation of the block.
 	/// This assumes that all uncles are valid uncles (i.e. of at least one generation before the current).
-	fn on_close_block(&self, block: &mut ExecutedBlock) -> Result<(), Error> {
+	fn on_close_block(&self, block: &mut ExecutedBlock, _parent_header: &Header) -> Result<(), Error> {
 		use std::ops::Shr;
 
 		let author = *block.header.author();

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -548,7 +548,7 @@ impl Miner {
 					}
 				},
 				// Invalid nonce error can happen only if previous transaction is skipped because of gas limit.
-				// If there is errornous state of transaction queue it will be fixed when next block is imported.
+				// If there is erroneous state of transaction queue it will be fixed when next block is imported.
 				Err(Error::Execution(ExecutionError::InvalidNonce { expected, got })) => {
 					debug!(target: "miner", "Skipping adding transaction to block because of invalid nonce: {:?} (expected: {:?}, got: {:?})", hash, expected, got);
 				},

--- a/ethcore/src/test_helpers.rs
+++ b/ethcore/src/test_helpers.rs
@@ -155,7 +155,6 @@ pub fn generate_dummy_client_with_spec_and_data<F>(test_spec: F, block_number: u
 			(3141562.into(), 31415620.into()),
 			vec![],
 			false,
-			None,
 		).unwrap();
 		rolling_timestamp += 10;
 		b.set_timestamp(rolling_timestamp);

--- a/ethcore/src/tests/client.rs
+++ b/ethcore/src/tests/client.rs
@@ -117,7 +117,7 @@ fn query_none_block() {
 		Arc::new(Miner::new_for_tests(&spec, None)),
 		IoChannel::disconnected(),
 	).unwrap();
-    let non_existant = client.block_header(BlockId::Number(188));
+	let non_existant = client.block_header(BlockId::Number(188));
 	assert!(non_existant.is_none());
 }
 

--- a/ethcore/src/tests/trace.rs
+++ b/ethcore/src/tests/trace.rs
@@ -87,7 +87,6 @@ fn can_trace_block_and_uncle_reward() {
 		(3141562.into(), 31415620.into()),
 		vec![],
 		false,
-		None,
 	).unwrap();
 	rolling_timestamp += 10;
 	root_block.set_timestamp(rolling_timestamp);
@@ -116,7 +115,6 @@ fn can_trace_block_and_uncle_reward() {
 		(3141562.into(), 31415620.into()),
 		vec![],
 		false,
-		None,
 	).unwrap();
 	rolling_timestamp += 10;
 	parent_block.set_timestamp(rolling_timestamp);
@@ -144,7 +142,6 @@ fn can_trace_block_and_uncle_reward() {
 		(3141562.into(), 31415620.into()),
 		vec![],
 		false,
-		None,
 		).unwrap();
 	rolling_timestamp += 10;
 	block.set_timestamp(rolling_timestamp);


### PR DESCRIPTION
ref. https://github.com/paritytech/parity-ethereum/issues/9114

Don't use the `Client` to [look up the parent block](https://github.com/paritytech/parity-ethereum/pull/10833/files#diff-3b2a71ed5fccb75dfe326f3b122487cdL1244) so we can [calculate the parent step](https://github.com/paritytech/parity-ethereum/pull/10833/files#diff-3b2a71ed5fccb75dfe326f3b122487cdR1247). Instead, store the parent header in the `OpenBlock` and [pass it](https://github.com/paritytech/parity-ethereum/pull/10833/files#diff-e2e171033e005c3b329818aaff213767R313) to `on_close_block()`.

It is unsatisfying to store a whole `Header` in all `OpenBlocks`/`ClosedBlocks` just because Aura need the parent step (a `u64`), but all calls to `OpenBlock::new()` already pass in the parent `Header` (so no new lookup/decoding). I tried to store a reference instead but `reopen()` is problematic.