### PR TITLE
Change the return type of step_inner function.

### DIFF
--- a/ethcore/evm/src/interpreter/mod.rs
+++ b/ethcore/evm/src/interpreter/mod.rs
@@ -341,13 +341,13 @@ impl<Cost: CostType> Interpreter<Cost> {
 
 				// Calculate gas cost
 				let requirements = match self.gasometer.as_mut().expect(GASOMETER_PROOF).requirements(ext, instruction, info, &self.stack, self.mem.size()) {
-                    Ok(t) => t,
+					Ok(t) => t,
 					Err(e) => return InterpreterResult::Done(Err(e)),
 				};
 				if self.do_trace {
 					ext.trace_prepare_execute(self.reader.position - 1, opcode, requirements.gas_cost.as_u256(), Self::mem_written(instruction, &self.stack), Self::store_written(instruction, &self.stack));
 				}
-                if let Err(e) = self.gasometer.as_mut().expect(GASOMETER_PROOF).verify_gas(&requirements.gas_cost) {
+				if let Err(e) = self.gasometer.as_mut().expect(GASOMETER_PROOF).verify_gas(&requirements.gas_cost) {
 					return InterpreterResult::Done(Err(e));
 				}
 				self.mem.expand(requirements.memory_required_size);
@@ -365,7 +365,7 @@ impl<Cost: CostType> Interpreter<Cost> {
 					Ok(x) => x,
 				};
 				evm_debug!({ self.informant.after_instruction(instruction) });
-                result
+				result
 			},
 		};
 
@@ -394,7 +394,7 @@ impl<Cost: CostType> Interpreter<Cost> {
 				let jump_destinations = self.valid_jump_destinations.as_ref().expect("jump_destinations are initialized on first jump; qed");
 				let pos = match self.verify_jump(position, jump_destinations) {
 					Ok(x) => x,
-                    Err(e) => return InterpreterResult::Done(Err(e))
+					Err(e) => return InterpreterResult::Done(Err(e))
 				};
 				self.reader.position = pos;
 			},

--- a/ethcore/evm/src/interpreter/mod.rs
+++ b/ethcore/evm/src/interpreter/mod.rs
@@ -109,8 +109,6 @@ enum InstructionResult<Gas> {
 	Trap(TrapKind),
 }
 
-enum Never {}
-
 /// ActionParams without code, so that it can be feed into CodeReader.
 #[derive(Debug)]
 struct InterpreterParams {
@@ -169,12 +167,6 @@ pub enum InterpreterResult {
 	/// The VM can continue to run.
 	Continue,
 	Trap(TrapKind),
-}
-
-impl From<vm::Error> for InterpreterResult {
-	fn from(error: vm::Error) -> InterpreterResult {
-		InterpreterResult::Done(Err(error))
-	}
 }
 
 /// Intepreter EVM implementation
@@ -309,7 +301,7 @@ impl<Cost: CostType> Interpreter<Cost> {
 		} else if self.reader.len() == 0 {
 			InterpreterResult::Done(Ok(GasLeft::Known(self.gasometer.as_ref().expect("Gasometer None case is checked above; qed").current_gas.as_u256())))
 		} else {
-			self.step_inner(ext).err().expect("step_inner never returns Ok(()); qed")
+			self.step_inner(ext)
 		};
 
 		if let &InterpreterResult::Done(_) = &result {
@@ -321,7 +313,7 @@ impl<Cost: CostType> Interpreter<Cost> {
 
 	/// Inner helper function for step.
 	#[inline(always)]
-	fn step_inner(&mut self, ext: &mut dyn vm::Ext) -> Result<Never, InterpreterResult> {
+	fn step_inner(&mut self, ext: &mut dyn vm::Ext) -> InterpreterResult {
 		let result = match self.resume_result.take() {
 			Some(result) => result,
 			None => {
@@ -336,22 +328,28 @@ impl<Cost: CostType> Interpreter<Cost> {
 
 				let instruction = match instruction {
 					Some(i) => i,
-					None => return Err(InterpreterResult::Done(Err(vm::Error::BadInstruction {
+					None => return InterpreterResult::Done(Err(vm::Error::BadInstruction {
 						instruction: opcode
-					}))),
+					})),
 				};
 
 				let info = instruction.info();
 				self.last_stack_ret_len = info.ret;
-				self.verify_instruction(ext, instruction, info)?;
+				if let Err(e) = self.verify_instruction(ext, instruction, info) {
+					return InterpreterResult::Done(Err(e));
+				};
 
 				// Calculate gas cost
-				let requirements = self.gasometer.as_mut().expect(GASOMETER_PROOF).requirements(ext, instruction, info, &self.stack, self.mem.size())?;
+				let requirements = match self.gasometer.as_mut().expect(GASOMETER_PROOF).requirements(ext, instruction, info, &self.stack, self.mem.size()) {
+                    Ok(t) => t,
+					Err(e) => return InterpreterResult::Done(Err(e)),
+				};
 				if self.do_trace {
 					ext.trace_prepare_execute(self.reader.position - 1, opcode, requirements.gas_cost.as_u256(), Self::mem_written(instruction, &self.stack), Self::store_written(instruction, &self.stack));
 				}
-
-				self.gasometer.as_mut().expect(GASOMETER_PROOF).verify_gas(&requirements.gas_cost)?;
+                if let Err(e) = self.gasometer.as_mut().expect(GASOMETER_PROOF).verify_gas(&requirements.gas_cost) {
+					return InterpreterResult::Done(Err(e));
+				}
 				self.mem.expand(requirements.memory_required_size);
 				self.gasometer.as_mut().expect(GASOMETER_PROOF).current_mem_gas = requirements.memory_total_gas;
 				self.gasometer.as_mut().expect(GASOMETER_PROOF).current_gas = self.gasometer.as_mut().expect(GASOMETER_PROOF).current_gas - requirements.gas_cost;
@@ -360,18 +358,19 @@ impl<Cost: CostType> Interpreter<Cost> {
 
 				// Execute instruction
 				let current_gas = self.gasometer.as_mut().expect(GASOMETER_PROOF).current_gas;
-				let result = self.exec_instruction(
+				let result = match self.exec_instruction(
 					current_gas, ext, instruction, requirements.provide_gas
-				)?;
-
+				) {
+					Err(x) => return InterpreterResult::Done(Err(x)),
+					Ok(x) => x,
+				};
 				evm_debug!({ self.informant.after_instruction(instruction) });
-
-				result
+                result
 			},
 		};
 
 		if let InstructionResult::Trap(trap) = result {
-			return Err(InterpreterResult::Trap(trap));
+			return InterpreterResult::Trap(trap);
 		}
 
 		if let InstructionResult::UnusedGas(ref gas) = result {
@@ -393,28 +392,31 @@ impl<Cost: CostType> Interpreter<Cost> {
 					self.valid_jump_destinations = Some(self.cache.jump_destinations(&self.params.code_hash, &self.reader.code));
 				}
 				let jump_destinations = self.valid_jump_destinations.as_ref().expect("jump_destinations are initialized on first jump; qed");
-				let pos = self.verify_jump(position, jump_destinations)?;
+				let pos = match self.verify_jump(position, jump_destinations) {
+					Ok(x) => x,
+                    Err(e) => return InterpreterResult::Done(Err(e))
+				};
 				self.reader.position = pos;
 			},
 			InstructionResult::StopExecutionNeedsReturn {gas, init_off, init_size, apply} => {
 				let mem = mem::replace(&mut self.mem, Vec::new());
-				return Err(InterpreterResult::Done(Ok(GasLeft::NeedsReturn {
+				return InterpreterResult::Done(Ok(GasLeft::NeedsReturn {
 					gas_left: gas.as_u256(),
 					data: mem.into_return_data(init_off, init_size),
 					apply_state: apply
-				})));
+				}));
 			},
 			InstructionResult::StopExecution => {
-				return Err(InterpreterResult::Done(Ok(GasLeft::Known(self.gasometer.as_mut().expect(GASOMETER_PROOF).current_gas.as_u256()))));
+				return InterpreterResult::Done(Ok(GasLeft::Known(self.gasometer.as_mut().expect(GASOMETER_PROOF).current_gas.as_u256())));
 			},
 			_ => {},
 		}
 
 		if self.reader.position >= self.reader.len() {
-			return Err(InterpreterResult::Done(Ok(GasLeft::Known(self.gasometer.as_mut().expect(GASOMETER_PROOF).current_gas.as_u256()))));
+			return InterpreterResult::Done(Ok(GasLeft::Known(self.gasometer.as_mut().expect(GASOMETER_PROOF).current_gas.as_u256())));
 		}
 
-		Err(InterpreterResult::Continue)
+		InterpreterResult::Continue
 	}
 
 	fn verify_instruction(&self, ext: &dyn vm::Ext, instruction: Instruction, info: &InstructionInfo) -> vm::Result<()> {


### PR DESCRIPTION

This PR simplifies the return result of step_inner function.

Using `Result<Never, InterpreterResult>` as return result will cause 
unnecessary overhead (mostly additional memory operations). Since 
step_inner is a hot function, I propose to simplify the return type of 
step_inner function and handle the error results manually.

Some benchmark results I have:

Without Optimization (Original Version):
test rng_u256          ... bench:  68,395,922 ns/iter (+/- 19,520,348)
test rng_usize         ... bench:  46,822,703 ns/iter (+/- 19,869,026)
test simple_loop_u256  ... bench:  18,807,019 ns/iter (+/- 5,683,907)
test simple_loop_usize ... bench:  13,812,568 ns/iter (+/- 3,310,862)

With Optimization:
test rng_u256          ... bench:  53,654,255 ns/iter (+/- 12,985,727)
test rng_usize         ... bench:  36,481,886 ns/iter (+/- 13,044,046)
test simple_loop_u256  ... bench:  15,010,101 ns/iter (+/- 5,306,132)
test simple_loop_usize ... bench:  10,584,103 ns/iter (+/- 2,439,375)

Some perf results I have:
 
<img width="1190" alt="image" src="https://user-images.githubusercontent.com/5557706/62407383-4a989880-b5ea-11e9-81a9-b4f800f6b0df.png">
