### PR TITLE
Fix deadlock in `network-devp2p`

### DIFF
--- a/util/network-devp2p/src/host.rs
+++ b/util/network-devp2p/src/host.rs
@@ -722,12 +722,13 @@ impl Host {
 					let session_result = session.lock().readable(io, &self.info.read());
 					match session_result {
 						Err(e) => {
+							let reserved_nodes = self.reserved_nodes.read();
 							let s = session.lock();
 							trace!(target: "network", "Session read error: {}:{:?} ({:?}) {:?}", token, s.id(), s.remote_addr(), e);
 							match e {
 								Error::Disconnect(DisconnectReason::IncompatibleProtocol) | Error::Disconnect(DisconnectReason::UselessPeer) => {
 									if let Some(id) = s.id() {
-										if !self.reserved_nodes.read().contains(id) {
+										if !reserved_nodes.contains(id) {
 											let mut nodes = self.nodes.write();
 											nodes.note_failure(&id);
 											nodes.mark_as_useless(id);
@@ -741,6 +742,7 @@ impl Host {
 						},
 						Ok(SessionData::Ready) => {
 							let (_, egress_count, ingress_count) = self.session_count();
+							let reserved_nodes = self.reserved_nodes.read();
 							let mut s = session.lock();
 							let (min_peers, mut max_peers, reserved_only, self_id) = {
 								let info = self.info.read();
@@ -765,7 +767,7 @@ impl Host {
 							if reserved_only ||
 								(s.info.originated && egress_count > min_peers) ||
 								(!s.info.originated && ingress_count > max_ingress) {
-								if !self.reserved_nodes.read().contains(&id) {
+								if !reserved_nodes.contains(&id) {
 									// only proceed if the connecting peer is reserved.
 									trace!(target: "network", "Disconnecting non-reserved peer {:?}", id);
 									s.disconnect(io, DisconnectReason::TooManyPeers);
@@ -980,7 +982,8 @@ impl Host {
 		for i in to_remove {
 			trace!(target: "network", "Removed from node table: {}", i);
 		}
-		self.nodes.write().update(node_changes, &*self.reserved_nodes.read());
+		let reserved_nodes = self.reserved_nodes.read();
+		self.nodes.write().update(node_changes, &*reserved_nodes);
 	}
 
 	pub fn with_context<F>(&self, protocol: ProtocolId, io: &IoContext<NetworkIoMessage>, action: F) where F: FnOnce(&dyn NetworkContextTrait) {
@@ -1066,8 +1069,9 @@ impl IoHandler<NetworkIoMessage> for Host {
 			},
 			NODE_TABLE => {
 				trace!(target: "network", "Refreshing node table");
-				self.nodes.write().clear_useless();
-				self.nodes.write().save();
+				let mut nodes = self.nodes.write();
+				nodes.clear_useless();
+				nodes.save();
 			},
 			_ => match self.timers.read().get(&token).cloned() {
 				Some(timer) => match self.handlers.read().get(&timer.protocol).cloned() {

--- a/util/network-devp2p/src/host.rs
+++ b/util/network-devp2p/src/host.rs
@@ -261,6 +261,8 @@ struct ProtocolTimer {
 }
 
 /// Root IO handler. Manages protocol handlers, IO timers and network connections.
+///
+/// NOTE: must keep the lock in order of: reserved_nodes (rwlock) -> session (mutex, from sessions)
 pub struct Host {
 	pub info: RwLock<HostInfo>,
 	udp_socket: Mutex<Option<UdpSocket>>,


### PR DESCRIPTION
Fix two deadlock in devp2p module.

# Reproduce
deadlock will occur in 5 minutes with this docker-compose.yaml.
```yaml
version: '3'
services:
  parity:
    image: parity/parity:latest
    command: --chain kovan --unsafe-expose --jsonrpc-apis=all --node-key=test --no-warp

  rpc_client:
    image: alpine
    command:
      - sh
      - -c
      - |-
        apk --no-cache add curl jq
        while :
          do
          curl --data '[
            {"method":"parity_addReservedPeer","params":["enode://5ff409de959e62e822273a53e42a603a81676538f58b8c708014ff057e48d2ec15c1273ff963ea162ccba8358587143e5d694564eeffd0cb3f9520272fb3c48e@parity:30303"],"id":1,"jsonrpc":"2.0"},
            {"method":"eth_syncing","params":[],"id":2,"jsonrpc":"2.0"}
          ]' -H "Content-Type: application/json" -X POST parity:8545 2>/dev/null | jq
        done
    depends_on:
      - parity
```

# Explanation

In `fn connect_peers(&self, io: &IoContext<NetworkIoMessage>)`, try to acquire mutex for `Session` while holding r-lock for `reserved_peers`:
https://github.com/paritytech/parity-ethereum/blob/00124b5a4bf8a38ad6c660b462a5e5addf13cab3/util/network-devp2p/src/host.rs#L576
https://github.com/paritytech/parity-ethereum/blob/00124b5a4bf8a38ad6c660b462a5e5addf13cab3/util/network-devp2p/src/host.rs#L603-L604

in `fn session_readable(&self, token: StreamToken, io: &IoContext<NetworkIoMessage>)`, there are two code path trying to acquire r-lock for `reserved_peers` while holding  mutex for `Session`:
- https://github.com/paritytech/parity-ethereum/blob/00124b5a4bf8a38ad6c660b462a5e5addf13cab3/util/network-devp2p/src/host.rs#L725-L730
- https://github.com/paritytech/parity-ethereum/blob/00124b5a4bf8a38ad6c660b462a5e5addf13cab3/util/network-devp2p/src/host.rs#L744
https://github.com/paritytech/parity-ethereum/blob/00124b5a4bf8a38ad6c660b462a5e5addf13cab3/util/network-devp2p/src/host.rs#L768

In the situation that:
- thread A is in `connect_peers` holding r-lock for `reserved_peers` and waiting the `session` mutex
- thread B is in `session_readable` holding mutex for `session` and trying to acquire r-lock for `reserved_peers`

if there is another thread C acquiring w-lock for `reserved_peers`, thread B will be blocked until there are no more writers which hold / **waiting for** the lock cause the dead lock among three threads.

Another deadlock is cause by `reserved_nodes` and `node` in `fn update_nodes(&self, _io: &IoContext<NetworkIoMessage>, node_changes: TableUpdates)` and `fn connect_peers(&self, io: &IoContext<NetworkIoMessage>)`.


