### PR TITLE
Verify transaction against its block during import

### DIFF
--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -512,10 +512,10 @@ impl Miner {
 			let sender = transaction.sender();
 
 			// Re-verify transaction again vs current state.
-			let result = client.verify_signed(&transaction)
+			let result = client.verify_for_pending_block(&transaction, &open_block.header)
 				.map_err(|e| e.into())
 				.and_then(|_| {
-					self.engine.machine().verify_transaction_basic(&transaction, &open_block.header)
+					client.verify_signed(&transaction)
 				})
 				.map_err(|e| e.into())
 				.and_then(|_| {

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -515,6 +515,10 @@ impl Miner {
 			let result = client.verify_signed(&transaction)
 				.map_err(|e| e.into())
 				.and_then(|_| {
+					self.engine.machine().verify_transaction_basic(&transaction, &open_block.header)
+				})
+				.map_err(|e| e.into())
+				.and_then(|_| {
 					open_block.push_transaction(transaction, None)
 				});
 

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -515,10 +515,6 @@ impl Miner {
 			let result = client.verify_for_pending_block(&transaction, &open_block.header)
 				.map_err(|e| e.into())
 				.and_then(|_| {
-					client.verify_signed(&transaction)
-				})
-				.map_err(|e| e.into())
-				.and_then(|_| {
 					open_block.push_transaction(transaction, None)
 				});
 

--- a/ethcore/src/miner/pool_client.rs
+++ b/ethcore/src/miner/pool_client.rs
@@ -120,6 +120,11 @@ impl<'a, C: 'a> PoolClient<'a, C> where
 	pub fn verify_signed(&self, tx: &SignedTransaction) -> Result<(), transaction::Error> {
 		self.engine.machine().verify_transaction(&tx, &self.best_block_header, self.chain)
 	}
+
+	/// Verifies transaction against its block (before its import into this block)
+	pub fn verify_for_pending_block(&self, transaction: &UnverifiedTransaction, header: &Header) -> Result<(), transaction::Error> {
+		self.engine.machine().verify_transaction_basic(transaction, header)
+	}
 }
 
 impl<'a, C: 'a> fmt::Debug for PoolClient<'a, C> {

--- a/ethcore/src/miner/pool_client.rs
+++ b/ethcore/src/miner/pool_client.rs
@@ -138,8 +138,10 @@ impl<'a, C: 'a> pool::client::Client for PoolClient<'a, C> where
 	}
 
 	fn verify_transaction(&self, tx: UnverifiedTransaction)-> Result<SignedTransaction, transaction::Error> {
+		self.engine.verify_transaction_basic(&tx, &self.best_block_header)?;
 		let tx = tx.verify_unordered()?;
-		self.verify_for_pending_block(&tx, &self.best_block_header)?;
+
+		self.engine.machine().verify_transaction(&tx, &self.best_block_header, self.chain)?;
 		Ok(tx)
 	}
 


### PR DESCRIPTION
Currently transaction's basic verification is not performed during its import from the pool (transaction's verify_basic method is not called).
As a result, incorrect transaction (for example, with incorrect chain id) can be added into the block and mined. Such blocks won't be accepted by other nodes (this transaction's verification will be called for the new block on other nodes). But incorrect block will stay on originator's node.

Solution: perform engine's verify_transaction_basic before adding transaction to the block during import (this will call transaction's verify_basic).

Drawback: this additional verification will increase import's time.

Closes #10411 