### PR TITLE
Enable sealing when engine is ready

### DIFF
--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -862,7 +862,10 @@ impl Miner {
 	fn prepare_and_update_sealing<C: miner::BlockChainClient>(&self, chain: &C) {
 		use miner::MinerService;
 		match self.engine.sealing_state() {
-			SealingState::Ready => self.update_sealing(chain),
+			SealingState::Ready => {
+				self.maybe_enable_sealing();
+				self.update_sealing(chain)
+			}
 			SealingState::External => {
 				// this calls `maybe_enable_sealing()`
 				if self.prepare_pending_block(chain) == BlockPreparationStatus::NotPrepared {


### PR DESCRIPTION
This PR fixes the following scenario appeared after #10529 and #10745 :

1. If the node in POA network is not a proposer on this round, its sealing state set to SealingState::NotReady and consequently miner's sealing is set to disabled.
2. After it the local transaction comes, this code https://github.com/paritytech/parity-ethereum/blob/master/ethcore/src/miner/miner.rs#L989 is trying to prepare and update sealing, sealing state of the engine is SealingState::Ready (because some work is required), but unfortunately sealing state of the miner is still disabled and attempt to prepare_and_update_sealing fails at the beginning.

Solution: try re-enable sealing state of the miner, if sealing state of the engine is SealingState::Ready

Closes #10936 