### PR TITLE
Configuration map of block reward contract addresses

### DIFF
--- a/json/src/spec/authority_round.rs
+++ b/json/src/spec/authority_round.rs
@@ -14,7 +14,29 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Authority params deserialization.
+//! Authority Round parameter deserialization.
+//!
+//! Here is an example of input parameters where the step duration is constant at 5 seconds, the set
+//! of validators is decided by the contract at address `0x10..01` starting from block 0, and where
+//! the address of the contract that computes block rewards is set to `0x20..02` for blocks 0
+//! through 41 and to `0x30.03` for all blocks starting from block 42.
+//!
+//! ```ignore
+//! "params": {
+//!     "stepDuration": "5",
+//!     "validators": {
+//!         "multi": {
+//!             "0": {
+//!                 "contract": "0x1000000000000000000000000000000000000001"
+//!             }
+//!         }
+//!     },
+//!     "blockRewardContractTransitions": {
+//!         "0": "0x2000000000000000000000000000000000000002",
+//!         "42": "0x3000000000000000000000000000000000000003"
+//!     }
+//! }
+//! ```
 
 use std::collections::BTreeMap;
 use hash::Address;
@@ -46,14 +68,19 @@ pub struct AuthorityRoundParams {
 	/// a single block reward contract transition and is compatible with the multiple address option
 	/// `block_reward_contract_transitions` below.
 	pub block_reward_contract_transition: Option<Uint>,
-	/// Block reward contract address (setting the block reward contract overrides the static block
-	/// reward definition). This option allows to add a single block reward contract address and is
-	/// compatible with the multiple address option `block_reward_contract_transitions` below.
+	/// Block reward contract address which overrides the `block_reward` setting. This option allows
+	/// to add a single block reward contract address and is compatible with the multiple address
+	/// option `block_reward_contract_transitions` below.
 	pub block_reward_contract_address: Option<Address>,
-	/// Block reward contract addresses with their associated starting block numbers. Setting the
-	/// block reward contract overrides the static block reward definition. If the single block
-	/// reward contract address is also present then it is added into the map at the block number
-	/// stored in `block_reward_contract_transition` or 0 if that block number is not provided.
+	/// Block reward contract addresses with their associated starting block numbers.
+	///
+	/// Setting the block reward contract overrides `block_reward`. If the single block reward
+	/// contract address is also present then it is added into the map at the block number stored in
+	/// `block_reward_contract_transition` or 0 if that block number is not provided. Therefore both
+	/// a single block reward contract transition and a map of reward contract transitions can be
+	/// used simulataneously in the same configuration. In such a case the code requires that the
+	/// block number of the single transition is strictly less than any of the block numbers in the
+	/// map.
 	pub block_reward_contract_transitions: Option<BTreeMap<Uint, Address>>,
 	/// Block reward code. This overrides the block reward contract address.
 	pub block_reward_contract_code: Option<Bytes>,

--- a/json/src/spec/authority_round.rs
+++ b/json/src/spec/authority_round.rs
@@ -64,13 +64,13 @@ pub struct AuthorityRoundParams {
 	pub immediate_transitions: Option<bool>,
 	/// Reward per block in wei.
 	pub block_reward: Option<Uint>,
-	/// Block at which the block reward contract should start being used. This option allows to add
-	/// a single block reward contract transition and is compatible with the multiple address option
-	/// `block_reward_contract_transitions` below.
+	/// Block at which the block reward contract should start being used. This option allows one to
+	/// add a single block reward contract transition and is compatible with the multiple address
+	/// option `block_reward_contract_transitions` below.
 	pub block_reward_contract_transition: Option<Uint>,
 	/// Block reward contract address which overrides the `block_reward` setting. This option allows
-	/// to add a single block reward contract address and is compatible with the multiple address
-	/// option `block_reward_contract_transitions` below.
+	/// one to add a single block reward contract address and is compatible with the multiple
+	/// address option `block_reward_contract_transitions` below.
 	pub block_reward_contract_address: Option<Address>,
 	/// Block reward contract addresses with their associated starting block numbers.
 	///

--- a/json/src/spec/authority_round.rs
+++ b/json/src/spec/authority_round.rs
@@ -16,6 +16,7 @@
 
 //! Authority params deserialization.
 
+use std::collections::BTreeMap;
 use hash::Address;
 use uint::Uint;
 use bytes::Bytes;
@@ -41,11 +42,19 @@ pub struct AuthorityRoundParams {
 	pub immediate_transitions: Option<bool>,
 	/// Reward per block in wei.
 	pub block_reward: Option<Uint>,
-	/// Block at which the block reward contract should start being used.
+	/// Block at which the block reward contract should start being used. This option allows to add
+	/// a single block reward contract transition and is compatible with the multiple address option
+	/// `block_reward_contract_transitions` below.
 	pub block_reward_contract_transition: Option<Uint>,
-	/// Block reward contract address (setting the block reward contract
-	/// overrides the static block reward definition).
+	/// Block reward contract address (setting the block reward contract overrides the static block
+	/// reward definition). This option allows to add a single block reward contract address and is
+	/// compatible with the multiple address option `block_reward_contract_transitions` below.
 	pub block_reward_contract_address: Option<Address>,
+	/// Block reward contract addresses with their associated starting block numbers. Setting the
+	/// block reward contract overrides the static block reward definition. If the single block
+	/// reward contract address is also present then it is added into the map at the block number
+	/// stored in `block_reward_contract_transition` or 0 if that block number is not provided.
+	pub block_reward_contract_transitions: Option<BTreeMap<Uint, Address>>,
 	/// Block reward code. This overrides the block reward contract address.
 	pub block_reward_contract_code: Option<Bytes>,
 	/// Block at which maximum uncle count should be considered.


### PR DESCRIPTION
The original issue fixed by this PR's changeset: https://github.com/poanetwork/parity-ethereum/issues/144.
