### PR TITLE
Edit publish-onchain.sh to use https

### DIFF
--- a/scripts/gitlab/publish-onchain.sh
+++ b/scripts/gitlab/publish-onchain.sh
@@ -7,7 +7,7 @@ echo "__________Register Release__________"
 DATA="secret=$RELEASES_SECRET"
 
 echo "Pushing release to Mainnet"
-./tools/safe-curl.sh $DATA "http://update.parity.io:1337/push-release/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$CI_COMMIT_SHA"
+./tools/safe-curl.sh $DATA "https://update.parity.io/push-release/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$CI_COMMIT_SHA"
 
 cd artifacts
 ls -l | sort -k9
@@ -26,7 +26,7 @@ do
   case $DIR in
     x86_64* )
       DATA="commit=$CI_COMMIT_SHA&sha3=$sha3&filename=parity$WIN&secret=$RELEASES_SECRET"
-      ../../tools/safe-curl.sh $DATA "http://update.parity.io:1337/push-build/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$DIR"
+      ../../tools/safe-curl.sh $DATA "https://update.parity.io/push-build/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$DIR"
       ;;
   esac
   cd ..


### PR DESCRIPTION
`update.parity.io` supports HTTPS, so it makes sense to use it.
