### PR TITLE
EIP 2028: transaction gas lowered from 68 to 16

### DIFF
--- a/ethcore/evm/src/tests.rs
+++ b/ethcore/evm/src/tests.rs
@@ -262,7 +262,6 @@ fn test_calldataload(factory: super::Factory) {
 
 	assert_eq!(gas_left, U256::from(79_991));
 	assert_store(&ext, 0, "23ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff23");
-
 }
 
 evm_test!{test_author: test_author_int}

--- a/ethcore/types/src/engines/params.rs
+++ b/ethcore/types/src/engines/params.rs
@@ -90,6 +90,8 @@ pub struct CommonParams {
 	pub eip1283_disable_transition: BlockNumber,
 	/// Number of first block where EIP-1014 rules begin.
 	pub eip1014_transition: BlockNumber,
+	/// Number of first block where EIP-2028 rules begin.
+	pub eip2028_transition: BlockNumber,
 	/// Number of first block where dust cleanup rules (EIP-168 and EIP169) begin.
 	pub dust_protection_transition: BlockNumber,
 	/// Nonce cap increase per block. Nonce cap is only checked if dust protection is enabled.
@@ -160,6 +162,9 @@ impl CommonParams {
 		schedule.have_bitwise_shifting = block_number >= self.eip145_transition;
 		schedule.have_extcodehash = block_number >= self.eip1052_transition;
 		schedule.eip1283 = block_number >= self.eip1283_transition && !(block_number >= self.eip1283_disable_transition);
+		if block_number >= self.eip2028_transition {
+			schedule.tx_data_non_zero_gas = 16;
+		}
 		if block_number >= self.eip210_transition {
 			schedule.blockhash_gas = 800;
 		}
@@ -274,6 +279,10 @@ impl From<ethjson::spec::Params> for CommonParams {
 				Into::into,
 			),
 			eip1014_transition: p.eip1014_transition.map_or_else(
+				BlockNumber::max_value,
+				Into::into,
+			),
+			eip2028_transition: p.eip2028_transition.map_or_else(
 				BlockNumber::max_value,
 				Into::into,
 			),

--- a/ethcore/vm/src/schedule.rs
+++ b/ethcore/vm/src/schedule.rs
@@ -91,7 +91,7 @@ pub struct Schedule {
 	pub tx_create_gas: usize,
 	/// Additional cost for empty data transaction
 	pub tx_data_zero_gas: usize,
-	/// Aditional cost for non-empty data transaction
+	/// Additional cost for non-empty data transaction
 	pub tx_data_non_zero_gas: usize,
 	/// Gas price for copying memory
 	pub copy_gas: usize,
@@ -285,6 +285,13 @@ impl Schedule {
 	pub fn new_constantinople() -> Schedule {
 		let mut schedule = Self::new_byzantium();
 		schedule.have_bitwise_shifting = true;
+		schedule
+	}
+
+	/// Schedule for the Istanbul fork of the Ethereum main net.
+	pub fn new_istanbul() -> Schedule {
+		let mut schedule = Self::new_constantinople();
+		schedule.tx_data_non_zero_gas = 16;
 		schedule
 	}
 

--- a/ethcore/vm/src/tests.rs
+++ b/ethcore/vm/src/tests.rs
@@ -98,6 +98,13 @@ impl FakeExt {
 		ext
 	}
 
+	/// New fake externalities with constantinople schedule rules
+	pub fn new_istanbul() -> Self {
+		let mut ext = FakeExt::default();
+		ext.schedule = Schedule::new_istanbul();
+		ext
+	}
+
 	/// Alter fake externalities to allow wasm
 	pub fn with_wasm(mut self) -> Self {
 		self.schedule.wasm = Some(Default::default());

--- a/json/src/spec/params.rs
+++ b/json/src/spec/params.rs
@@ -94,6 +94,8 @@ pub struct Params {
 	/// See `CommonParams` docs.
 	pub eip1014_transition: Option<Uint>,
 	/// See `CommonParams` docs.
+	pub eip2028_transition: Option<Uint>,
+	/// See `CommonParams` docs.
 	pub dust_protection_transition: Option<Uint>,
 	/// See `CommonParams` docs.
 	pub nonce_cap_increment: Option<Uint>,


### PR DESCRIPTION
Closes #10986

Note: there are no tests in this PR. Not sure what the process is for adding state tests (or whatever it is we need).