### PR TITLE
[ethcore]: make it compile without `test-helpers` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,7 +1040,7 @@ dependencies = [
  "rlp 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp_compress 0.1.0",
  "rlp_derive 0.1.0",
- "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -54,7 +54,7 @@ rand_xorshift = "0.1.1"
 rayon = "1.1"
 rlp = "0.4.0"
 rlp_derive = { path = "../util/rlp-derive" }
-rustc-hex = { version = "1", optional = true }
+rustc-hex = "1"
 serde = "1.0"
 serde_derive = "1.0"
 snapshot = { path = "snapshot" }
@@ -93,6 +93,7 @@ rlp_compress = { path = "../util/rlp-compress" }
 rustc-hex = "1"
 serde_json = "1.0"
 stats = { path = "../util/stats" }
+pod = { path = "pod" }
 tempdir = "0.3"
 trie-standardmap = "0.15.0"
 
@@ -135,7 +136,6 @@ test-helpers = [
     "kvdb-rocksdb",
     "macros",
     "pod",
-    "rustc-hex",
     "tempdir",
     "basic-authority/test-helpers"
  ]

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -54,7 +54,7 @@ rand_xorshift = "0.1.1"
 rayon = "1.1"
 rlp = "0.4.0"
 rlp_derive = { path = "../util/rlp-derive" }
-rustc-hex = "1"
+rustc-hex = "2"
 serde = "1.0"
 serde_derive = "1.0"
 snapshot = { path = "snapshot" }
@@ -90,7 +90,6 @@ macros = { path = "../util/macros" }
 null-engine = { path = "./engines/null-engine" }
 parity-runtime = { path = "../util/runtime" }
 rlp_compress = { path = "../util/rlp-compress" }
-rustc-hex = "1"
 serde_json = "1.0"
 stats = { path = "../util/stats" }
 pod = { path = "pod" }

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -81,6 +81,7 @@ extern crate patricia_trie_ethereum as ethtrie;
 extern crate rand;
 extern crate rayon;
 extern crate rlp;
+extern crate rustc_hex;
 extern crate serde;
 extern crate snapshot;
 extern crate spec;
@@ -126,8 +127,6 @@ extern crate pod;
 extern crate blooms_db;
 #[cfg(any(test, feature = "env_logger"))]
 extern crate env_logger;
-#[cfg(any(test, feature = "test-helpers"))]
-extern crate rustc_hex;
 #[cfg(test)]
 extern crate serde_json;
 #[cfg(any(test, feature = "tempdir"))]

--- a/ethcore/src/tests/client.rs
+++ b/ethcore/src/tests/client.rs
@@ -393,12 +393,12 @@ fn reset_blockchain() {
 #[test]
 fn import_export_hex() {
 	let client = get_test_client_with_blocks(get_good_dummy_block_seq(19));
-	let block_rlps = (15..20)
+	let block_rlps: Vec<String> = (15..20)
 		.filter_map(|num| client.block(BlockId::Number(num)))
 		.map(|header| {
 			header.raw().to_hex()
 		})
-		.collect::<Vec<_>>();
+		.collect();
 
 	let mut out = Vec::new();
 

--- a/ethcore/src/tests/evm.rs
+++ b/ethcore/src/tests/evm.rs
@@ -35,11 +35,11 @@ use ethereum_types::{H256, Address};
 
 evm_test!{test_blockhash_eip210: test_blockhash_eip210_int}
 fn test_blockhash_eip210(factory: Factory) {
-	let get_prev_hash_code = Arc::new("600143034060205260206020f3".from_hex().unwrap()); // this returns previous block hash
+	let get_prev_hash_code = Arc::new("600143034060205260206020f3".from_hex::<Vec<_>>().unwrap()); // this returns previous block hash
 	let get_prev_hash_code_hash = keccak(get_prev_hash_code.as_ref());
 	// This is same as DEFAULT_BLOCKHASH_CONTRACT except for metropolis transition block check removed.
 	let test_blockhash_contract = "73fffffffffffffffffffffffffffffffffffffffe33141561007a57600143036020526000356101006020510755600061010060205107141561005057600035610100610100602051050761010001555b6000620100006020510714156100755760003561010062010000602051050761020001555b61014a565b4360003512151561009057600060405260206040f35b610100600035430312156100b357610100600035075460605260206060f3610149565b62010000600035430312156100d157600061010060003507146100d4565b60005b156100f6576101006101006000350507610100015460805260206080f3610148565b630100000060003543031215610116576000620100006000350714610119565b60005b1561013c57610100620100006000350507610200015460a052602060a0f3610147565b600060c052602060c0f35b5b5b5b5b";
-	let blockhash_contract_code = Arc::new(test_blockhash_contract.from_hex().unwrap());
+	let blockhash_contract_code = Arc::new(test_blockhash_contract.from_hex::<Vec<_>>().unwrap());
 	let blockhash_contract_code_hash = keccak(blockhash_contract_code.as_ref());
 	let machine = new_eip210_test_machine();
 	let mut env_info = EnvInfo::default();

--- a/ethcore/types/src/data_format.rs
+++ b/ethcore/types/src/data_format.rs
@@ -20,24 +20,26 @@ use std::str::FromStr;
 /// Format for importing/exporting blocks
 #[derive(Debug, PartialEq)]
 pub enum DataFormat {
-    Hex,
-    Binary,
+	/// Hexadecimal format
+	Hex,
+	/// Binary format
+	Binary,
 }
 
 impl Default for DataFormat {
-    fn default() -> Self {
-        DataFormat::Binary
-    }
+	fn default() -> Self {
+		DataFormat::Binary
+	}
 }
 
 impl FromStr for DataFormat {
-    type Err = String;
+	type Err = String;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "binary" | "bin" => Ok(DataFormat::Binary),
-            "hex" => Ok(DataFormat::Hex),
-            x => Err(format!("Invalid format: {}", x))
-        }
-    }
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		match s {
+			"binary" | "bin" => Ok(DataFormat::Binary),
+			"hex" => Ok(DataFormat::Hex),
+			x => Err(format!("Invalid format: {}", x))
+		}
+	}
 }


### PR DESCRIPTION
After [this change](https://github.com/paritytech/parity-ethereum/blob/master/ethcore/src/client/client.rs#L2686) `rustc-hex` is not an optional dependency anymore which this PR fixes

As a bonus, I added docs to [DataFormat](https://github.com/paritytech/parity-ethereum/blob/master/ethcore/types/src/data_format.rs) and replaced space indentation.
