### PR TITLE
[build]: remove `test-helper feat` from build

### DIFF
--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -97,7 +97,11 @@ parity = ["work-notify", "price-info", "stratum", "macros"]
 # but might be omitted for other dependent crates.
 work-notify = ["ethcore-miner/work-notify"]
 price-info = ["ethcore-miner/price-info"]
-stratum = ["ethcore-stratum"]
+stratum = [
+	"ethash",
+	"ethcore-stratum"
+]
+
 
 # Disables seal verification for mined blocks.
 # This allows you to submit any seal via RPC to test and benchmark
@@ -122,7 +126,6 @@ test-heavy = []
 # note[dvdplm]: "basic-authority/test-helpers" is needed so that `generate_dummy_client_with_spec` works
 test-helpers = [
     "blooms-db",
-    "ethash",
     "ethjson",
     "ethkey",
     "kvdb-memorydb",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -39,7 +39,7 @@ client-traits = { path = "../ethcore/client-traits" }
 common-types = { path = "../ethcore/types" }
 engine = { path = "../ethcore/engine" }
 ethash = { path = "../ethash" }
-ethcore = { path = "../ethcore", features = ["test-helpers"] }
+ethcore = { path = "../ethcore" }
 ethcore-accounts = { path = "../accounts", optional = true }
 ethcore-light = { path = "../ethcore/light" }
 ethcore-logger = { path = "../parity/logger" }


### PR DESCRIPTION
We have unintentionally built parity with the feature `test-helpers` which should only be enabled for running tests which this PR fixes.

Could reduce the binary size but I don't think it would be much...