### PR TITLE
Resolve "Reverted report validator transactions get added in block #10580"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "state-db 0.1.0",
  "time-utils 0.1.0",
  "unexpected 0.1.0",
+ "validator-reporting-config 0.1.0",
  "validator-set 0.1.0",
 ]
 
@@ -870,6 +871,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "machine 0.1.0",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator-reporting-config 0.1.0",
  "vm 0.1.0",
 ]
 
@@ -3037,6 +3039,7 @@ dependencies = [
  "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator-reporting-config 0.1.0",
  "verification 0.1.0",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4993,6 +4996,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "validator-reporting-config"
+version = "0.1.0"
+
+[[package]]
 name = "validator-set"
 version = "0.1.0"
 dependencies = [
@@ -5024,6 +5031,7 @@ dependencies = [
  "spec 0.1.0",
  "triehash-ethereum 0.2.0",
  "unexpected 0.1.0",
+ "validator-reporting-config 0.1.0",
  "vm 0.1.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,11 +741,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_builder_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -757,7 +812,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -952,7 +1007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ethabi 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1160,6 +1215,7 @@ name = "ethcore-call-contract"
 version = "0.1.0"
 dependencies = [
  "common-types 0.1.0",
+ "derive_builder 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1719,7 +1775,7 @@ name = "failure_derive"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2059,6 +2115,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,7 +2329,7 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2563,7 +2624,7 @@ name = "malloc_size_of_derive"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2770,6 +2831,7 @@ dependencies = [
  "ethabi-contract 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi-derive 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore 1.12.0",
+ "ethcore-call-contract 0.1.0",
  "ethcore-io 1.12.0",
  "ethcore-network 1.12.0",
  "ethcore-network-devp2p 1.12.0",
@@ -3267,6 +3329,7 @@ dependencies = [
  "ethabi-contract 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi-derive 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore 1.12.0",
+ "ethcore-call-contract 0.1.0",
  "ethcore-sync 1.12.0",
  "ethereum-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3595,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.20"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3658,7 +3721,7 @@ name = "quote"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3949,7 +4012,7 @@ dependencies = [
 name = "rlp_derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4093,7 +4156,7 @@ name = "serde_derive"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4391,7 +4454,7 @@ name = "syn"
 version = "0.15.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4419,7 +4482,7 @@ name = "synstructure"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5042,7 +5105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5284,7 +5347,7 @@ name = "zeroize_derive"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5354,6 +5417,11 @@ dependencies = [
 "checksum ct-logs 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b4660f8b07a560a88c02d76286edb9f0d5d64e495d2b0f233186155aa51be1f"
 "checksum ctr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "022cd691704491df67d25d006fe8eca083098253c4d43516c2206479c58c6736"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
+"checksum darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
+"checksum darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
+"checksum darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
+"checksum derive_builder 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ac53fa6a3cda160df823a9346442525dcaf1e171999a1cf23e67067e4fd64d4"
+"checksum derive_builder_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0288a23da9333c246bb18c143426074a6ae96747995c5819d2947b64cd942b37"
 "checksum derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fbe9f11be34f800b3ecaaed0ec9ec2e015d1d0ba0c8644c1310f73d6e8994615"
 "checksum derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
@@ -5411,6 +5479,7 @@ dependencies = [
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)" = "f1ebec079129e43af5e234ef36ee3d7e6085687d145b7ea653b262d16c6b65f1"
 "checksum hyper-rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff2c61fbda2bc72e793e329190a3e8f0ae74cb896905c8b301304c4c93f2755"
+"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4bac95d9aa0624e7b78187d6fb8ab012b41d9f6f54b1bcb61e61c4845f8357ec"
 "checksum igd 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96f0f346ff76d5143011b2de50fbe72c3e521304868dfbd0d781b4f262a75dd5"
@@ -5527,7 +5596,7 @@ dependencies = [
 "checksum primitive-types 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2288eb2a39386c4bc817974cc413afe173010dc80e470fcb1e9a35580869f024"
 "checksum proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
 "checksum proc-macro-hack 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e688f31d92ffd7c1ddc57a1b4e6d773c0f2a14ee437a4b0a4f5a69c80eb221c8"
-"checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
+"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5c2380ae88876faae57698be9e9775e3544decad214599c3a6266cca6ac802"
 "checksum pulldown-cmark 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8361e81576d2e02643b04950e487ec172b687180da65c731c03cf336784e6c07"
 "checksum pwasm-utils 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e9135bed7b452e20dbb395a2d519abaf0c46d60e7ecc02daeeab447d29bada1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ spec = { path = "ethcore/spec" }
 term_size = "0.3"
 textwrap = "0.9"
 toml = "0.4"
+validator-reporting-config = { path = "ethcore/engines/validator-set/reporting-config" }
 verification = { path = "ethcore/verification" }
 
 [build-dependencies]

--- a/ethcore/call-contract/Cargo.toml
+++ b/ethcore/call-contract/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2018"
 types = { path = "../types", package = "common-types" }
 ethereum-types = "0.6.0"
 bytes = { version = "0.1", package = "parity-bytes" }
+derive_builder = "0.7.2"

--- a/ethcore/call-contract/src/call_contract.rs
+++ b/ethcore/call-contract/src/call_contract.rs
@@ -50,6 +50,7 @@ pub struct CallOptions {
 	/// Value in wei
 	pub value: U256,
 	/// Provided gas
+	#[builder(default = "self.default_gas()")]
 	pub gas: U256,
 	/// Gas price
 	pub gas_price: U256,
@@ -58,8 +59,14 @@ pub struct CallOptions {
 impl CallOptions {
 	/// Convenience method for creating the most common use case.
 	pub fn new(contract: Address, data: Bytes) -> Self {
-		CallOptionsBuilder::default().contract_address(contract).data(data).gas(U256::from(50_000_000)).build().unwrap()
+		CallOptionsBuilder::default().contract_address(contract).data(data).build().unwrap()
 	}
+}
+
+impl CallOptionsBuilder {
+    fn default_gas(&self) -> U256 {
+        U256::from(50_000_000)
+    }
 }
 
 /// Provides `call_contract` method

--- a/ethcore/call-contract/src/call_contract.rs
+++ b/ethcore/call-contract/src/call_contract.rs
@@ -58,7 +58,7 @@ pub struct CallOptions {
 impl CallOptions {
 	/// Convenience method for creating the most common use case.
 	pub fn new(contract: Address, data: Bytes) -> Self {
-		CallOptionsBuilder::default().contract_address(contract).data(data).gas_price(U256::from(50_000_000)).build().unwrap()
+		CallOptionsBuilder::default().contract_address(contract).data(data).gas(U256::from(50_000_000)).build().unwrap()
 	}
 }
 

--- a/ethcore/call-contract/src/call_contract.rs
+++ b/ethcore/call-contract/src/call_contract.rs
@@ -38,7 +38,7 @@ impl fmt::Display for CallError {
 }
 
 #[derive(Builder, Default, Clone)]
-#[builder(setter(into))]
+#[builder(default)]
 /// Options to make a call to contract
 pub struct CallOptions {
 	/// Contract address

--- a/ethcore/engine/Cargo.toml
+++ b/ethcore/engine/Cargo.toml
@@ -15,6 +15,7 @@ common-types = { path = "../types" }
 ethereum-types = "0.6.0"
 ethkey = { path = "../../accounts/ethkey" }
 machine = { path = "../machine" }
+validator-reporting-config = { path = "../engines/validator-set/reporting-config" }
 vm = { path = "../vm" }
 
 # used from test-helpers

--- a/ethcore/engine/src/engine.rs
+++ b/ethcore/engine/src/engine.rs
@@ -384,7 +384,7 @@ pub trait Engine: Sync + Send {
 	}
 
 	/// Set reporting
-	fn set_reporting(&self, benign_reporting: ReportingConfig, malicious_reporting: ReportingConfig) {}
+	fn set_reporting(&self, _benign_reporting: ReportingConfig, _malicious_reporting: ReportingConfig) {}
 }
 
 /// Verifier for all blocks within an epoch with self-contained state.

--- a/ethcore/engine/src/engine.rs
+++ b/ethcore/engine/src/engine.rs
@@ -45,6 +45,7 @@ use machine::{
 use vm::{EnvInfo, Schedule, CallType, ActionValue};
 
 use crate::signer::EngineSigner;
+use validator_reporting_config::ReportingConfig;
 
 /// A system-calling closure. Enacts calls on a block's state from the system address.
 pub type SystemCall<'a> = dyn FnMut(Address, Vec<u8>) -> Result<Vec<u8>, String> + 'a;
@@ -381,6 +382,9 @@ pub trait Engine: Sync + Send {
 	fn decode_transaction(&self, transaction: &[u8]) -> Result<UnverifiedTransaction, transaction::Error> {
 		self.machine().decode_transaction(transaction)
 	}
+
+	/// Set reporting
+	fn set_reporting(&self, benign_reporting: ReportingConfig, malicious_reporting: ReportingConfig) {}
 }
 
 /// Verifier for all blocks within an epoch with self-contained state.

--- a/ethcore/engines/authority-round/Cargo.toml
+++ b/ethcore/engines/authority-round/Cargo.toml
@@ -28,6 +28,7 @@ rlp = "0.4.0"
 time-utils = { path = "../../../util/time-utils" }
 unexpected = { path = "../../../util/unexpected" }
 validator-set = { path = "../validator-set" }
+validator-reporting-config = { path = "../validator-set/reporting-config" }
 
 [dev-dependencies]
 accounts = { package = "ethcore-accounts", path = "../../../accounts" }

--- a/ethcore/engines/validator-set/Cargo.toml
+++ b/ethcore/engines/validator-set/Cargo.toml
@@ -28,6 +28,7 @@ parking_lot = "0.8"
 rlp = "0.4.2"
 triehash = { package = "triehash-ethereum", version = "0.2",  path = "../../../util/triehash-ethereum" }
 unexpected = { path = "../../../util/unexpected" }
+validator-reporting-config = { path = "./reporting-config" }
 vm = { path = "../../vm" }
 
 [dev-dependencies]

--- a/ethcore/engines/validator-set/Cargo.toml
+++ b/ethcore/engines/validator-set/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
+call-contract = { package = "ethcore-call-contract", path = "../../call-contract" }
 client-traits = { path = "../../client-traits" }
 common-types = { path = "../../types" }
 engine = { path = "../../engine" }
@@ -33,7 +34,6 @@ vm = { path = "../../vm" }
 
 [dev-dependencies]
 accounts = { package = "ethcore-accounts", path = "../../../accounts" }
-call-contract = { package = "ethcore-call-contract", path = "../../call-contract" }
 engine = { path = "../../engine", features = ["test-helpers"] }
 env_logger = "0.6.2"
 ethcore = { path = "../..", features = ["test-helpers"] }

--- a/ethcore/engines/validator-set/reporting-config/Cargo.toml
+++ b/ethcore/engines/validator-set/reporting-config/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+description = "Validators reporting config"
+name = "validator-reporting-config"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+license = "GPL-3.0"

--- a/ethcore/engines/validator-set/reporting-config/src/lib.rs
+++ b/ethcore/engines/validator-set/reporting-config/src/lib.rs
@@ -1,0 +1,45 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity Ethereum.
+
+// Parity Ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
+
+/// Reporting config
+#[derive(PartialEq, Debug, Clone)]
+pub enum ReportingConfig {
+	Force,
+	Call(u64),
+	Disable
+}
+
+impl ReportingConfig {
+	pub fn from_str_and_call_every(config_str: Option<String>, call_every: u64) -> Result<Self, String> {
+		if let Some(s) = config_str {
+			let s = s.as_str();
+			match s {
+				"force" => Ok(ReportingConfig::Force),
+				"call" => Ok(ReportingConfig::Call(call_every)),
+				"disable" => Ok(ReportingConfig::Disable),
+				other => Err(format!("Invalid reporting config value: {}", other))
+			}
+		} else {
+			Ok(Default::default())
+		}
+	}
+}
+
+impl Default for ReportingConfig {
+	fn default() -> Self {
+		ReportingConfig::Force
+	}
+}

--- a/ethcore/engines/validator-set/src/lib.rs
+++ b/ethcore/engines/validator-set/src/lib.rs
@@ -168,9 +168,9 @@ pub trait ValidatorSet: Send + Sync + 'static {
 	fn count_with_caller(&self, parent_block_hash: &H256, caller: &Call) -> usize;
 
 	/// Notifies about malicious behaviour.
-	fn report_malicious(&self, _validator: &Address, _set_block: BlockNumber, _block: BlockNumber, _proof: Bytes, _reporting: &mut ValidatorReporting) {}
+	fn report_malicious(&self, _validator: &Address, _set_block: BlockNumber, _block: BlockNumber, _proof: Bytes, _reporting: &mut ValidatorReporting, _sender: Address) {}
 	/// Notifies about benign misbehaviour.
-	fn report_benign(&self, _validator: &Address, _set_block: BlockNumber, _block: BlockNumber, _reporting: &mut ValidatorReporting) {}
+	fn report_benign(&self, _validator: &Address, _set_block: BlockNumber, _block: BlockNumber, _reporting: &mut ValidatorReporting, _sender: Address) {}
 	/// Allows blockchain state access.
 	fn register_client(&self, _client: Weak<dyn EngineClient>) {}
 }

--- a/ethcore/engines/validator-set/src/multi.rs
+++ b/ethcore/engines/validator-set/src/multi.rs
@@ -131,12 +131,12 @@ impl ValidatorSet for Multi {
 			.map_or_else(usize::max_value, |set| set.count_with_caller(bh, caller))
 	}
 
-	fn report_malicious(&self, validator: &Address, set_block: BlockNumber, block: BlockNumber, proof: Bytes, reporting: &mut ValidatorReporting) {
-		self.correct_set_by_number(set_block).1.report_malicious(validator, set_block, block, proof, reporting);
+	fn report_malicious(&self, validator: &Address, set_block: BlockNumber, block: BlockNumber, proof: Bytes, reporting: &mut ValidatorReporting, sender: Address) {
+		self.correct_set_by_number(set_block).1.report_malicious(validator, set_block, block, proof, reporting, sender);
 	}
 
-	fn report_benign(&self, validator: &Address, set_block: BlockNumber, block: BlockNumber, reporting: &mut ValidatorReporting) {
-		self.correct_set_by_number(set_block).1.report_benign(validator, set_block, block, reporting);
+	fn report_benign(&self, validator: &Address, set_block: BlockNumber, block: BlockNumber, reporting: &mut ValidatorReporting, sender: Address) {
+		self.correct_set_by_number(set_block).1.report_benign(validator, set_block, block, reporting, sender);
 	}
 
 	fn register_client(&self, client: Weak<dyn EngineClient>) {

--- a/ethcore/engines/validator-set/src/multi.rs
+++ b/ethcore/engines/validator-set/src/multi.rs
@@ -33,7 +33,7 @@ use parity_bytes::Bytes;
 use parking_lot::RwLock;
 use machine::Machine;
 
-use super::{SystemCall, ValidatorSet};
+use super::{SystemCall, ValidatorSet, ValidatorReporting};
 
 type BlockNumberLookup = Box<dyn Fn(BlockId) -> Result<BlockNumber, String> + Send + Sync + 'static>;
 
@@ -131,12 +131,12 @@ impl ValidatorSet for Multi {
 			.map_or_else(usize::max_value, |set| set.count_with_caller(bh, caller))
 	}
 
-	fn report_malicious(&self, validator: &Address, set_block: BlockNumber, block: BlockNumber, proof: Bytes) {
-		self.correct_set_by_number(set_block).1.report_malicious(validator, set_block, block, proof);
+	fn report_malicious(&self, validator: &Address, set_block: BlockNumber, block: BlockNumber, proof: Bytes, reporting: &mut ValidatorReporting) {
+		self.correct_set_by_number(set_block).1.report_malicious(validator, set_block, block, proof, reporting);
 	}
 
-	fn report_benign(&self, validator: &Address, set_block: BlockNumber, block: BlockNumber) {
-		self.correct_set_by_number(set_block).1.report_benign(validator, set_block, block);
+	fn report_benign(&self, validator: &Address, set_block: BlockNumber, block: BlockNumber, reporting: &mut ValidatorReporting) {
+		self.correct_set_by_number(set_block).1.report_benign(validator, set_block, block, reporting);
 	}
 
 	fn register_client(&self, client: Weak<dyn EngineClient>) {

--- a/ethcore/engines/validator-set/src/safe_contract.rs
+++ b/ethcore/engines/validator-set/src/safe_contract.rs
@@ -18,6 +18,7 @@
 
 use std::sync::{Weak, Arc};
 
+use call_contract::CallOptions;
 use client_traits::EngineClient;
 use common_types::{
 	BlockNumber,
@@ -294,7 +295,7 @@ impl ValidatorSet for ValidatorSafeContract {
 			.ok_or_else(|| "No client!".into())
 			.and_then(|c| {
 				match c.as_full_client() {
-					Some(c) => c.call_contract(id, addr, data),
+					Some(c) => c.call_contract(id, CallOptions::new(addr, data)).map_err(|e| e.to_string()),
 					None => Err("No full client!".into()),
 				}
 			})

--- a/ethcore/engines/validator-set/src/test.rs
+++ b/ethcore/engines/validator-set/src/test.rs
@@ -94,11 +94,11 @@ impl ValidatorSet for TestSet {
 		1
 	}
 
-	fn report_malicious(&self, _validator: &Address, _set_block: BlockNumber, block: BlockNumber, _proof: Bytes, _reporting: &mut ValidatorReporting) {
+	fn report_malicious(&self, _validator: &Address, _set_block: BlockNumber, block: BlockNumber, _proof: Bytes, _reporting: &mut ValidatorReporting, _sender: Address) {
 		self.last_malicious.store(block as usize, AtomicOrdering::SeqCst)
 	}
 
-	fn report_benign(&self, _validator: &Address, _set_block: BlockNumber, block: BlockNumber, _reporting: &mut ValidatorReporting) {
+	fn report_benign(&self, _validator: &Address, _set_block: BlockNumber, block: BlockNumber, _reporting: &mut ValidatorReporting, _sender: Address) {
 		trace!(target: "engine", "test validator set recording benign misbehaviour");
 		self.last_benign.store(block as usize, AtomicOrdering::SeqCst)
 	}

--- a/ethcore/engines/validator-set/src/test.rs
+++ b/ethcore/engines/validator-set/src/test.rs
@@ -33,7 +33,7 @@ use ethereum_types::{H256, Address};
 use machine::Machine;
 use parity_bytes::Bytes;
 
-use super::{ValidatorSet, SimpleList};
+use super::{ValidatorSet, SimpleList, ValidatorReporting};
 
 /// Set used for testing with a single validator.
 #[derive(MallocSizeOf, Debug)]
@@ -94,11 +94,11 @@ impl ValidatorSet for TestSet {
 		1
 	}
 
-	fn report_malicious(&self, _validator: &Address, _set_block: BlockNumber, block: BlockNumber, _proof: Bytes) {
+	fn report_malicious(&self, _validator: &Address, _set_block: BlockNumber, block: BlockNumber, _proof: Bytes, _reporting: &mut ValidatorReporting) {
 		self.last_malicious.store(block as usize, AtomicOrdering::SeqCst)
 	}
 
-	fn report_benign(&self, _validator: &Address, _set_block: BlockNumber, block: BlockNumber) {
+	fn report_benign(&self, _validator: &Address, _set_block: BlockNumber, block: BlockNumber, _reporting: &mut ValidatorReporting) {
 		trace!(target: "engine", "test validator set recording benign misbehaviour");
 		self.last_benign.store(block as usize, AtomicOrdering::SeqCst)
 	}

--- a/ethcore/node-filter/Cargo.toml
+++ b/ethcore/node-filter/Cargo.toml
@@ -7,6 +7,7 @@ version = "1.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
+call-contract = { package = "ethcore-call-contract", path = "../call-contract" }
 client-traits = { path = "../client-traits" }
 common-types = { path = "../types" }
 ethcore = { path = ".."}

--- a/ethcore/private-tx/src/key_server_keys.rs
+++ b/ethcore/private-tx/src/key_server_keys.rs
@@ -19,7 +19,7 @@
 use std::sync::Arc;
 use parking_lot::RwLock;
 use ethereum_types::{H256, Address};
-use call_contract::{CallContract, RegistryInfo};
+use call_contract::{CallContract, CallOptions, RegistryInfo};
 use types::ids::BlockId;
 use ethabi::FunctionOutputDecoder;
 
@@ -79,7 +79,7 @@ impl<C> KeyProvider for SecretStoreKeys<C> where C: CallContract + RegistryInfo 
 		match *self.keys_acl_contract.read() {
 			Some(acl_contract_address) => {
 				let (data, decoder) = keys_acl_contract::functions::available_keys::call(*account);
-				if let Ok(value) = self.client.call_contract(block, acl_contract_address, data) {
+				if let Ok(value) = self.client.call_contract(block, CallOptions::new(acl_contract_address, data)) {
 					decoder.decode(&value).ok().map(|key_values| {
 						key_values.iter().map(key_to_address).collect()
 					})
@@ -159,7 +159,7 @@ mod tests {
 	}
 
 	impl CallContract for DummyRegistryClient {
-		fn call_contract(&self, _id: BlockId, _address: Address, _data: Bytes) -> Result<Bytes, String> { Ok(vec![]) }
+		fn call_contract(&self, _id: BlockId, _call_options: CallOptions) -> Result<Bytes, String> { Ok(vec![]) }
 	}
 
 	#[test]

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -63,7 +63,7 @@ use types::{
 use vm::{Schedule, LastHashes};
 
 use block::{OpenBlock, SealedBlock, ClosedBlock};
-use call_contract::{CallContract, RegistryInfo};
+use call_contract::{CallContract, CallOptions, RegistryInfo, CallError as ContractCallError};
 use client::{
 	ReopenBlock, PrepareOpenBlock, ImportSealedBlock, BroadcastProposalBlock, Call,
 	EngineInfo, BlockProducer, SealedBlockImporter,
@@ -532,7 +532,7 @@ impl BlockInfo for TestBlockChainClient {
 }
 
 impl CallContract for TestBlockChainClient {
-	fn call_contract(&self, _id: BlockId, _address: Address, _data: Bytes) -> Result<Bytes, String> { Ok(vec![]) }
+	fn call_contract(&self, _id: BlockId, _call_options: CallOptions) -> Result<Bytes, ContractCallError> { Ok(vec![]) }
 }
 
 impl TransactionInfo for TestBlockChainClient {

--- a/miner/src/service_transaction_checker.rs
+++ b/miner/src/service_transaction_checker.rs
@@ -19,7 +19,7 @@
 use std::collections::HashMap;
 use std::mem;
 use std::sync::Arc;
-use call_contract::{RegistryInfo, CallContract};
+use call_contract::{RegistryInfo, CallContract, CallOptions};
 use types::ids::BlockId;
 use types::transaction::SignedTransaction;
 use ethabi::FunctionOutputDecoder;
@@ -88,7 +88,7 @@ impl ServiceTransactionChecker {
 
 	fn call_contract<C: CallContract + RegistryInfo>(&self, client: &C, contract_address: Address, sender: Address) -> Result<bool, String> {
 		let (data, decoder) = service_transaction::functions::certified::call(sender);
-		let value = client.call_contract(BlockId::Latest, contract_address, data)?;
+		let value = client.call_contract(BlockId::Latest, CallOptions::new(contract_address, data)).map_err(|e| e.to_string())?;
 		decoder.decode(&value).map_err(|e| e.to_string())
 	}
 }

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -834,6 +834,19 @@ usage! {
 			"--max-round-blocks-to-import=[S]",
 			"Maximal number of blocks to import for each import round.",
 
+		["Reporting configuration"]
+			ARG arg_benign_reporting: (Option<String>) = None, or |c: &Config| c.reporting.as_ref()?.benign_reporting.clone(),
+			"--benign_reporting=[force|call|disable]",
+			"AuRa benign reporting configuration.",
+
+			ARG arg_malicious_reporting: (Option<String>) = None, or |c: &Config| c.reporting.as_ref()?.malicious_reporting.clone(),
+			"--malicious_reporting=[force|call|disable]",
+			"AuRa malicious reporting configuration.",
+
+			ARG arg_report_cache_call_every: (u64) = 100u64, or |c: &Config| c.reporting.as_ref()?.cache_call_every.clone(),
+			"--report_cache_call_every=[BLOCK_NUM]",
+			"AuRa cache call report successfulness for specified amount if blocks.",
+
 		["Internal Options"]
 			FLAG flag_can_restart: (bool) = false, or |_| None,
 			"--can-restart",
@@ -1163,6 +1176,7 @@ struct Config {
 	stratum: Option<Stratum>,
 	whisper: Option<Whisper>,
 	light: Option<Light>,
+	reporting: Option<ReportingConfig>
 }
 
 #[derive(Default, Debug, PartialEq, Deserialize)]
@@ -1445,12 +1459,20 @@ struct Light {
 	on_demand_request_consecutive_failures: Option<usize>,
 }
 
+#[derive(Default, Debug, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReportingConfig {
+	benign_reporting: Option<String>,
+	malicious_reporting: Option<String>,
+	cache_call_every: Option<u64>,
+}
+
 #[cfg(test)]
 mod tests {
 	use super::{
 		Args, ArgsError,
 		Config, Operating, Account, Ui, Network, Ws, Rpc, Ipc, Dapps, Ipfs, Mining, Footprint,
-		Snapshots, Misc, Whisper, SecretStore, Light,
+		Snapshots, Misc, Whisper, SecretStore, Light, ReportingConfig
 	};
 	use toml;
 	use clap::{ErrorKind as ClapErrorKind};
@@ -1997,6 +2019,11 @@ mod tests {
 			arg_log_file: Some("/var/log/parity.log".into()),
 			flag_no_color: false,
 			flag_no_config: false,
+
+			// -- Reporting Options
+			arg_benign_reporting: Some("call".into()),
+			arg_malicious_reporting: Some("force".into()),
+			arg_report_cache_call_every: 100,
 		});
 	}
 
@@ -2221,6 +2248,7 @@ mod tests {
 				pool_size: Some(50),
 			}),
 			stratum: None,
+			reporting: None,
 		});
 	}
 

--- a/parity/cli/tests/config.full.toml
+++ b/parity/cli/tests/config.full.toml
@@ -176,3 +176,8 @@ color = true
 [whisper]
 enabled = false
 pool_size = 20
+
+[reporting]
+benign_reporting = "call"
+malicious_reporting = "force"
+cache_call_every = 100

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -55,6 +55,8 @@ use account::{AccountCmd, NewAccount, ListAccounts, ImportAccounts, ImportFromGe
 use snapshot_cmd::{self, SnapshotCommand};
 use network::{IpFilter};
 
+use validator_reporting_config::ReportingConfig;
+
 const DEFAULT_MAX_PEERS: u16 = 50;
 const DEFAULT_MIN_PEERS: u16 = 25;
 
@@ -418,6 +420,8 @@ impl Configuration {
 				on_demand_request_backoff_max: self.args.arg_on_demand_request_backoff_max,
 				on_demand_request_backoff_rounds_max: self.args.arg_on_demand_request_backoff_rounds_max,
 				on_demand_request_consecutive_failures: self.args.arg_on_demand_request_consecutive_failures,
+				benign_reporting: ReportingConfig::from_str_and_call_every(self.args.arg_benign_reporting, self.args.arg_report_cache_call_every)?,
+				malicious_reporting: ReportingConfig::from_str_and_call_every(self.args.arg_malicious_reporting, self.args.arg_report_cache_call_every)?,
 			};
 			Cmd::Run(run_cmd)
 		};
@@ -1480,6 +1484,8 @@ mod tests {
 			on_demand_request_backoff_max: None,
 			on_demand_request_backoff_rounds_max: None,
 			on_demand_request_consecutive_failures: None,
+			benign_reporting: Default::default(),
+			malicious_reporting: Default::default(),
 		};
 		expected.secretstore_conf.enabled = cfg!(feature = "secretstore");
 		expected.secretstore_conf.http_enabled = cfg!(feature = "secretstore");

--- a/parity/lib.rs
+++ b/parity/lib.rs
@@ -75,6 +75,7 @@ extern crate parity_version;
 extern crate registrar;
 extern crate snapshot;
 extern crate spec;
+extern crate validator_reporting_config;
 extern crate verification;
 
 #[macro_use]

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -21,7 +21,7 @@ use std::thread;
 
 use ansi_term::Colour;
 use bytes::Bytes;
-use call_contract::CallContract;
+use call_contract::{CallContract, CallOptions};
 use client_traits::{BlockInfo, BlockChainClient};
 use ethcore::client::{Client, DatabaseCompactionProfile, VMType};
 use ethcore::miner::{self, stratum, Miner, MinerService, MinerOptions};
@@ -702,7 +702,7 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 					.ok_or_else(|| "Registrar not defined.".into())
 			}
 			fn call_contract(&self, address: Address, data: Bytes) -> Self::Call {
-				Box::new(self.client.call_contract(BlockId::Latest, address, data).into_future())
+				Box::new(self.client.call_contract(BlockId::Latest, CallOptions::new(address, data)).map_err(|e| e.to_string()).into_future())
 			}
 		}
 

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -71,6 +71,7 @@ use rpc_apis;
 use secretstore;
 use signer;
 use db;
+use validator_reporting_config::ReportingConfig;
 
 // how often to take periodic snapshots.
 const SNAPSHOT_PERIOD: u64 = 5000;
@@ -144,6 +145,8 @@ pub struct RunCmd {
 	pub on_demand_request_backoff_max: Option<u64>,
 	pub on_demand_request_backoff_rounds_max: Option<usize>,
 	pub on_demand_request_consecutive_failures: Option<usize>,
+	pub benign_reporting: ReportingConfig,
+	pub malicious_reporting: ReportingConfig,
 }
 
 // node info fetcher for the local store.
@@ -488,6 +491,9 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 	let fetch = fetch::Client::new(FETCH_FULL_NUM_DNS_THREADS).map_err(|e| format!("Error starting fetch client: {:?}", e))?;
 
 	let txpool_size = cmd.miner_options.pool_limits.max_count;
+
+	spec.engine.set_reporting(cmd.benign_reporting, cmd.malicious_reporting);
+
 	// create miner
 	let miner = Arc::new(Miner::new(
 		cmd.miner_options,

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -6,6 +6,7 @@ license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
+call-contract = { package = "ethcore-call-contract", path = "../ethcore/call-contract" }
 client-traits = { path = "../ethcore/client-traits" }
 common-types = { path = "../ethcore/types" }
 ethabi = "8.0"

--- a/updater/src/lib.rs
+++ b/updater/src/lib.rs
@@ -18,6 +18,7 @@
 
 #![warn(missing_docs)]
 
+extern crate call_contract;
 extern crate client_traits;
 extern crate common_types;
 extern crate ethabi;

--- a/updater/src/updater.rs
+++ b/updater/src/updater.rs
@@ -25,6 +25,7 @@ use parking_lot::{Mutex, MutexGuard};
 use rand::{self, Rng};
 use target_info::Target;
 
+use call_contract::CallOptions;
 use common_types::{
 	BlockNumber,
 	ids::BlockId,
@@ -252,7 +253,7 @@ impl OperationsClient for OperationsContractClient {
 
 		let client = self.client.upgrade().ok_or_else(|| "Cannot obtain client")?;
 		let address = client.registry_address("operations".into(), BlockId::Latest).ok_or_else(|| "Cannot get operations contract address")?;
-		let do_call = |data| client.call_contract(BlockId::Latest, address, data).map_err(|e| format!("{:?}", e));
+		let do_call = |data| client.call_contract(BlockId::Latest, CallOptions::new(address, data)).map_err(|e| format!("{:?}", e));
 
 		trace!(target: "updater", "Looking up this_fork for our release: {}/{:?}", CLIENT_ID, this.hash);
 


### PR DESCRIPTION
Continuation of #10602

I opened the new MR since I couldnt reopen the previous MR (probably because I force pushed).

Basically here I implemented CLI flags for selecting a preferred strategy for reports as mentioned [here](https://github.com/paritytech/parity-ethereum/pull/10602#issuecomment-502715665) with caching.

It's possible to use the following CLI flags:
- benign_reporting=[force|call|disable]
- malicious_reporting=[force|call|disable]
- report_cache_call_every=[blk_num]

The frequency in blocks for caching is set for both reporting types. I wasn't sure whether it makes sense to make it also separated, but it will be easy to add if needed.

Please take a look and let me know if I need to improve or update something :)

Closes #10580