### PR TITLE
Fix ethash benchmark imports.

### DIFF
--- a/ethash/src/lib.rs
+++ b/ethash/src/lib.rs
@@ -37,20 +37,16 @@ extern crate serde_json;
 #[cfg(test)]
 extern crate tempdir;
 
-#[cfg(feature = "bench")]
+// TODO: This should only be public for benchmarks.
 pub mod compute;
-#[cfg(not(feature = "bench"))]
-mod compute;
 
 mod seed_compute;
 mod cache;
 mod keccak;
 mod shared;
 
-#[cfg(feature = "bench")]
+// TODO: This should only be public for benchmarks.
 pub mod progpow;
-#[cfg(not(feature = "bench"))]
-mod progpow;
 
 pub use cache::NodeCacheBuilder;
 pub use compute::{ProofOfWork, quick_get_difficulty, slow_hash_block_number};


### PR DESCRIPTION
This fixes `cargo check --all --all-targets`.

Otherwise the `ethash` benches wouldn't compile:
```
error[E0603]: module `progpow` is private
 --> ethash/benches/progpow.rs:9:13
  |
9 | use ethash::progpow;
  |             ^^^^^^^

error[E0603]: module `compute` is private
  --> ethash/benches/progpow.rs:14:13
   |
14 | use ethash::compute::light_compute;
```
(When building benches, the crate isn't compiled with the `bench` feature.)