### PR TITLE
Fix rlp decode for inline trie nodes.

### DIFF
--- a/util/patricia-trie-ethereum/src/lib.rs
+++ b/util/patricia-trie-ethereum/src/lib.rs
@@ -145,3 +145,41 @@ pub type TrieFactory = trie::TrieFactory<Layout>;
 pub type TrieError = trie::TrieError<H256, DecoderError>;
 /// Convenience type alias for Keccak/Rlp flavoured trie results
 pub type Result<T> = trie::Result<T, H256, DecoderError>;
+
+#[test]
+fn test_inline_encoding() {
+	use crate::{TrieDBMut, trie::TrieMut};
+	use trie::Trie;
+	let mut memdb = journaldb::new_memory_db();
+	let mut root = H256::zero();
+	{
+		let mut triedbmut = TrieDBMut::new(&mut memdb, &mut root);
+		triedbmut.insert(b"foo", b"bar").unwrap();
+		triedbmut.insert(b"fog", b"b").unwrap();
+		triedbmut.insert(b"fot", &vec![0u8;33][..]).unwrap();
+	}
+	let t = TrieDB::new(&memdb, &root).unwrap();
+	assert!(t.contains(b"foo").unwrap());
+	assert!(t.contains(b"fog").unwrap());
+	assert_eq!(t.get(b"foo").unwrap().unwrap(), b"bar".to_vec());
+	assert_eq!(t.get(b"fog").unwrap().unwrap(), b"b".to_vec());
+	assert_eq!(t.get(b"fot").unwrap().unwrap(), vec![0u8;33]);
+}
+
+#[test]
+fn test_inline_encoding_extension() {
+	use crate::{TrieDBMut, trie::TrieMut};
+	use trie::Trie;
+	let mut memdb = journaldb::new_memory_db();
+	let mut root = H256::zero();
+	{
+		let mut triedbmut = TrieDBMut::new(&mut memdb, &mut root);
+		triedbmut.insert(b"foo", b"b").unwrap();
+		triedbmut.insert(b"fog", b"a").unwrap();
+	}
+	let t = TrieDB::new(&memdb, &root).unwrap();
+	assert!(t.contains(b"foo").unwrap());
+	assert!(t.contains(b"fog").unwrap());
+	assert_eq!(t.get(b"foo").unwrap().unwrap(), b"b".to_vec());
+	assert_eq!(t.get(b"fog").unwrap().unwrap(), b"a".to_vec());
+}

--- a/util/patricia-trie-ethereum/src/lib.rs
+++ b/util/patricia-trie-ethereum/src/lib.rs
@@ -146,40 +146,45 @@ pub type TrieError = trie::TrieError<H256, DecoderError>;
 /// Convenience type alias for Keccak/Rlp flavoured trie results
 pub type Result<T> = trie::Result<T, H256, DecoderError>;
 
-#[test]
-fn test_inline_encoding() {
-	use crate::{TrieDBMut, trie::TrieMut};
-	use trie::Trie;
-	let mut memdb = journaldb::new_memory_db();
-	let mut root = H256::zero();
-	{
-		let mut triedbmut = TrieDBMut::new(&mut memdb, &mut root);
-		triedbmut.insert(b"foo", b"bar").unwrap();
-		triedbmut.insert(b"fog", b"b").unwrap();
-		triedbmut.insert(b"fot", &vec![0u8;33][..]).unwrap();
-	}
-	let t = TrieDB::new(&memdb, &root).unwrap();
-	assert!(t.contains(b"foo").unwrap());
-	assert!(t.contains(b"fog").unwrap());
-	assert_eq!(t.get(b"foo").unwrap().unwrap(), b"bar".to_vec());
-	assert_eq!(t.get(b"fog").unwrap().unwrap(), b"b".to_vec());
-	assert_eq!(t.get(b"fot").unwrap().unwrap(), vec![0u8;33]);
-}
+#[cfg(test)]
+mod tests {
 
-#[test]
-fn test_inline_encoding_extension() {
-	use crate::{TrieDBMut, trie::TrieMut};
+	use ethereum_types::H256;
+	use crate::{TrieDB, TrieDBMut, trie::TrieMut};
 	use trie::Trie;
-	let mut memdb = journaldb::new_memory_db();
-	let mut root = H256::zero();
-	{
-		let mut triedbmut = TrieDBMut::new(&mut memdb, &mut root);
-		triedbmut.insert(b"foo", b"b").unwrap();
-		triedbmut.insert(b"fog", b"a").unwrap();
+
+	#[test]
+	fn test_inline_encoding_branch() {
+		let mut memdb = journaldb::new_memory_db();
+		let mut root = H256::zero();
+		{
+			let mut triedbmut = TrieDBMut::new(&mut memdb, &mut root);
+			triedbmut.insert(b"foo", b"bar").unwrap();
+			triedbmut.insert(b"fog", b"b").unwrap();
+			triedbmut.insert(b"fot", &vec![0u8;33][..]).unwrap();
+		}
+		let t = TrieDB::new(&memdb, &root).unwrap();
+		assert!(t.contains(b"foo").unwrap());
+		assert!(t.contains(b"fog").unwrap());
+		assert_eq!(t.get(b"foo").unwrap().unwrap(), b"bar".to_vec());
+		assert_eq!(t.get(b"fog").unwrap().unwrap(), b"b".to_vec());
+		assert_eq!(t.get(b"fot").unwrap().unwrap(), vec![0u8;33]);
 	}
-	let t = TrieDB::new(&memdb, &root).unwrap();
-	assert!(t.contains(b"foo").unwrap());
-	assert!(t.contains(b"fog").unwrap());
-	assert_eq!(t.get(b"foo").unwrap().unwrap(), b"b".to_vec());
-	assert_eq!(t.get(b"fog").unwrap().unwrap(), b"a".to_vec());
+
+	#[test]
+	fn test_inline_encoding_extension() {
+		let mut memdb = journaldb::new_memory_db();
+		let mut root = H256::zero();
+		{
+			let mut triedbmut = TrieDBMut::new(&mut memdb, &mut root);
+			triedbmut.insert(b"foo", b"b").unwrap();
+			triedbmut.insert(b"fog", b"a").unwrap();
+		}
+		let t = TrieDB::new(&memdb, &root).unwrap();
+		assert!(t.contains(b"foo").unwrap());
+		assert!(t.contains(b"fog").unwrap());
+		assert_eq!(t.get(b"foo").unwrap().unwrap(), b"b".to_vec());
+		assert_eq!(t.get(b"fog").unwrap().unwrap(), b"a".to_vec());
+	}
+
 }

--- a/util/patricia-trie-ethereum/src/rlp_node_codec.rs
+++ b/util/patricia-trie-ethereum/src/rlp_node_codec.rs
@@ -98,7 +98,14 @@ impl NodeCodec<KeccakHasher> for RlpNodeCodec<KeccakHasher> {
 				};
 				match from_encoded {
 					(slice, true) => Ok(Node::Leaf(slice, r.at(1)?.data()?)),
-					(slice, false) => Ok(Node::Extension(slice, r.at(1)?.data()?)),
+					(slice, false) => Ok(Node::Extension(slice, {
+						let value = r.at(1)?;
+						if value.is_data() && value.size() == KeccakHasher::LENGTH {
+							value.data()?
+						} else {
+							value.as_raw()
+						}
+					})),
 				}
 			},
 			// branch - first 16 are nodes, 17th is a value (or empty).
@@ -109,10 +116,10 @@ impl NodeCodec<KeccakHasher> for RlpNodeCodec<KeccakHasher> {
 					if value.is_empty() {
 						nodes[i] = None;
 					} else {
-						if value.is_data() && value.size() <= KeccakHasher::LENGTH {
+						if value.is_data() && value.size() == KeccakHasher::LENGTH {
 							nodes[i] = Some(value.data()?);
 						} else {
-							return Err(DecoderError::Custom("Rlp is not valid."));
+							nodes[i] = Some(value.as_raw());
 						}
 					}
 				}
@@ -176,7 +183,9 @@ impl NodeCodec<KeccakHasher> for RlpNodeCodec<KeccakHasher> {
 		for child_ref in children {
 			match child_ref.borrow() {
 				Some(c) => match c {
-					ChildReference::Hash(h) => stream.append(h),
+					ChildReference::Hash(h) => {
+						stream.append(h)
+					},
 					ChildReference::Inline(inline_data, length) => {
 						let bytes = &AsRef::<[u8]>::as_ref(inline_data)[..*length];
 						stream.append_raw(bytes, 1)

--- a/util/patricia-trie-ethereum/src/rlp_node_codec.rs
+++ b/util/patricia-trie-ethereum/src/rlp_node_codec.rs
@@ -109,7 +109,7 @@ impl NodeCodec<KeccakHasher> for RlpNodeCodec<KeccakHasher> {
 					if value.is_empty() {
 						nodes[i] = None;
 					} else {
-						if value.is_data() && value.size() == KeccakHasher::LENGTH {
+						if value.is_data() && value.size() <= KeccakHasher::LENGTH {
 							nodes[i] = Some(value.data()?);
 						} else {
 							return Err(DecoderError::Custom("Rlp is not valid."));


### PR DESCRIPTION
The test from #10972 last commit was incorrect, and fails on inline trie node.