### PR TITLE
Set the block gas limit to the value returned by a contract call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ dependencies = [
 name = "authority-round"
 version = "0.1.0"
 dependencies = [
+ "block-gas-limit 0.1.0",
  "block-reward 0.1.0",
  "client-traits 0.1.0",
  "common-types 0.1.0",
@@ -362,6 +363,21 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "block-gas-limit"
+version = "0.1.0"
+dependencies = [
+ "client-traits 0.1.0",
+ "common-types 0.1.0",
+ "ethabi 9.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi-contract 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi-derive 9.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethcore 1.12.0",
+ "ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spec 0.1.0",
 ]
 
 [[package]]

--- a/ethcore/block-gas-limit/Cargo.toml
+++ b/ethcore/block-gas-limit/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+description = "A crate to interact with the block gas limit contract"
+name = "block-gas-limit"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+license = "GPL-3.0"
+
+[dependencies]
+client-traits = { path = "../client-traits" }
+common-types = { path = "../types" }
+ethabi = "9.0.1"
+ethabi-derive = "9.0.1"
+ethabi-contract = "9.0.0"
+ethereum-types = "0.8.0"
+log = "0.4"
+
+[dev-dependencies]
+ethcore = { path = "..", features = ["test-helpers"] }
+spec = { path = "../spec" }

--- a/ethcore/block-gas-limit/res/block_gas_limit.json
+++ b/ethcore/block-gas-limit/res/block_gas_limit.json
@@ -1,0 +1,16 @@
+[
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "blockGasLimit",
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	}
+]

--- a/ethcore/block-gas-limit/src/lib.rs
+++ b/ethcore/block-gas-limit/src/lib.rs
@@ -1,0 +1,39 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity Ethereum.
+
+// Parity Ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
+
+//! A client interface for interacting with the block gas limit contract.
+
+use client_traits::BlockChainClient;
+use common_types::{header::Header, ids::BlockId};
+use ethabi::FunctionOutputDecoder;
+use ethabi_contract::use_contract;
+use ethereum_types::{Address, U256};
+use log::{debug, error};
+
+use_contract!(contract, "res/block_gas_limit.json");
+
+pub fn block_gas_limit(full_client: &dyn BlockChainClient, header: &Header, address: Address) -> Option<U256> {
+	let (data, decoder) = contract::functions::block_gas_limit::call();
+	let value = full_client.call_contract(BlockId::Hash(*header.parent_hash()), address, data).map_err(|err| {
+		error!(target: "block_gas_limit", "Contract call failed. Not changing the block gas limit. {:?}", err);
+	}).ok()?;
+	if value.is_empty() {
+		debug!(target: "block_gas_limit", "Contract call returned nothing. Not changing the block gas limit.");
+		None
+	} else {
+		decoder.decode(&value).ok()
+	}
+}

--- a/ethcore/engine/src/engine.rs
+++ b/ethcore/engine/src/engine.rs
@@ -347,6 +347,12 @@ pub trait Engine: Sync + Send {
 		Ok(*header.author())
 	}
 
+	/// Overrides the block gas limit. Whenever this returns `Some` for a header, the next block's gas limit must be
+	/// exactly that value.
+	fn gas_limit_override(&self, _header: &Header) -> Option<U256> {
+		None
+	}
+
 	/// Get the general parameters of the chain.
 	fn params(&self) -> &CommonParams;
 
@@ -396,6 +402,11 @@ pub trait Engine: Sync + Send {
 	/// Performs pre-validation of RLP decoded transaction before other processing
 	fn decode_transaction(&self, transaction: &[u8]) -> Result<UnverifiedTransaction, transaction::Error> {
 		self.machine().decode_transaction(transaction)
+	}
+
+	/// The configured minimum gas limit.
+	fn min_gas_limit(&self) -> U256 {
+		self.params().min_gas_limit
 	}
 }
 

--- a/ethcore/engines/authority-round/Cargo.toml
+++ b/ethcore/engines/authority-round/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
+block-gas-limit = { path = "../../block-gas-limit" }
 block-reward = { path = "../../block-reward" }
 client-traits = { path = "../../client-traits" }
 common-types = { path = "../../types" }

--- a/ethcore/verification/src/verification.rs
+++ b/ethcore/verification/src/verification.rs
@@ -61,6 +61,14 @@ pub fn verify_block_basic(block: &Unverified, engine: &dyn Engine, check_seal: b
 		}
 	}
 
+	if let Some(gas_limit) = engine.gas_limit_override(&block.header) {
+		if *block.header.gas_limit() != gas_limit {
+			return Err(From::from(BlockError::InvalidGasLimit(
+				OutOfBounds { min: Some(gas_limit), max: Some(gas_limit), found: *block.header.gas_limit() }
+			)));
+		}
+	}
+
 	for t in &block.transactions {
 		engine.verify_transaction_basic(t, &block.header)?;
 	}
@@ -284,6 +292,25 @@ pub(crate) fn verify_header_params(header: &Header, engine: &dyn Engine, check_s
 			found: *header.gas_used()
 		})));
 	}
+	if engine.gas_limit_override(header).is_none() {
+		let min_gas_limit = engine.min_gas_limit();
+		if header.gas_limit() < &min_gas_limit {
+			return Err(From::from(BlockError::InvalidGasLimit(OutOfBounds {
+				min: Some(min_gas_limit),
+				max: None,
+				found: *header.gas_limit()
+			})));
+		}
+		if let Some(limit) = engine.maximum_gas_limit() {
+			if header.gas_limit() > &limit {
+				return Err(From::from(BlockError::InvalidGasLimit(OutOfBounds {
+					min: None,
+					max: Some(limit),
+					found: *header.gas_limit()
+				})));
+			}
+		}
+	}
 	let maximum_extra_data_size = engine.maximum_extra_data_size();
 	if header.number() != 0 && header.extra_data().len() > maximum_extra_data_size {
 		return Err(From::from(BlockError::ExtraDataOutOfBounds(OutOfBounds {
@@ -341,8 +368,6 @@ fn verify_parent(header: &Header, parent: &Header, engine: &dyn Engine) -> Resul
 	assert!(header.parent_hash().is_zero() || &parent.hash() == header.parent_hash(),
 			"Parent hash should already have been verified; qed");
 
-	let gas_limit_divisor = engine.params().gas_limit_bound_divisor;
-
 	if !engine.is_timestamp_valid(header.timestamp(), parent.timestamp()) {
 		let now = SystemTime::now();
 		let min = CheckedSystemTime::checked_add(now, Duration::from_secs(parent.timestamp().saturating_add(1)))
@@ -365,31 +390,8 @@ fn verify_parent(header: &Header, parent: &Header, engine: &dyn Engine) -> Resul
 			found: header.number()
 		}).into());
 	}
-	if let Some(gas_limit) = engine.gas_limit_override(header) {
-		if *header.gas_limit() != gas_limit {
-			return Err(BlockError::InvalidGasLimit(
-				OutOfBounds { min: Some(gas_limit), max: Some(gas_limit), found: *header.gas_limit() }
-			).into());
-		}
-	} else {
-		let min_gas_limit = engine.params().min_gas_limit;
-		if header.gas_limit() < &min_gas_limit {
-			return Err(From::from(BlockError::InvalidGasLimit(OutOfBounds {
-				min: Some(min_gas_limit),
-				max: None,
-				found: *header.gas_limit()
-			})));
-		}
-		if let Some(limit) = engine.maximum_gas_limit() {
-			if header.gas_limit() > &limit {
-				return Err(From::from(BlockError::InvalidGasLimit(OutOfBounds {
-					min: None,
-					max: Some(limit),
-					found: *header.gas_limit()
-				})));
-			}
-		}
-
+	if engine.gas_limit_override(header).is_none() {
+		let gas_limit_divisor = engine.params().gas_limit_bound_divisor;
 		let parent_gas_limit = *parent.gas_limit();
 		let min_gas = parent_gas_limit - parent_gas_limit / gas_limit_divisor;
 		let max_gas = parent_gas_limit + parent_gas_limit / gas_limit_divisor;
@@ -658,9 +660,8 @@ mod tests {
 		header.set_uncles_hash(good_uncles_hash.clone());
 		check_ok(basic_test(&create_test_block_with_data(&header, &good_transactions, &good_uncles), engine));
 
-		header = good.clone();
 		header.set_gas_limit(min_gas_limit - 1);
-		check_fail(family_test(&create_test_block(&header), engine, &bc),
+		check_fail(basic_test(&create_test_block(&header), engine),
 			InvalidGasLimit(OutOfBounds { min: Some(min_gas_limit), max: None, found: header.gas_limit().clone() }));
 
 		header = good.clone();

--- a/json/src/spec/authority_round.rs
+++ b/json/src/spec/authority_round.rs
@@ -97,22 +97,28 @@ pub struct AuthorityRoundParams {
 	pub two_thirds_majority_transition: Option<Uint>,
 	/// The random number contract's address, or a map of contract transitions.
 	pub randomness_contract_address: Option<BTreeMap<Uint, Address>>,
+	/// The addresses of contracts that determine the block gas limit starting from the block number
+	/// associated with each of those contracts.
+	pub block_gas_limit_contract_transitions: Option<BTreeMap<Uint, Address>>,
 }
 
 /// Authority engine deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AuthorityRound {
-	/// Ethash params.
+	/// Authority Round parameters.
 	pub params: AuthorityRoundParams,
 }
 
 #[cfg(test)]
 mod tests {
-	use super::{Address, Uint, StepDuration};
-	use ethereum_types::{U256, H160};
-	use crate::spec::{validator_set::ValidatorSet, authority_round::AuthorityRound};
 	use std::str::FromStr;
+
+	use ethereum_types::{U256, H160};
+	use serde_json;
+
+	use super::{Address, Uint, StepDuration};
+	use crate::{spec::{validator_set::ValidatorSet, authority_round::AuthorityRound}};
 
 	#[test]
 	fn authority_round_deserialization() {
@@ -130,6 +136,10 @@ mod tests {
 				"randomnessContractAddress": {
 					"10": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					"20": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+				},
+				"blockGasLimitContractTransitions": {
+					"10": "0x1000000000000000000000000000000000000001",
+					"20": "0x2000000000000000000000000000000000000002"
 				}
 			}
 		}"#;
@@ -149,5 +159,10 @@ mod tests {
 				(Uint(10.into()), Address(H160::from_str("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap())),
 				(Uint(20.into()), Address(H160::from_str("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").unwrap())),
 			].into_iter().collect());
+		let expected_bglc =
+			[(Uint(10.into()), Address(H160::from_str("1000000000000000000000000000000000000001").unwrap())),
+			 (Uint(20.into()), Address(H160::from_str("2000000000000000000000000000000000000002").unwrap()))];
+		assert_eq!(deserialized.params.block_gas_limit_contract_transitions,
+				   Some(expected_bglc.to_vec().into_iter().collect()));
 	}
 }


### PR DESCRIPTION
This PR allows to have programmable block gas limit.

See also:
- original PR: https://github.com/poanetwork/parity-ethereum/pull/140
- original issue https://github.com/poanetwork/parity-ethereum/issues/119