### PR TITLE
Fixes incorrect comment.

### DIFF
--- a/miner/src/pool/scoring.rs
+++ b/miner/src/pool/scoring.rs
@@ -34,7 +34,7 @@ use txpool::{self, scoring};
 use super::{verifier, PrioritizationStrategy, VerifiedTransaction, ScoredTransaction};
 
 /// Transaction with the same (sender, nonce) can be replaced only if
-/// `new_gas_price > old_gas_price + old_gas_price >> SHIFT`
+/// `new_gas_price >= old_gas_price + old_gas_price >> SHIFT`
 const GAS_PRICE_BUMP_SHIFT: usize = 3; // 2 = 25%, 3 = 12.5%, 4 = 6.25%
 
 /// Calculate minimal gas price requirement.


### PR DESCRIPTION
I _believe_ (someone please double-check my work) that this comment is subtly incorrect and in fact the replacement will occur if the new gas price is exactly 12.5% (given current configuration) higher.

Relevant pieces of code:
```rust
fn bump_gas_price(old_gp: U256) -> U256 {
	old_gp.saturating_add(old_gp >> GAS_PRICE_BUMP_SHIFT)
}
```
```rust
let min_required_gp = bump_gas_price(*old_gp);
match min_required_gp.cmp(&new_gp) {
	cmp::Ordering::Greater => scoring::Choice::RejectNew,
	_ => scoring::Choice::ReplaceOld,
}
```