### PR TITLE
new ethereum consensus tests

### DIFF
--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -346,6 +346,10 @@ impl<'a> CallCreateExecutive<'a> {
 				| Err(vm::Error::OutOfBounds)
 				| Err(vm::Error::Reverted)
 				| Ok(FinalizationResult { apply_state: false, .. }) => {
+					let ripemd = Address::from_low_u64_be(3);
+					if un_substate.touched.contains(&ripemd) {
+						substate.touched.insert(ripemd);
+					}
 					state.revert_to_checkpoint();
 			},
 			Ok(_) | Err(vm::Error::Internal(_)) => {


### PR DESCRIPTION
ref #10908

discussion explaining changes I made: https://github.com/ethereum/aleth/pull/5664

my limited knowledge of current state of executive and how tests are loaded doesn't allow me to fix all failing tests

tests which are still failing

- `RevertPrecompiledTouchExactOOG_d31g1v0_Byzantium`
- `RevertPrecompiledTouchExactOOG_d31g1v0_Constantinople`
- `RevertPrecompiledTouchExactOOG_d31g1v0_ConstantinopleFix`
- `RevertPrecompiledTouchExactOOG_d7g1v0_Byzantium` 
- `RevertPrecompiledTouchExactOOG_d7g1v0_Constantinople` 
- `RevertPrecompiledTouchExactOOG_d7g1v0_ConstantinopleFix`

----

my questions:

- what is [`"network": "EIP158"`](https://github.com/ethereum/tests/blob/a8f6d53bdd77bedcc08badb86079931c500e7f2f/BlockchainTests/GeneralStateTests/stRevertTest/RevertPrecompiledTouchExactOOG_d31g1v0.json#L896) and why do we load it from json test file `eip161_test.json`
- how is this network different to byzantium and constantinople

cc @sorpaas @tomusdrw 