### PR TITLE
Transaction propagation improvements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,7 +153,7 @@ build-android:
 
 build-linux:
   <<:                              *build-on-linux
-  only:                            *releaseable_branches
+#  only:                            *releaseable_branches
 
 build-linux-i386:
   <<:                              *build-on-linux
@@ -223,7 +223,7 @@ publish-docker:
     DOCKER_DRIVER:                 overlay2
     GIT_STRATEGY:                  none
     # DOCKERFILE:                  tools/Dockerfile
-    # CONTAINER_IMAGE:             parity/parity 
+    # CONTAINER_IMAGE:             parity/parity
   script:
     # we stopped pushing nightlies to dockerhub, will push to own registry prb.
     - ./tools/publish-docker.sh

--- a/ethcore/src/json_tests/executive.rs
+++ b/ethcore/src/json_tests/executive.rs
@@ -300,7 +300,7 @@ fn do_json_test_for<H: FnMut(&str, HookType)>(vm_type: &VMType, json_data: &[u8]
 				&mut tracer,
 				&mut vm_tracer,
 			));
-			let mut evm = vm_factory.create(params, &schedule, 0).expect("Current tests are all of version 0; factory always return Some; qed");
+			let evm = vm_factory.create(params, &schedule, 0).expect("Current tests are all of version 0; factory always return Some; qed");
 			let res = evm.exec(&mut ex).ok().expect("TestExt never trap; resume error never happens; qed");
 			// a return in finalize will not alter callcreates
 			let callcreates = ex.callcreates.clone();

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::{Arc, mpsc, atomic};
+use std::sync::{Arc, mpsc};
 use std::collections::{HashMap, BTreeMap};
 use std::io;
 use std::ops::RangeInclusive;
@@ -238,16 +238,7 @@ pub enum PriorityTask {
 		difficulty: U256,
 	},
 	/// Propagate a list of transactions
-	PropagateTransactions(::std::time::Instant, Arc<atomic::AtomicBool>),
-}
-impl PriorityTask {
-	/// Mark the task as being processed, right after it's retrieved from the queue.
-	pub fn starting(&self) {
-		match *self {
-			PriorityTask::PropagateTransactions(_, ref is_ready) => is_ready.store(true, atomic::Ordering::SeqCst),
-			_ => {},
-		}
-	}
+	PropagateTransactions(::std::time::Instant, Vec<H256>),
 }
 
 /// EthSync initialization parameters.

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -456,10 +456,7 @@ impl ChainSyncApi {
 			// since we already have everything let's use a different deadline
 			// to do the rest of the job now, so that previous work is not wasted.
 			let deadline = Instant::now() + PRIORITY_TASK_DEADLINE;
-			let as_ms = move |prev| {
-				let dur: Duration = Instant::now() - prev;
-				dur.as_secs() * 1_000 + dur.subsec_millis() as u64
-			};
+			let elapsed_ms = |prev: Instant| { prev.elapsed().as_millis() };
 			match task {
 				// NOTE We can't simply use existing methods,
 				// cause the block is not in the DB yet.
@@ -478,13 +475,13 @@ impl ChainSyncApi {
 							}
 						}
 					}
-					debug!(target: "sync", "Finished block propagation, took {}ms", as_ms(started));
+					debug!(target: "sync", "Finished block propagation, took {}ms", elapsed_ms(started));
 				},
 				PriorityTask::PropagateTransactions(time, _) => {
 					SyncPropagator::propagate_new_transactions(&mut sync, io, || {
 						check_deadline(deadline).is_some()
 					});
-					debug!(target: "sync", "Finished transaction propagation, took {}ms", as_ms(time));
+					debug!(target: "sync", "Finished transaction propagation, took {}ms", elapsed_ms(time));
 				},
 			}
 

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -128,7 +128,7 @@ use self::sync_packet::SyncPacket::{
 	StatusPacket,
 };
 
-use self::propagator::SyncPropagator;
+use self::propagator::{SyncPropagator, TransactionsFilter};
 use self::requester::SyncRequester;
 pub(crate) use self::supplier::SyncSupplier;
 
@@ -479,7 +479,7 @@ impl ChainSyncApi {
 				PriorityTask::PropagateTransactions(time, txns) => {
 					SyncPropagator::propagate_new_transactions(&mut sync, io, || {
 						check_deadline(deadline).is_some()
-					}, Some(txns));
+					}, TransactionsFilter::Only(txns));
 					debug!(target: "sync", "Finished transaction propagation, took {}ms", elapsed_ms(time));
 				},
 			}
@@ -1338,7 +1338,7 @@ impl ChainSync {
 				debug!(target: "sync", "Wasn't able to finish transaction propagation within a deadline.");
 				false
 			}
-		}, None);
+		}, TransactionsFilter::All);
 	}
 
 	/// Broadcast consensus message to peers.

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -623,9 +623,48 @@ pub struct ChainSync {
 	private_tx_handler: Option<Arc<dyn PrivateTxHandler>>,
 	/// Enable warp sync.
 	warp_sync: WarpSync,
-
 	#[ignore_malloc_size_of = "mpsc unmettered, ignoring"]
-	status_sinks: Vec<futures_mpsc::UnboundedSender<SyncState>>
+	status_sinks: Vec<futures_mpsc::UnboundedSender<SyncState>>,
+	/// Cached peer selection for transaction propagation.
+	pub(crate) peers_for_txn_propagation: ExpiredCell<Vec<PeerId>>,
+}
+
+#[derive(Clone, Debug, MallocSizeOf)]
+pub(crate) struct ExpiredCell<T> {
+	inner: T,
+	last_updated: Instant,
+	expiration: Duration,
+}
+
+impl<T: Default + Clone> Default for ExpiredCell<T> {
+	fn default() -> Self {
+		Self::new(T::default(), Duration::from_secs(2))
+	}
+}
+
+impl<T: Clone> ExpiredCell<T> {
+	pub fn new(t: T, expiration: Duration) -> Self {
+		Self {
+			inner: t,
+			last_updated: Instant::now(),
+			expiration,
+		}
+	}
+
+	pub fn get<F>(&mut self, init: F) -> T
+	where
+		F: FnOnce() -> T,
+	{
+		if self.is_expired() {
+			self.inner = init();
+			self.last_updated = Instant::now();
+		}
+		self.inner.clone()
+	}
+
+	fn is_expired(&self) -> bool {
+		self.last_updated.elapsed() >= self.expiration
+	}
 }
 
 impl ChainSync {
@@ -657,7 +696,8 @@ impl ChainSync {
 			transactions_stats: TransactionsStats::default(),
 			private_tx_handler,
 			warp_sync: config.warp_sync,
-			status_sinks: Vec::new()
+			status_sinks: Vec::new(),
+			peers_for_txn_propagation: ExpiredCell::default(),
 		};
 		sync.update_targets(chain);
 		sync

--- a/ethcore/sync/src/chain/propagator.rs
+++ b/ethcore/sync/src/chain/propagator.rs
@@ -316,14 +316,13 @@ impl SyncPropagator {
 		where F: Fn(&PeerId) -> bool {
 		// sqrt(x)/x scaled to max u32
 		let fraction = ((sync.peers.len() as f64).powf(-0.5) * (u32::max_value() as f64).round()) as u32;
-		let peers = &sync.peers;
-		let small = peers.len() < MIN_PEERS_PROPAGATION;
+		let small = sync.peers.len() < MIN_PEERS_PROPAGATION;
+		let peers = sync.peers.keys().cloned();
 
 		let update_selection = || {
 			let mut rng = random::new();
-			peers.keys().filter(|_| small || rng.next_u32() < fraction)
+			peers.filter(|_| small || rng.next_u32() < fraction)
 				.take(MAX_PEERS_PROPAGATION)
-				.map(|id| *id)
 				.collect()
 		};
 

--- a/ethcore/sync/src/chain/propagator.rs
+++ b/ethcore/sync/src/chain/propagator.rs
@@ -234,15 +234,10 @@ impl SyncPropagator {
 				stats.propagated(hash, id, block_number);
 			}
 
-			peer_info.last_sent_transactions = all_transactions_hashes
-				.intersection(&peer_info.last_sent_transactions)
-				.chain(&to_send)
-				.cloned()
-				.collect();
+			peer_info.last_sent_transactions = all_transactions_hashes.clone();
 			send_packet(io, peer_id, to_send.len(), packet.out());
 			sent_to_peers.insert(peer_id);
 			max_sent = cmp::max(max_sent, to_send.len());
-
 		}
 
 		debug!(target: "sync", "Sent up to {} transactions to {} peers.", max_sent, sent_to_peers.len());

--- a/ethcore/sync/src/chain/propagator.rs
+++ b/ethcore/sync/src/chain/propagator.rs
@@ -478,13 +478,13 @@ mod tests {
 		let queue = RwLock::new(VecDeque::new());
 		let ss = TestSnapshotService::new();
 		let mut io = TestIo::new(&mut client, &ss, &queue, None);
-		let peer_count = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true);
+		let peer_count = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true, None);
 		// Try to propagate same transactions for the second time
-		let peer_count2 = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true);
+		let peer_count2 = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true, None);
 		// Even after new block transactions should not be propagated twice
 		sync.chain_new_blocks(&mut io, &[], &[], &[], &[], &[], &[]);
 		// Try to propagate same transactions for the third time
-		let peer_count3 = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true);
+		let peer_count3 = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true, None);
 
 		// 1 message should be send
 		assert_eq!(1, io.packets.len());
@@ -505,7 +505,7 @@ mod tests {
 		let queue = RwLock::new(VecDeque::new());
 		let ss = TestSnapshotService::new();
 		let mut io = TestIo::new(&mut client, &ss, &queue, None);
-		let peer_count = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true);
+		let peer_count = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true, None);
 		io.chain.insert_transaction_to_queue();
 		// New block import should not trigger propagation.
 		// (we only propagate on timeout)
@@ -529,10 +529,10 @@ mod tests {
 		let queue = RwLock::new(VecDeque::new());
 		let ss = TestSnapshotService::new();
 		let mut io = TestIo::new(&mut client, &ss, &queue, None);
-		let peer_count = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true);
+		let peer_count = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true, None);
 		sync.chain_new_blocks(&mut io, &[], &[], &[], &[], &[], &[]);
 		// Try to propagate same transactions for the second time
-		let peer_count2 = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true);
+		let peer_count2 = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true, None);
 
 		assert_eq!(0, io.packets.len());
 		assert_eq!(0, peer_count);
@@ -550,7 +550,7 @@ mod tests {
 		// should sent some
 		{
 			let mut io = TestIo::new(&mut client, &ss, &queue, None);
-			let peer_count = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true);
+			let peer_count = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true, None);
 			assert_eq!(1, io.packets.len());
 			assert_eq!(1, peer_count);
 		}
@@ -559,9 +559,9 @@ mod tests {
 		let (peer_count2, peer_count3) = {
 			let mut io = TestIo::new(&mut client, &ss, &queue, None);
 			// Propagate new transactions
-			let peer_count2 = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true);
+			let peer_count2 = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true, None);
 			// And now the peer should have all transactions
-			let peer_count3 = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true);
+			let peer_count3 = SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true, None);
 			(peer_count2, peer_count3)
 		};
 
@@ -584,7 +584,7 @@ mod tests {
 		let queue = RwLock::new(VecDeque::new());
 		let ss = TestSnapshotService::new();
 		let mut io = TestIo::new(&mut client, &ss, &queue, None);
-		SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true);
+		SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true, None);
 
 		let stats = sync.transactions_stats();
 		assert_eq!(stats.len(), 1, "Should maintain stats for single transaction.")
@@ -611,7 +611,7 @@ mod tests {
 		io.peers_info.insert(3, "Parity-Ethereum/ABCDEFGH/v2.7.3/linux/rustc".to_owned());
 
 		// and new service transaction is propagated to peers
-		SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true);
+		SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true, None);
 
 		// peer#2 && peer#3 are receiving service transaction
 		assert!(io.packets.iter().any(|p| p.packet_id == 0x02 && p.recipient == 2)); // TRANSACTIONS_PACKET
@@ -635,7 +635,7 @@ mod tests {
 		io.peers_info.insert(1, "Parity-Ethereum/v2.6.0/linux/rustc".to_owned());
 
 		// and service + non-service transactions are propagated to peers
-		SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true);
+		SyncPropagator::propagate_new_transactions(&mut sync, &mut io, || true, None);
 
 		// two separate packets for peer are queued:
 		// 1) with non-service-transaction

--- a/ethcore/sync/src/chain/propagator.rs
+++ b/ethcore/sync/src/chain/propagator.rs
@@ -316,13 +316,14 @@ impl SyncPropagator {
 		where F: Fn(&PeerId) -> bool {
 		// sqrt(x)/x scaled to max u32
 		let fraction = ((sync.peers.len() as f64).powf(-0.5) * (u32::max_value() as f64).round()) as u32;
-		let small = sync.peers.len() < MIN_PEERS_PROPAGATION;
-		let peers = sync.peers.keys().cloned();
+		let peers = &sync.peers;
+		let small = peers.len() < MIN_PEERS_PROPAGATION;
 
 		let update_selection = || {
 			let mut rng = random::new();
-			peers.filter(|_| small || rng.next_u32() < fraction)
+			peers.keys().filter(|_| small || rng.next_u32() < fraction)
 				.take(MAX_PEERS_PROPAGATION)
+				.map(|id| *id)
 				.collect()
 		};
 

--- a/ethcore/sync/src/chain/propagator.rs
+++ b/ethcore/sync/src/chain/propagator.rs
@@ -176,11 +176,8 @@ impl SyncPropagator {
 			}
 
 			let stats = &mut sync.transactions_stats;
-
-			let peer_info = match sync.peers.get_mut(&peer_id) {
-				Some(info) => info,
-				None => continue,
-			};
+			let peer_info = sync.peers.get_mut(&peer_id)
+				.expect("peer_id is form peers; peers is result of select_peers_for_transactions; select_peers_for_transactions selects peers from self.peers; qed");
 
 			// Send all transactions, if the peer doesn't know about anything
 			if peer_info.last_sent_transactions.is_empty() {
@@ -312,27 +309,19 @@ impl SyncPropagator {
 		}
 	}
 
-	fn select_peers_for_transactions<F>(sync: &mut ChainSync, filter: F) -> Vec<PeerId>
+	fn select_peers_for_transactions<F>(sync: &ChainSync, filter: F) -> Vec<PeerId>
 		where F: Fn(&PeerId) -> bool {
 		// sqrt(x)/x scaled to max u32
 		let fraction = ((sync.peers.len() as f64).powf(-0.5) * (u32::max_value() as f64).round()) as u32;
 		let small = sync.peers.len() < MIN_PEERS_PROPAGATION;
-		let peers = sync.peers.keys().cloned();
 
-		let update_selection = || {
-			let mut rng = random::new();
-			peers.filter(|_| small || rng.next_u32() < fraction)
-				.take(MAX_PEERS_PROPAGATION)
-				.collect()
-		};
-
-		let v = sync.peers_for_txn_propagation
-			.get(update_selection)
-			.into_iter()
+		let mut random = random::new();
+		sync.peers.keys()
+			.cloned()
 			.filter(filter)
-			.collect();
-		debug!(target: "sync", "selected peers for txn propagation {:?}", v);
-		v
+			.filter(|_| small || random.next_u32() < fraction)
+			.take(MAX_PEERS_PROPAGATION)
+			.collect()
 	}
 
 	/// Generic packet sender

--- a/miner/src/pool/local_transactions.rs
+++ b/miner/src/pool/local_transactions.rs
@@ -21,7 +21,7 @@ use std::{fmt, sync::Arc};
 use ethereum_types::H256;
 use linked_hash_map::LinkedHashMap;
 use pool::{VerifiedTransaction as Transaction, ScoredTransaction};
-use txpool::{self, VerifiedTransaction};
+use txpool;
 
 /// Status of local transaction.
 /// Can indicate that the transaction is currently part of the queue (`Pending/Future`)

--- a/miner/src/pool/mod.rs
+++ b/miner/src/pool/mod.rs
@@ -165,6 +165,10 @@ impl VerifiedTransaction {
 		&self.transaction
 	}
 
+	/// Gets the transaction hash
+	pub fn hash(&self) -> &H256 {
+		&self.hash
+	}
 }
 
 impl txpool::VerifiedTransaction for VerifiedTransaction {


### PR DESCRIPTION
Implement suggestions by @tomusdrw:
* propagates only new transactions when we get an import notification [here](https://github.com/paritytech/parity-ethereum/pull/10877/files#diff-05d235380ad5b27b1e5ee6a84511a5e8R658), but send it no more than once per 20ms

TODO
- [ ] check if we need to tweak sending transactions on `TX_TIMER` at all