### PR TITLE
tx-pool: accept local tx with higher gas price when pool full

### DIFF
--- a/miner/src/pool/replace.rs
+++ b/miner/src/pool/replace.rs
@@ -75,36 +75,21 @@ where
 				// calculate readiness based on state nonce + pooled txs from same sender
 				let is_ready = |replace: &ReplaceTransaction<T>| {
 					let mut nonce = state.account_nonce(replace.sender());
-					let mut tx_same_nonce = None;
 					if let Some(txs) = replace.pooled_by_sender {
 						for tx in txs.iter() {
 							if nonce == tx.nonce() && *tx.transaction != ***replace.transaction {
-								nonce = nonce.saturating_add(U256::from(1));
-								if tx.nonce() == replace.nonce() {
-									tx_same_nonce = Some(tx.clone());
-								}
+								nonce = nonce.saturating_add(U256::from(1))
 							} else {
 								break
 							}
 						}
 					}
-					(nonce == replace.nonce(), tx_same_nonce)
+					nonce == replace.nonce()
 				};
 
-				let (new_is_ready, tx_same_nonce) = is_ready(new);
-				let (old_is_ready, _) = is_ready(old);
-
-				if !new_is_ready && old_is_ready {
-					let new_is_same_nonce_and_better = tx_same_nonce
-						.map_or(false, |existing_tx| {
-							new.priority().is_local() && self.scoring.choose(&existing_tx, &new) != Choice::RejectNew
-						});
-					if new_is_same_nonce_and_better {
-						Choice::InsertNew
-					} else {
-						// prevent a ready transaction being replace by a non-ready transaction
-						Choice::RejectNew
-					}
+				if !is_ready(new) && is_ready(old) {
+					// prevent a ready transaction being replace by a non-ready transaction
+					Choice::RejectNew
 				} else {
 					Choice::ReplaceOld
 				}
@@ -426,47 +411,5 @@ mod tests {
 		let new = ReplaceTransaction::new(&new_tx, Some(&pooled_txs));
 
 		assert_eq!(replace.should_replace(&old, &new), ReplaceOld);
-	}
-
-	#[test]
-	fn should_accept_local_tx_with_same_sender_and_nonce_with_better_gas_price() {
-		let scoring = NonceAndGasPrice(PrioritizationStrategy::GasPriceOnly);
-		let client = TestClient::new().with_nonce(1);
-		let replace = ReplaceByScoreAndReadiness::new(scoring, client);
-
-		// current transaction is ready
-		let old_tx = {
-			let tx = Tx {
-				nonce: 1,
-				gas_price: 1,
-				..Default::default()
-			};
-			tx.signed().verified()
-		};
-
-		let new_sender = Random.generate().unwrap();
-		let tx_new_ready_1 = local_tx_verified(Tx {
-			nonce: 1,
-			gas_price: 1,
-			..Default::default()
-		}, &new_sender);
-
-		let tx_new_ready_2 = local_tx_verified(Tx {
-			nonce: 1,
-			gas_price: 2, // same nonce, higher gas price
-			..Default::default()
-		}, &new_sender);
-
-		let old_tx = txpool::Transaction { insertion_id: 0, transaction: Arc::new(old_tx) };
-
-		let new_tx = txpool::Transaction { insertion_id: 0, transaction: Arc::new(tx_new_ready_2) };
-		let pooled_txs = [
-			txpool::Transaction { insertion_id: 0, transaction: Arc::new(tx_new_ready_1) },
-		];
-
-		let old = ReplaceTransaction::new(&old_tx, None);
-		let new = ReplaceTransaction::new(&new_tx, Some(&pooled_txs));
-
-		assert_eq!(replace.should_replace(&old, &new), InsertNew);
 	}
 }

--- a/miner/src/pool/replace.rs
+++ b/miner/src/pool/replace.rs
@@ -71,7 +71,11 @@ where
 			let old_score = (old.priority(), old.gas_price());
 			let new_score = (new.priority(), new.gas_price());
 			if new_score > old_score {
-				// check for an existing transaction with the same nonce
+				// Check if this is a replacement transaction.
+				// 
+				// With replacement transactions we can safely return `InsertNew` here, because
+				// we don't need to remove `old` (worst transaction in the pool) since `new` will replace
+			    // some other transaction in the pool so we will never go above limit anyway.
 				if let Some(txs) = new.pooled_by_sender {
 					if let Ok(index) = txs.binary_search_by(|old| self.scoring.compare(old, new)) {
 						return self.scoring.choose(&txs[index], new)


### PR DESCRIPTION
Attempt at resolving https://github.com/paritytech/parity-ethereum/issues/10671.

I believe what was happening:

1. Pool becomes full (memory or transaction limit exceeded)
2. Local tx(1) submitted with gas price *x* 
3. tx(1) accepted, replaces *worst* transaction (because it is better, local priority and/or higher gas price)
4. Local tx(2) submitted with same sender and nonce as tx(1), but a higher gas price.
5. tx(2) **rejected** (as described in #10671) because it falls foul of the logic introduced in #10526: a *ready* transaction cannot be replaced by a *non-ready* transaction. The existence of tx(1) meant that the new tx was being calculated as *not ready*, and thus rejected as it is in this case.

This fix will accept any transaction which has the same sender/nonce and a higher gas price. 