### PR TITLE
Additional arithmetic EVM opcode benchmarks

### DIFF
--- a/ethcore/evm/benches/basic.rs
+++ b/ethcore/evm/benches/basic.rs
@@ -32,6 +32,7 @@ extern crate rustc_hex;
 use criterion::{Criterion, Bencher, black_box};
 use std::str::FromStr;
 use std::sync::Arc;
+use bytes::Bytes;
 use ethereum_types::{U256, Address};
 use vm::{ActionParams, Result, GasLeft, Ext};
 use vm::tests::FakeExt;
@@ -40,6 +41,28 @@ use rustc_hex::FromHex;
 
 criterion_group!(
 	basic,
+	mul500,
+	mul1000,
+	div500,
+	div1000,
+	sdiv500,
+	sdiv1000,
+	mod500,
+	mod1000,
+	smod500,
+	smod1000,
+	addmod500,
+	addmod1000,
+	mulmod500,
+	mulmod1000,
+	mulmod1_500,
+	mulmod1_1000,
+	mulmod5_500,
+	mulmod5_1000,
+	mulmod11_500,
+	mulmod11_1000,
+	mulmod_big_500,
+	mulmod_big_1000,
 	simple_loop_log0_usize,
 	simple_loop_log0_u256,
 	mem_gas_calculation_same_usize,
@@ -206,4 +229,189 @@ fn result(r: Result<evm::GasLeft>) -> U256 {
 		Ok(GasLeft::NeedsReturn { gas_left,  .. }) => gas_left,
 		_ => U256::zero(),
 	}
+}
+
+/// Runs a given EVM bytecode.
+fn run_code(b: &mut Bencher, code: Bytes) {
+	let factory = Factory::default();
+	let mut ext = FakeExt::new();
+	b.iter(|| {
+		let mut params = ActionParams::default();
+		params.address = Address::from_str("0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6").unwrap();
+		params.gas = U256::MAX;
+		params.code = Some(Arc::new(black_box(code.clone())));
+		let vm = factory.create(params, ext.schedule(), 0);
+		result(vm.exec(&mut ext).ok().unwrap())
+	});
+}
+
+/// Compute mulmod(U256::MAX, U256::MAX, 1) 500 times.
+fn mulmod1_500(b: &mut Criterion) {
+	b.bench_function("mulmod modulo 1, 500 times", |b| {
+		run_code(b, "6101f45b6001900360017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80095080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute mulmod(U256::MAX, U256::MAX, 1) 1000 times.
+fn mulmod1_1000(b: &mut Criterion) {
+	b.bench_function("mulmod modulo 1, 1000 times", |b| {
+		run_code(b, "6103e85b6001900360017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80095080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute mulmod(U256::MAX, U256::MAX, 5) 500 times.
+fn mulmod5_500(b: &mut Criterion) {
+	b.bench_function("mulmod modulo 5, 500 times", |b| {
+		run_code(b, "6101f45b6001900360057fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80095080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute mulmod(U256::MAX, U256::MAX, 5) 1000 times.
+fn mulmod5_1000(b: &mut Criterion) {
+	b.bench_function("mulmod modulo 5, 1000 times", |b| {
+		run_code(b, "6103e85b6001900360057fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80095080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute mulmod(U256::MAX, U256::MAX, 11) 500 times.
+fn mulmod11_500(b: &mut Criterion) {
+	b.bench_function("mulmod modulo 11, 500 times", |b| {
+		run_code(b, "6101f45b60019003600b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80095080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute mulmod(U256::MAX, U256::MAX, 11) 1000 times.
+fn mulmod11_1000(b: &mut Criterion) {
+	b.bench_function("mulmod modulo 11, 1000 times", |b| {
+		run_code(b, "6103e85b60019003600b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80095080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute mulmod(U256::MAX, U256::MAX, 0x58bca9711298bc76cd73f173352c8bc1d1640f977c1ec9a849dfde6fdbfbd591) 500 times.
+fn mulmod_big_500(b: &mut Criterion) {
+	b.bench_function("mulmod modulo random 256-bit number, 500 times", |b| {
+		run_code(b, "6101f45b600190037f58bca9711298bc76cd73f173352c8bc1d1640f977c1ec9a849dfde6fdbfbd5917fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80095080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute mulmod(U256::MAX, U256::MAX, 0x58bca9711298bc76cd73f173352c8bc1d1640f977c1ec9a849dfde6fdbfbd591) 1000 times.
+fn mulmod_big_1000(b: &mut Criterion) {
+	b.bench_function("mulmod modulo random 256-bit number, 1000 times", |b| {
+		run_code(b, "6103e85b600190037f58bca9711298bc76cd73f173352c8bc1d1640f977c1ec9a849dfde6fdbfbd5917fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80095080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute mulmod(a, b, c) for random 256-bit a, b and c. Iterate 500 times.
+///
+/// Source:
+/// ```
+/// PUSH2 0x01F4
+/// JUMPDEST
+/// PUSH1 0x01
+/// SWAP1
+/// SUB
+/// PUSH32 0x5ed6db9489224124a1a4110ec8bec8b01369c8b549a4b8c4388a1796dc35a937
+/// PUSH32 0xb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db
+/// PUSH32 0xcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca
+/// MULMOD
+/// POP
+/// DUP1
+/// PUSH1 0x03
+/// JUMPI
+/// ```
+fn mulmod500(b: &mut Criterion) {
+	b.bench_function("mulmod randomly generated ints, 500 times", |b| {
+		run_code(b, "6101f45b600190037f5ed6db9489224124a1a4110ec8bec8b01369c8b549a4b8c4388a1796dc35a9377fb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db7fcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca095080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute mulmod(a, b, c) for random 256-bit a, b and c. Iterate 1000 times.
+fn mulmod1000(b: &mut Criterion) {
+	b.bench_function("mulmod randomly generated ints, 1000 times", |b| {
+		run_code(b, "6103e85b600190037f5ed6db9489224124a1a4110ec8bec8b01369c8b549a4b8c4388a1796dc35a9377fb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db7fcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca095080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute addmod(a, b, c) for random 256-bit a, b and c. Iterate 500 times.
+fn addmod500(b: &mut Criterion) {
+	b.bench_function("addmod randomly generated ints, 500 times", |b| {
+		run_code(b, "6101f45b600190037f5ed6db9489224124a1a4110ec8bec8b01369c8b549a4b8c4388a1796dc35a9377fb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db7fcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca085080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute addmod(a, b, c) for random 256-bit a, b and c. Iterate 1000 times.
+fn addmod1000(b: &mut Criterion) {
+	b.bench_function("addmod randomly generated ints, 1000 times", |b| {
+		run_code(b, "6103e85b600190037f5ed6db9489224124a1a4110ec8bec8b01369c8b549a4b8c4388a1796dc35a9377fb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db7fcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca085080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute mul(a, b) for random 256-bit a and b. Iterate 500 times.
+fn mul500(b: &mut Criterion) {
+	b.bench_function("mul randomly generated ints, 500 times", |b| {
+		run_code(b, "6101f45b600190037fb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db7fcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca025080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute mul(a, b) for random 256-bit a and b. Iterate 1000 times.
+fn mul1000(b: &mut Criterion) {
+	b.bench_function("mul randomly generated ints, 1000 times", |b| {
+		run_code(b, "6103e85b600190037fb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db7fcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca025080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute div(a, b) for random 256-bit a and b. Iterate 500 times.
+fn div500(b: &mut Criterion) {
+	b.bench_function("div randomly generated ints, 500 times", |b| {
+		run_code(b, "6101f45b600190037fb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db7fcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca045080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute div(a, b) for random 256-bit a and b. Iterate 1000 times.
+fn div1000(b: &mut Criterion) {
+	b.bench_function("div randomly generated ints, 1000 times", |b| {
+		run_code(b, "6103e85b600190037fb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db7fcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca045080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute sdiv(a, b) for random 256-bit a and b. Iterate 500 times.
+fn sdiv500(b: &mut Criterion) {
+	b.bench_function("sdiv randomly generated ints, 500 times", |b| {
+		run_code(b, "6101f45b600190037fb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db7fcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca055080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute sdiv(a, b) for random 256-bit a and b. Iterate 1000 times.
+fn sdiv1000(b: &mut Criterion) {
+	b.bench_function("sdiv randomly generated ints, 1000 times", |b| {
+		run_code(b, "6103e85b600190037fb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db7fcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca055080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute mod(a, b) for random 256-bit a and b. Iterate 500 times.
+fn mod500(b: &mut Criterion) {
+	b.bench_function("mod randomly generated ints, 500 times", |b| {
+		run_code(b, "6101f45b600190037fb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db7fcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca065080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute mod(a, b) for random 256-bit a and b. Iterate 1000 times.
+fn mod1000(b: &mut Criterion) {
+	b.bench_function("mod randomly generated ints, 1000 times", |b| {
+		run_code(b, "6103e85b600190037fb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db7fcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca065080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute smod(a, b) for random 256-bit a and b. Iterate 500 times.
+fn smod500(b: &mut Criterion) {
+	b.bench_function("smod randomly generated ints, 500 times", |b| {
+		run_code(b, "6101f45b600190037fb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db7fcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca075080600357".from_hex().unwrap());
+	});
+}
+
+/// Compute smod(a, b) for random 256-bit a and b. Iterate 1000 times.
+fn smod1000(b: &mut Criterion) {
+	b.bench_function("smod randomly generated ints, 1000 times", |b| {
+		run_code(b, "6103e85b600190037fb8e0a2b6b1587398c28bf9e9d34ea24ba34df308eec2acedca363b2fce2c25db7fcc2de1f8ec6cc9a24ed2c48b856637f9e45f0a5feee21a196aa42a290ef454ca075080600357".from_hex().unwrap());
+	});
 }


### PR DESCRIPTION
These benchmarks apply to demanding arithmetic operations, in particular to `MULMOD`. A helper function `run_code` was added in order to keep the benchmark code succinct.