### PR TITLE
Avast whitelist script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,7 +193,7 @@ build-darwin:
 build-windows:
   stage:                           build
   <<:                              *collect_artifacts
-  only:                            *releaseable_branches
+  # only:                            *releaseable_branches
   variables:
     CARGO_TARGET:                  x86_64-pc-windows-msvc
     CARGO_HOME:                    "C:/ci-cache/parity-ethereum/cargo/$CI_JOB_NAME"
@@ -323,3 +323,18 @@ publish-docs:
   tags:
     - linux-docker
   allow_failure:                   true
+
+publish-av-whitelist:
+  stage:                          publish
+  <<:                             *no_git
+  # only:                           *releaseable_branches
+  except:
+    variables:
+      - $SCHEDULE_TAG == "nightly"
+  cache:                          {}
+  dependencies:
+    - build-windows
+  script:
+    - scripts/gitlab/publish-av-whitelists.sh
+  tags:
+    - linux-docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,7 +193,7 @@ build-darwin:
 build-windows:
   stage:                           build
   <<:                              *collect_artifacts
-  # only:                            *releaseable_branches
+  only:                            *releaseable_branches
   variables:
     CARGO_TARGET:                  x86_64-pc-windows-msvc
     CARGO_HOME:                    "C:/ci-cache/parity-ethereum/cargo/$CI_JOB_NAME"

--- a/scripts/gitlab/publish-av-whitelists.sh
+++ b/scripts/gitlab/publish-av-whitelists.sh
@@ -3,7 +3,7 @@ set -e
 
 echo "__________Publish Windows binaries to Avast Whitelisting program__________"
 
-target_filename="parity-${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}.exe"
+target_filename="parity-${CI_COMMIT_TAG:-${CI_COMMIT_REF_NAME}}.exe"
 apt -y update
 apt -y install ftp
 ls ./artifacts

--- a/scripts/gitlab/publish-av-whitelists.sh
+++ b/scripts/gitlab/publish-av-whitelists.sh
@@ -6,7 +6,6 @@ echo "__________Publish Windows binaries to Avast Whitelisting program__________
 target_filename="parity-${CI_COMMIT_TAG:-${CI_COMMIT_REF_NAME}}.exe"
 apt -y update
 apt -y install ftp
-ls ./artifacts
 ftp -pinv whitelisting.avast.com <<EOF
 quote USER ftp_parityio
 quote PASS $avast_ftp_password

--- a/scripts/gitlab/publish-av-whitelists.sh
+++ b/scripts/gitlab/publish-av-whitelists.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+echo "__________Publish Windows binaries to Avast Whitelisting program__________"
+
+target_filename="parity-${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}.exe"
+apt -y update
+apt -y install ftp
+ls ./artifacts
+ftp -pinv whitelisting.avast.com <<EOF
+quote USER ftp_parityio
+quote PASS $avast_ftp_password
+cd /share
+put ./artifacts/x86_64-pc-windows-msvc/parity.exe $target_filename
+bye
+EOF
+


### PR DESCRIPTION
Adds a script to automatically push Windows binaries (currently only `parity.exe`) to Avast's AV Whitelisting program. Should reduce the change of false positives (ref: #10598).