### PR TITLE
Fix compilation on recent nightlies

### DIFF
--- a/ipfs/Cargo.toml
+++ b/ipfs/Cargo.toml
@@ -12,7 +12,7 @@ common-types = { path = "../ethcore/types" }
 ethcore = { path = "../ethcore" }
 bytes = { package = "parity-bytes", version = "0.1"}
 ethereum-types = "0.6.0"
-core = { package = "jsonrpc-core", version = "12.0.0"}
+jsonrpc-core = "12.0.0"
 http = { package = "jsonrpc-http-server", version = "12.0.0"}
 rlp = "0.4.0"
 cid = "0.3"

--- a/ipfs/src/lib.rs
+++ b/ipfs/src/lib.rs
@@ -21,8 +21,8 @@ use std::thread;
 use std::sync::{mpsc, Arc};
 use std::net::{SocketAddr, IpAddr};
 
-use core::futures::future::{self, FutureResult};
-use core::futures::{self, Future};
+use jsonrpc_core::futures::future::{self, FutureResult};
+use jsonrpc_core::futures::{self, Future};
 use client_traits::BlockChainClient;
 use http::hyper::{self, server, Method, StatusCode, Body,
 	header::{self, HeaderValue},


### PR DESCRIPTION
For reasons unknown (to me) recent rustc nightlies can't find the `format!`-macro in `core` when there is an import named `core`. This PR removes the package rename and uses the full `jsonrpc_core` crate name instead.