### PR TITLE
EIP-1108: Add deactivate_at to builtin contracts

### DIFF
--- a/ethcore/builtin/src/lib.rs
+++ b/ethcore/builtin/src/lib.rs
@@ -146,6 +146,7 @@ pub struct Builtin {
 	pricer: Box<dyn Pricer>,
 	native: Box<dyn Implementation>,
 	activate_at: u64,
+	deactivate_at: Option<u64>,
 }
 
 impl Builtin {
@@ -161,7 +162,7 @@ impl Builtin {
 
 	/// Whether the builtin is activated at the given block number.
 	pub fn is_active(&self, at: u64) -> bool {
-		at >= self.activate_at
+		at >= self.activate_at && self.deactivate_at.map(|inactive_block| at < inactive_block).unwrap_or(true)
 	}
 }
 
@@ -196,6 +197,7 @@ impl From<ethjson::spec::Builtin> for Builtin {
 			pricer: pricer,
 			native: ethereum_builtin(&b.name),
 			activate_at: b.activate_at.map(Into::into).unwrap_or(0),
+			deactivate_at: b.deactivate_at.map(Into::into),
 		}
 	}
 }

--- a/ethcore/builtin/src/lib.rs
+++ b/ethcore/builtin/src/lib.rs
@@ -711,6 +711,7 @@ mod tests {
 			pricer: Box::new(ModexpPricer { divisor: 20 }),
 			native: ethereum_builtin("modexp"),
 			activate_at: 0,
+			deactivate_at: None,
 		};
 
 		// test for potential gas cost multiplication overflow
@@ -822,6 +823,7 @@ mod tests {
 			pricer: Box::new(Linear { base: 0, word: 0 }),
 			native: ethereum_builtin("alt_bn128_add"),
 			activate_at: 0,
+			deactivate_at: None,
 		};
 
 		// zero-points additions
@@ -881,6 +883,7 @@ mod tests {
 			pricer: Box::new(Linear { base: 0, word: 0 }),
 			native: ethereum_builtin("alt_bn128_mul"),
 			activate_at: 0,
+			deactivate_at: None,
 		};
 
 		// zero-point multiplication
@@ -921,6 +924,7 @@ mod tests {
 			pricer: Box::new(Linear { base: 0, word: 0 }),
 			native: ethereum_builtin("alt_bn128_pairing"),
 			activate_at: 0,
+			deactivate_at: None,
 		}
 	}
 
@@ -1005,6 +1009,7 @@ mod tests {
 			pricer: pricer as Box<dyn Pricer>,
 			native: ethereum_builtin("identity"),
 			activate_at: 100_000,
+			deactivate_at: None,
 		};
 
 		assert!(!b.is_active(99_999));
@@ -1019,6 +1024,7 @@ mod tests {
 			pricer: pricer as Box<dyn Pricer>,
 			native: ethereum_builtin("identity"),
 			activate_at: 1,
+			deactivate_at: None,
 		};
 
 		assert_eq!(b.cost(&[0; 0]), U256::from(10));
@@ -1041,6 +1047,7 @@ mod tests {
 				word: 20,
 			}),
 			activate_at: None,
+			deactivate_at: None,
 		});
 
 		assert_eq!(b.cost(&[0; 0]), U256::from(10));

--- a/json/src/spec/builtin.rs
+++ b/json/src/spec/builtin.rs
@@ -69,6 +69,8 @@ pub struct Builtin {
 	pub pricing: Pricing,
 	/// Activation block.
 	pub activate_at: Option<Uint>,
+	/// Deactivation block.
+	pub deactivate_at: Option<Uint>,
 }
 
 #[cfg(test)]
@@ -101,5 +103,19 @@ mod tests {
 		assert_eq!(deserialized.name, "late_start");
 		assert_eq!(deserialized.pricing, Pricing::Modexp(Modexp { divisor: 5 }));
 		assert_eq!(deserialized.activate_at, Some(Uint(100000.into())));
+	}
+
+	#[test]
+	fn deactivate_at() {
+		let s = r#"{
+			"name": "early_finish",
+			"deactivate_at": 200000,
+			"pricing": { "modexp": { "divisor": 5 } }
+		}"#;
+
+		let deserialized: Builtin = serde_json::from_str(s).unwrap();
+		assert_eq!(deserialized.name, "early_finish");
+		assert_eq!(deserialized.pricing, Pricing::Modexp(Modexp { divisor: 5 }));
+		assert_eq!(deserialized.deactivate_at, Some(Uint(200000.into())));
 	}
 }


### PR DESCRIPTION
For [EIP-1108](https://eips.ethereum.org/EIPS/eip-1108), the gas costs of certain builtin operations related to alt_bn128 are being reduced. I looked at how these are currently implemented in Parity and asked a couple of questions in the gitter channel. The approach this PR suggests is to add a `deactivate_at` to builtin contracts that allows certain contracts to expire. The expectation for Istanbul would be to use this functionality to deactivate the current alt_bn128 builtins and activate new ones with adjusted gas costs at the chosen fork block.

This is my first PR for Parity and Rust, so apologies if anything is off. I believe I've held to the style guide, but I'm not sure about the ideal next steps in terms of test writing, though I'm happy to dig in as needed. Also open to feedback that this is not a good approach, of course.

Two flags:
- The additions to `is_active` may make for a line that's too long per the style guide; happy to wrap that if preferred.
- `deactivate_at` in `builtin/src/lib.rs` is an `Option<u64>` for expressiveness. If options are too expensive, this should be fairly straightforward to convert to a boolean + `u64` combo.

Opening this as a draft given my own uncertainty :)