### PR TITLE
[evmbin] fix time formatting

### DIFF
--- a/evmbin/src/display/mod.rs
+++ b/evmbin/src/display/mod.rs
@@ -24,7 +24,7 @@ pub mod simple;
 
 /// Formats duration into human readable format.
 pub fn format_time(time: &Duration) -> String {
-	format!("{}.{:.9}s", time.as_secs(), time.subsec_nanos())
+	format!("{}.{:09}s", time.as_secs(), time.subsec_nanos())
 }
 
 /// Formats the time as microseconds.


### PR DESCRIPTION
The timing information was displayed incorrectly due to right padding.
https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=e6b3607859f46f1304a0159804c45d37

Thanks @holiman for spotting this. 