### PR TITLE
fn queue_transactions accepts UnverifiedTransactions

### DIFF
--- a/ethcore/light/src/net/mod.rs
+++ b/ethcore/light/src/net/mod.rs
@@ -246,7 +246,7 @@ pub trait Handler: Send + Sync {
 	/// Called when a peer makes an announcement.
 	fn on_announcement(&self, _ctx: &dyn EventContext, _announcement: &Announcement) { }
 	/// Called when a peer requests relay of some transactions.
-	fn on_transactions(&self, _ctx: &dyn EventContext, _relay: &[UnverifiedTransaction]) { }
+	fn on_transactions(&self, _ctx: &dyn EventContext, _relay: Vec<UnverifiedTransaction>) { }
 	/// Called when a peer responds to requests.
 	/// Responses not guaranteed to contain valid data and are not yet checked against
 	/// the requests they correspond to.
@@ -1138,7 +1138,7 @@ impl LightProtocol {
 				peer,
 				io,
 				proto: self,
-			}, &txs);
+			}, txs.clone());
 		}
 
 		Ok(())

--- a/ethcore/src/client/chain_notify.rs
+++ b/ethcore/src/client/chain_notify.rs
@@ -16,7 +16,6 @@
 
 use bytes::Bytes;
 use ethereum_types::{H256, U256};
-use types::transaction::UnverifiedTransaction;
 use blockchain::ImportRoute;
 use std::time::Duration;
 use std::collections::HashMap;
@@ -185,7 +184,7 @@ pub trait ChainNotify : Send + Sync {
 
 	/// fires when new transactions are received from a peer
 	fn transactions_received(&self,
-		_txs: &[UnverifiedTransaction],
+		_txs: &[H256],
 		_peer_id: usize,
 	) {
 		// does nothing by default

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -34,9 +34,9 @@ use itertools::Itertools;
 use kvdb::DBValue;
 use kvdb_memorydb;
 use parking_lot::RwLock;
-use rlp::{Rlp, RlpStream};
+use rlp::RlpStream;
 use rustc_hex::FromHex;
-use types::transaction::{self, Transaction, LocalizedTransaction, SignedTransaction, Action};
+use types::transaction::{self, Transaction, LocalizedTransaction, SignedTransaction, Action, UnverifiedTransaction};
 use types::BlockNumber;
 use types::basic_account::BasicAccount;
 use types::encoded;
@@ -903,10 +903,9 @@ impl BlockChainClient for TestBlockChainClient {
 }
 
 impl IoClient for TestBlockChainClient {
-	fn queue_transactions(&self, transactions: Vec<Bytes>, _peer_id: usize) {
+	fn queue_transactions(&self, transactions: Vec<UnverifiedTransaction>, _peer_id: usize) {
 		// import right here
-		let txs = transactions.into_iter().filter_map(|bytes| Rlp::new(&bytes).as_val().ok()).collect();
-		self.miner.import_external_transactions(self, txs);
+		self.miner.import_external_transactions(self, transactions);
 	}
 
 	fn queue_ancient_block(&self, unverified: Unverified, _r: Bytes) -> EthcoreResult<H256> {

--- a/ethcore/src/client/traits.rs
+++ b/ethcore/src/client/traits.rs
@@ -25,7 +25,7 @@ use ethereum_types::{H256, U256, Address};
 use evm::Schedule;
 use itertools::Itertools;
 use kvdb::DBValue;
-use types::transaction::{self, LocalizedTransaction, SignedTransaction};
+use types::transaction::{self, LocalizedTransaction, SignedTransaction, UnverifiedTransaction};
 use types::BlockNumber;
 use types::basic_account::BasicAccount;
 use types::block_status::BlockStatus;
@@ -184,7 +184,7 @@ pub trait EngineInfo {
 /// IO operations that should off-load heavy work to another thread.
 pub trait IoClient: Sync + Send {
 	/// Queue transactions for importing.
-	fn queue_transactions(&self, transactions: Vec<Bytes>, peer_id: usize);
+	fn queue_transactions(&self, transactions: Vec<UnverifiedTransaction>, peer_id: usize);
 
 	/// Queue block import with transaction receipts. Does no sealing and transaction validation.
 	fn queue_ancient_block(&self, block_bytes: Unverified, receipts_bytes: Bytes) -> EthcoreResult<H256>;

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -541,9 +541,13 @@ pub trait Engine: Sync + Send {
 		self.machine().verify_transaction_basic(t, header)
 	}
 
-	/// Performs pre-validation of RLP decoded transaction before other processing
-	fn decode_transaction(&self, transaction: &[u8]) -> Result<UnverifiedTransaction, transaction::Error> {
-		self.machine().decode_transaction(transaction)
+	/// Verifies len of transaction RLP
+	fn verify_transaction_len(&self, transaction: &[u8]) -> Result<(), transaction::Error> {
+		if transaction.len() > self.params().max_transaction_size {
+			return Err(transaction::Error::TooBig)
+		}
+
+		Ok(())
 	}
 }
 

--- a/ethcore/src/machine.rs
+++ b/ethcore/src/machine.rs
@@ -21,7 +21,6 @@ use std::cmp;
 use std::sync::Arc;
 
 use ethereum_types::{U256, H256, Address};
-use rlp::Rlp;
 use types::transaction::{self, SYSTEM_ADDRESS, UNSIGNED_SENDER, UnverifiedTransaction, SignedTransaction};
 use types::BlockNumber;
 use types::header::Header;
@@ -383,16 +382,6 @@ impl Machine {
 		}
 
 		Ok(())
-	}
-
-	/// Performs pre-validation of RLP decoded transaction before other processing
-	pub fn decode_transaction(&self, transaction: &[u8]) -> Result<UnverifiedTransaction, transaction::Error> {
-		let rlp = Rlp::new(&transaction);
-		if rlp.as_raw().len() > self.params().max_transaction_size {
-			debug!("Rejected oversized transaction of {} bytes", rlp.as_raw().len());
-			return Err(transaction::Error::TooBig)
-		}
-		rlp.as_val().map_err(|e| transaction::Error::InvalidRlp(e.to_string()))
 	}
 
 	/// Get the balance, in base units, associated with an account.

--- a/ethcore/src/miner/pool_client.rs
+++ b/ethcore/src/miner/pool_client.rs
@@ -169,8 +169,8 @@ impl<'a, C: 'a> pool::client::Client for PoolClient<'a, C> where
 		}
 	}
 
-	fn decode_transaction(&self, transaction: &[u8]) -> Result<UnverifiedTransaction, transaction::Error> {
-		self.engine.decode_transaction(transaction)
+	fn verify_transaction_len(&self, transaction: &[u8]) -> Result<(), transaction::Error> {
+		self.engine.verify_transaction_len(transaction)
 	}
 }
 

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -53,7 +53,6 @@ use parity_runtime::Executor;
 use std::sync::atomic::{AtomicBool, Ordering};
 use network::IpFilter;
 use private_tx::PrivateTxHandler;
-use types::transaction::UnverifiedTransaction;
 
 use super::light_sync::SyncInfo;
 
@@ -603,7 +602,7 @@ impl ChainNotify for EthSync {
 		});
 	}
 
-	fn transactions_received(&self, txs: &[UnverifiedTransaction], peer_id: PeerId) {
+	fn transactions_received(&self, txs: &[H256], peer_id: PeerId) {
 		let mut sync = self.eth_handler.sync.write();
 		sync.transactions_received(txs, peer_id);
 	}
@@ -614,9 +613,9 @@ impl ChainNotify for EthSync {
 struct TxRelay(Arc<dyn BlockChainClient>);
 
 impl LightHandler for TxRelay {
-	fn on_transactions(&self, ctx: &dyn EventContext, relay: &[::types::transaction::UnverifiedTransaction]) {
+	fn on_transactions(&self, ctx: &dyn EventContext, relay: Vec<::types::transaction::UnverifiedTransaction>) {
 		trace!(target: "pip", "Relaying {} transactions from peer {}", relay.len(), ctx.peer());
-		self.0.queue_transactions(relay.iter().map(|tx| ::rlp::encode(tx)).collect(), ctx.peer())
+		self.0.queue_transactions(relay, ctx.peer())
 	}
 }
 

--- a/ethcore/sync/src/chain/handler.rs
+++ b/ethcore/sync/src/chain/handler.rs
@@ -673,8 +673,7 @@ impl SyncHandler {
 		trace!(target: "sync", "{:02} -> Transactions ({} entries)", peer_id, item_count);
 		let mut transactions = Vec::with_capacity(item_count);
 		for i in 0 .. item_count {
-			let rlp = r.at(i)?;
-			let tx = rlp.as_raw().to_vec();
+			let tx = r.val_at(i)?;
 			transactions.push(tx);
 		}
 		io.chain().queue_transactions(transactions, peer_id);

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -118,7 +118,6 @@ use snapshot::{Snapshot};
 use api::{EthProtocolInfo as PeerInfoDigest, WARP_SYNC_PROTOCOL_ID, PriorityTask};
 use private_tx::PrivateTxHandler;
 use transactions_stats::{TransactionsStats, Stats as TransactionStats};
-use types::transaction::UnverifiedTransaction;
 use types::BlockNumber;
 
 use self::handler::SyncHandler;
@@ -701,9 +700,9 @@ impl ChainSync {
 	}
 
 	/// Updates transactions were received by a peer
-	pub fn transactions_received(&mut self, txs: &[UnverifiedTransaction], peer_id: PeerId) {
+	pub fn transactions_received(&mut self, txs: &[H256], peer_id: PeerId) {
 		if let Some(peer_info) = self.peers.get_mut(&peer_id) {
-			peer_info.last_sent_transactions.extend(txs.iter().map(|tx| tx.hash()));
+			peer_info.last_sent_transactions.extend(txs);
 		}
 	}
 
@@ -1373,6 +1372,7 @@ pub mod tests {
 	use ethcore::client::{BlockChainClient, EachBlockWith, TestBlockChainClient, ChainInfo, BlockInfo};
 	use ethcore::miner::{MinerService, PendingOrdering};
 	use types::header::Header;
+	use types::transaction::UnverifiedTransaction;
 
 	pub fn get_dummy_block(order: u32, parent_hash: H256) -> Bytes {
 		let mut header = Header::new();

--- a/ethcore/sync/src/chain/propagator.rs
+++ b/ethcore/sync/src/chain/propagator.rs
@@ -335,12 +335,14 @@ impl SyncPropagator {
 
 #[cfg(test)]
 mod tests {
-	use ethcore::client::{BlockInfo, ChainInfo, EachBlockWith, TestBlockChainClient};
+	use std::collections::VecDeque;
 	use parking_lot::RwLock;
-	use rlp::{Rlp};
-	use std::collections::{VecDeque};
-	use tests::helpers::{TestIo};
+
+	use ethcore::client::{BlockInfo, ChainInfo, EachBlockWith, TestBlockChainClient};
+	use rlp::Rlp;
+	use tests::helpers::TestIo;
 	use tests::snapshot::TestSnapshotService;
+	use types::transaction::UnverifiedTransaction;
 
 	use super::{*, super::{*, tests::*}};
 

--- a/miner/src/pool/client.rs
+++ b/miner/src/pool/client.rs
@@ -63,9 +63,8 @@ pub trait Client: fmt::Debug + Sync {
 	/// Classify transaction (check if transaction is filtered by some contracts).
 	fn transaction_type(&self, tx: &transaction::SignedTransaction) -> TransactionType;
 
-	/// Performs pre-validation of RLP decoded transaction
-	fn decode_transaction(&self, transaction: &[u8])
-		-> Result<transaction::UnverifiedTransaction, transaction::Error>;
+	/// Verifies len of transaction RLP
+	fn verify_transaction_len(&self, transaction: &[u8]) -> Result<(), transaction::Error>;
 }
 
 /// State nonce client

--- a/miner/src/pool/tests/client.rs
+++ b/miner/src/pool/tests/client.rs
@@ -17,7 +17,6 @@
 use std::sync::{atomic, Arc};
 
 use ethereum_types::{U256, H256, Address};
-use rlp::Rlp;
 use types::transaction::{self, Transaction, SignedTransaction, UnverifiedTransaction};
 
 use pool;
@@ -131,14 +130,13 @@ impl pool::client::Client for TestClient {
 		}
 	}
 
-	fn decode_transaction(&self, transaction: &[u8]) -> Result<UnverifiedTransaction, transaction::Error> {
-		let rlp = Rlp::new(&transaction);
-		if rlp.as_raw().len() > self.max_transaction_size {
+	fn verify_transaction_len(&self, transaction: &[u8]) -> Result<(), transaction::Error> {
+		if transaction.len() > self.max_transaction_size {
 			return Err(transaction::Error::TooBig)
 		}
-		rlp.as_val().map_err(|e| transaction::Error::InvalidRlp(e.to_string()))
-	}
 
+		Ok(())
+	}
 }
 
 impl pool::client::NonceClient for TestClient {

--- a/miner/src/pool/verifier.rs
+++ b/miner/src/pool/verifier.rs
@@ -254,7 +254,7 @@ impl<C: Client> txpool::Verifier<Transaction> for Verifier<C, ::pool::scoring::N
 		};
 
 		// Verify RLP payload
-		if let Err(err) = self.client.decode_transaction(&transaction.rlp_bytes()) {
+		if let Err(err) = self.client.verify_transaction_len(&transaction.rlp_bytes()) {
 			debug!(target: "txqueue", "[{:?}] Rejected transaction's rlp payload", err);
 			return Err(err)
 		}


### PR DESCRIPTION
importing transactions on a client layer is a mess, this pr tries too simplify it a bit and reduce the number of redundant transaction encoding and decoding. example scenario before this pr and after this pr

#### before

light client, relay:

- `ethcore/light/src/net/mod.rs` decodes transaction
- `ethcore/sync/src/api.rs` encodes transaction
- `ethcore/src/client/client.rs ` decodes transaction
- `miner/src/pool/verifier.rs` encodes transaction
- `ethcore/src/machine.rs` decodes transaction

#### now

light client, relay

- `ethcore/light/src/net/mod.rs` decodes transaction
- `miner/src/pool/verifier.rs` encodes transaction

it's still not perfect, but definitely better than it was before