### PR TITLE
Step duration map configuration parameter ported from the POA Network fork

### DIFF
--- a/ethcore/engines/authority-round/src/lib.rs
+++ b/ethcore/engines/authority-round/src/lib.rs
@@ -32,7 +32,7 @@ use std::u64;
 use client_traits::EngineClient;
 use engine::{Engine, ConstructedVerifier};
 use block_reward::{self, BlockRewardContract, RewardKind};
-use ethjson::{self, spec::step_duration::StepDuration};
+use ethjson;
 use machine::{
 	ExecutedBlock,
 	Machine,

--- a/ethcore/types/src/errors/engine_error.rs
+++ b/ethcore/types/src/errors/engine_error.rs
@@ -67,6 +67,8 @@ pub enum EngineError {
 	CliqueTooRecentlySigned(Address),
 	/// Custom
 	Custom(String),
+	/// Configuration error.
+	Config,
 }
 
 impl fmt::Display for EngineError {
@@ -83,6 +85,7 @@ impl fmt::Display for EngineError {
 			CliqueWrongAuthorCheckpoint(ref oob) => format!("Unexpected checkpoint author: {}", oob),
 			CliqueFaultyRecoveredSigners(ref mis) => format!("Faulty recovered signers {:?}", mis),
 			CliqueTooRecentlySigned(ref address) => format!("The signer: {} has signed a block too recently", address),
+			Config => format!("Configuration error"),
 			Custom(ref s) => s.clone(),
 			DoubleVote(ref address) => format!("Author {} issued too many blocks.", address),
 			NotProposer(ref mis) => format!("Author is not a current proposer: {}", mis),

--- a/ethcore/types/src/errors/engine_error.rs
+++ b/ethcore/types/src/errors/engine_error.rs
@@ -67,8 +67,6 @@ pub enum EngineError {
 	CliqueTooRecentlySigned(Address),
 	/// Custom
 	Custom(String),
-	/// Configuration error.
-	Config,
 }
 
 impl fmt::Display for EngineError {
@@ -85,7 +83,6 @@ impl fmt::Display for EngineError {
 			CliqueWrongAuthorCheckpoint(ref oob) => format!("Unexpected checkpoint author: {}", oob),
 			CliqueFaultyRecoveredSigners(ref mis) => format!("Faulty recovered signers {:?}", mis),
 			CliqueTooRecentlySigned(ref address) => format!("The signer: {} has signed a block too recently", address),
-			Config => format!("Configuration error"),
 			Custom(ref s) => s.clone(),
 			DoubleVote(ref address) => format!("Author {} issued too many blocks.", address),
 			NotProposer(ref mis) => format!("Author is not a current proposer: {}", mis),

--- a/json/src/spec/authority_round.rs
+++ b/json/src/spec/authority_round.rs
@@ -41,7 +41,7 @@
 use std::collections::BTreeMap;
 use crate::{bytes::Bytes, hash::Address, uint::Uint};
 use serde::Deserialize;
-use super::ValidatorSet;
+use super::{StepDuration, ValidatorSet};
 
 /// Authority params deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
@@ -49,7 +49,7 @@ use super::ValidatorSet;
 #[serde(rename_all = "camelCase")]
 pub struct AuthorityRoundParams {
 	/// Block duration, in seconds.
-	pub step_duration: Uint,
+	pub step_duration: StepDuration,
 	/// Valid authorities
 	pub validators: ValidatorSet,
 	/// Starting step. Determined automatically if not specified.
@@ -107,7 +107,7 @@ pub struct AuthorityRound {
 
 #[cfg(test)]
 mod tests {
-	use super::{Address, Uint};
+	use super::{Address, Uint, StepDuration};
 	use ethereum_types::{U256, H160};
 	use crate::spec::{validator_set::ValidatorSet, authority_round::AuthorityRound};
 	use std::str::FromStr;
@@ -129,7 +129,7 @@ mod tests {
 		}"#;
 
 		let deserialized: AuthorityRound = serde_json::from_str(s).unwrap();
-		assert_eq!(deserialized.params.step_duration, Uint(U256::from(0x02)));
+		assert_eq!(deserialized.params.step_duration, StepDuration::Single(Uint(U256::from(2))));
 		assert_eq!(
 			deserialized.params.validators,
 			ValidatorSet::List(vec![Address(H160::from_str("c6d9d2cd449a754c494264e1809c50e34d64562b").unwrap())]),

--- a/json/src/spec/mod.rs
+++ b/json/src/spec/mod.rs
@@ -32,6 +32,7 @@ pub mod null_engine;
 pub mod instant_seal;
 pub mod hardcoded_sync;
 pub mod clique;
+pub mod step_duration;
 
 pub use self::account::Account;
 pub use self::builtin::{Builtin, Pricing, Linear};
@@ -49,3 +50,4 @@ pub use self::clique::{Clique, CliqueParams};
 pub use self::null_engine::{NullEngine, NullEngineParams};
 pub use self::instant_seal::{InstantSeal, InstantSealParams};
 pub use self::hardcoded_sync::HardcodedSync;
+pub use self::step_duration::StepDuration;

--- a/json/src/spec/step_duration.rs
+++ b/json/src/spec/step_duration.rs
@@ -1,0 +1,36 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Step duration configuration parameter
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+use crate::uint::Uint;
+
+/// Step duration can be specified either as a `Uint` (in seconds), in which case it will be
+/// constant, or as a list of pairs consisting of a block number and a duration, in which case the
+/// duration of a step will be determined by a mapping arising from that list.
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(untagged)]
+pub enum StepDuration {
+	/// Duration of all steps.
+	Single(Uint),
+	/// Step duration transitions: a mapping of timestamp to step durations.
+	Transitions(BTreeMap<Uint, Uint>),
+}

--- a/json/src/spec/step_duration.rs
+++ b/json/src/spec/step_duration.rs
@@ -23,8 +23,8 @@ use serde::Deserialize;
 use crate::uint::Uint;
 
 /// Step duration can be specified either as a `Uint` (in seconds), in which case it will be
-/// constant, or as a list of pairs consisting of a block number and a duration, in which case the
-/// duration of a step will be determined by a mapping arising from that list.
+/// constant, or as a list of pairs consisting of a timestamp of type `Uint` and a duration, in
+/// which case the duration of a step will be determined by a mapping arising from that list.
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(untagged)]


### PR DESCRIPTION
The original PR: https://github.com/poanetwork/parity-ethereum/pull/152.

Summary: Instead of a single step duration, this PR allows specifying time intervals with given step durations.