### PR TITLE
[sync]: rust 2018

### DIFF
--- a/ethcore/sync/Cargo.toml
+++ b/ethcore/sync/Cargo.toml
@@ -4,26 +4,27 @@ name = "ethcore-sync"
 version = "1.12.0"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [lib]
 
 [dependencies]
 client-traits = { path = "../client-traits" }
-common-types = { path = "../types" }
+types = { package = "common-types", path = "../types" }
 enum_primitive = "0.1.1"
 ethcore-io = { path = "../../util/io" }
-ethcore-light = { path = "../light" }
-ethcore-network = { path = "../../util/network" }
-ethcore-network-devp2p = { path = "../../util/network-devp2p" }
+light = { package = "ethcore-light", path = "../light" }
+network = { package = "ethcore-network", path = "../../util/network" }
+devp2p = { package = "ethcore-network-devp2p", path = "../../util/network-devp2p" }
 ethcore-private-tx = { path = "../private-tx" }
 ethereum-types = "0.6.0"
 ethkey = { path = "../../accounts/ethkey" }
 fastmap = { path = "../../util/fastmap" }
 futures = "0.1"
-keccak-hash = "0.2.0"
+hash = { package = "keccak-hash", version = "0.2.0"}
 log = "0.4"
 macros = { path = "../../util/macros" }
-parity-bytes = "0.1"
+bytes = { package = "parity-bytes", version = "0.1" }
 parity-runtime = { path = "../../util/runtime" }
 parity-util-mem = "0.2.0"
 parking_lot = "0.8"

--- a/ethcore/sync/Cargo.toml
+++ b/ethcore/sync/Cargo.toml
@@ -20,7 +20,7 @@ ethereum-types = "0.6.0"
 ethkey = { path = "../../accounts/ethkey" }
 fastmap = { path = "../../util/fastmap" }
 futures = "0.1"
-hash = { package = "keccak-hash", version = "0.2.0"}
+keccak-hash = "0.2.0"
 light = { package = "ethcore-light", path = "../light" }
 log = "0.4"
 macros = { path = "../../util/macros" }

--- a/ethcore/sync/Cargo.toml
+++ b/ethcore/sync/Cargo.toml
@@ -9,22 +9,22 @@ edition = "2018"
 [lib]
 
 [dependencies]
+bytes = { package = "parity-bytes", version = "0.1" }
 client-traits = { path = "../client-traits" }
-types = { package = "common-types", path = "../types" }
+common-types = { path = "../types" }
+devp2p = { package = "ethcore-network-devp2p", path = "../../util/network-devp2p" }
 enum_primitive = "0.1.1"
 ethcore-io = { path = "../../util/io" }
-light = { package = "ethcore-light", path = "../light" }
-network = { package = "ethcore-network", path = "../../util/network" }
-devp2p = { package = "ethcore-network-devp2p", path = "../../util/network-devp2p" }
 ethcore-private-tx = { path = "../private-tx" }
 ethereum-types = "0.6.0"
 ethkey = { path = "../../accounts/ethkey" }
 fastmap = { path = "../../util/fastmap" }
 futures = "0.1"
 hash = { package = "keccak-hash", version = "0.2.0"}
+light = { package = "ethcore-light", path = "../light" }
 log = "0.4"
 macros = { path = "../../util/macros" }
-bytes = { package = "parity-bytes", version = "0.1" }
+network = { package = "ethcore-network", path = "../../util/network" }
 parity-runtime = { path = "../../util/runtime" }
 parity-util-mem = "0.2.0"
 parking_lot = "0.8"

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -60,7 +60,7 @@ use snapshot::SnapshotService;
 use parking_lot::{RwLock, Mutex};
 use parity_runtime::Executor;
 use trace_time::trace_time;
-use types::{
+use common_types::{
 	BlockNumber,
 	chain_notify::{NewBlocks, ChainMessageType},
 	pruning_info::PruningInfo,
@@ -654,14 +654,14 @@ impl ChainNotify for EthSync {
 struct TxRelay(Arc<dyn BlockChainClient>);
 
 impl LightHandler for TxRelay {
-	fn on_transactions(&self, ctx: &dyn EventContext, relay: &[::types::transaction::UnverifiedTransaction]) {
+	fn on_transactions(&self, ctx: &dyn EventContext, relay: &[UnverifiedTransaction]) {
 		trace!(target: "pip", "Relaying {} transactions from peer {}", relay.len(), ctx.peer());
-		self.0.queue_transactions(relay.iter().map(|tx| ::rlp::encode(tx)).collect(), ctx.peer())
+		self.0.queue_transactions(relay.iter().map(|tx| rlp::encode(tx)).collect(), ctx.peer())
 	}
 }
 
 /// Trait for managing network
-pub trait ManageNetwork : Send + Sync {
+pub trait ManageNetwork: Send + Sync {
 	/// Set to allow unreserved peers to connect
 	fn accept_unreserved_peers(&self);
 	/// Set to deny unreserved peers to connect
@@ -953,7 +953,7 @@ impl LightSync {
 
 }
 
-impl ::std::ops::Deref for LightSync {
+impl std::ops::Deref for LightSync {
 	type Target = dyn (light_sync::SyncInfo);
 
 	fn deref(&self) -> &Self::Target { &*self.sync }
@@ -961,7 +961,7 @@ impl ::std::ops::Deref for LightSync {
 
 
 impl LightNetworkDispatcher for LightSync {
-	fn with_context<F, T>(&self, f: F) -> Option<T> where F: FnOnce(&dyn (::light::net::BasicContext)) -> T {
+	fn with_context<F, T>(&self, f: F) -> Option<T> where F: FnOnce(&dyn (light::net::BasicContext)) -> T {
 		self.network.with_context_eval(
 			self.subprotocol_name,
 			move |ctx| self.proto.with_context(&ctx, f),

--- a/ethcore/sync/src/block_sync.rs
+++ b/ethcore/sync/src/block_sync.rs
@@ -648,7 +648,7 @@ mod tests {
 
 	use ethcore::test_helpers::TestBlockChainClient;
 	use ethkey::{Random, Generator};
-	use hash::keccak;
+	use keccak_hash::keccak;
 	use parking_lot::RwLock;
 	use rlp::{encode_list, RlpStream};
 	use triehash_ethereum::ordered_trie_root;

--- a/ethcore/sync/src/block_sync.rs
+++ b/ethcore/sync/src/block_sync.rs
@@ -20,20 +20,24 @@
 
 use std::collections::{HashSet, VecDeque};
 use std::cmp;
-use parity_util_mem::MallocSizeOf;
+
+use crate::{
+	blocks::{BlockCollection, SyncBody, SyncHeader},
+	chain::BlockSet,
+	sync_io::SyncIo
+};
+
 use ethereum_types::H256;
-use rlp::{self, Rlp};
+use log::{debug, trace};
+use network::{client_version::ClientCapabilities, PeerId};
+use rlp::Rlp;
+use parity_util_mem::MallocSizeOf;
 use types::{
 	BlockNumber,
 	block_status::BlockStatus,
 	ids::BlockId,
 	errors::{EthcoreError, BlockError, ImportError},
 };
-use sync_io::SyncIo;
-use blocks::{BlockCollection, SyncBody, SyncHeader};
-use chain::BlockSet;
-use network::PeerId;
-use network::client_version::ClientCapabilities;
 
 const MAX_HEADERS_TO_REQUEST: usize = 128;
 const MAX_BODIES_TO_REQUEST_LARGE: usize = 128;
@@ -635,18 +639,23 @@ fn all_expected<A, B, F>(values: &[A], expected_values: &[B], is_expected: F) ->
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+	use super::{
+		BlockSet, BlockDownloader, BlockDownloaderImportError, DownloadAction, SyncIo, H256,
+		MAX_HEADERS_TO_REQUEST, MAX_USELESS_HEADERS_PER_ROUND, SUBCHAIN_SIZE, State, Rlp, VecDeque
+	};
+
+	use crate::tests::{helpers::TestIo, snapshot::TestSnapshotService};
+
 	use ethcore::test_helpers::TestBlockChainClient;
-	use spec;
-	use ethkey::{Generator, Random};
+	use ethkey::{Random, Generator};
 	use hash::keccak;
 	use parking_lot::RwLock;
 	use rlp::{encode_list, RlpStream};
-	use tests::helpers::TestIo;
-	use tests::snapshot::TestSnapshotService;
-	use types::transaction::{Transaction, SignedTransaction};
 	use triehash_ethereum::ordered_trie_root;
-	use types::header::Header as BlockHeader;
+	use types::{
+		transaction::{Transaction, SignedTransaction},
+		header::Header as BlockHeader,
+	};
 
 	fn dummy_header(number: u64, parent_hash: H256) -> BlockHeader {
 		let mut header = BlockHeader::new();
@@ -680,7 +689,7 @@ mod tests {
 
 	#[test]
 	fn import_headers_in_chain_head_state() {
-		::env_logger::try_init().ok();
+		env_logger::try_init().ok();
 
 		let spec = spec::new_test();
 		let genesis_hash = spec.genesis_header().hash();
@@ -752,7 +761,7 @@ mod tests {
 
 	#[test]
 	fn import_headers_in_blocks_state() {
-		::env_logger::try_init().ok();
+		env_logger::try_init().ok();
 
 		let mut chain = TestBlockChainClient::new();
 		let snapshot_service = TestSnapshotService::new();
@@ -802,7 +811,7 @@ mod tests {
 
 	#[test]
 	fn import_bodies() {
-		::env_logger::try_init().ok();
+		env_logger::try_init().ok();
 
 		let mut chain = TestBlockChainClient::new();
 		let snapshot_service = TestSnapshotService::new();
@@ -870,7 +879,7 @@ mod tests {
 
 	#[test]
 	fn import_receipts() {
-		::env_logger::try_init().ok();
+		env_logger::try_init().ok();
 
 		let mut chain = TestBlockChainClient::new();
 		let snapshot_service = TestSnapshotService::new();
@@ -929,7 +938,7 @@ mod tests {
 
 	#[test]
 	fn reset_after_multiple_sets_of_useless_headers() {
-		::env_logger::try_init().ok();
+		env_logger::try_init().ok();
 
 		let spec = spec::new_test();
 		let genesis_hash = spec.genesis_header().hash();
@@ -969,7 +978,7 @@ mod tests {
 
 	#[test]
 	fn dont_reset_after_multiple_sets_of_useless_headers_for_chain_head() {
-		::env_logger::try_init().ok();
+		env_logger::try_init().ok();
 
 		let spec = spec::new_test();
 		let genesis_hash = spec.genesis_header().hash();

--- a/ethcore/sync/src/block_sync.rs
+++ b/ethcore/sync/src/block_sync.rs
@@ -32,7 +32,7 @@ use log::{debug, trace};
 use network::{client_version::ClientCapabilities, PeerId};
 use rlp::Rlp;
 use parity_util_mem::MallocSizeOf;
-use types::{
+use common_types::{
 	BlockNumber,
 	block_status::BlockStatus,
 	ids::BlockId,
@@ -652,7 +652,7 @@ mod tests {
 	use parking_lot::RwLock;
 	use rlp::{encode_list, RlpStream};
 	use triehash_ethereum::ordered_trie_root;
-	use types::{
+	use common_types::{
 		transaction::{Transaction, SignedTransaction},
 		header::Header as BlockHeader,
 	};

--- a/ethcore/sync/src/blocks.rs
+++ b/ethcore/sync/src/blocks.rs
@@ -15,13 +15,14 @@
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::{HashSet, HashMap, hash_map};
-use hash::{keccak, KECCAK_NULL_RLP, KECCAK_EMPTY_LIST_RLP};
-use parity_util_mem::MallocSizeOf;
-use ethereum_types::H256;
-use triehash_ethereum::ordered_trie_root;
+
 use bytes::Bytes;
+use ethereum_types::H256;
+use hash::{keccak, KECCAK_NULL_RLP, KECCAK_EMPTY_LIST_RLP};
+use log::{trace, warn};
+use parity_util_mem::MallocSizeOf;
 use rlp::{Rlp, RlpStream, DecoderError};
-use network;
+use triehash_ethereum::ordered_trie_root;
 use types::{
 	transaction::UnverifiedTransaction,
 	header::Header as BlockHeader,
@@ -40,7 +41,7 @@ pub struct SyncHeader {
 impl SyncHeader {
 	pub fn from_rlp(bytes: Bytes) -> Result<Self, DecoderError> {
 		let result = SyncHeader {
-			header: ::rlp::decode(&bytes)?,
+			header: rlp::decode(&bytes)?,
 			bytes,
 		};
 
@@ -151,18 +152,7 @@ pub struct BlockCollection {
 impl BlockCollection {
 	/// Create a new instance.
 	pub fn new(download_receipts: bool) -> BlockCollection {
-		BlockCollection {
-			need_receipts: download_receipts,
-			blocks: HashMap::new(),
-			header_ids: HashMap::new(),
-			receipt_ids: HashMap::new(),
-			heads: Vec::new(),
-			parents: HashMap::new(),
-			head: None,
-			downloading_headers: HashSet::new(),
-			downloading_bodies: HashSet::new(),
-			downloading_receipts: HashSet::new(),
-		}
+		Self { need_receipts: download_receipts, ..Default::default() }
 	}
 
 	/// Clear everything.

--- a/ethcore/sync/src/blocks.rs
+++ b/ethcore/sync/src/blocks.rs
@@ -18,7 +18,7 @@ use std::collections::{HashSet, HashMap, hash_map};
 
 use bytes::Bytes;
 use ethereum_types::H256;
-use hash::{keccak, KECCAK_NULL_RLP, KECCAK_EMPTY_LIST_RLP};
+use keccak_hash::{keccak, KECCAK_NULL_RLP, KECCAK_EMPTY_LIST_RLP};
 use log::{trace, warn};
 use parity_util_mem::MallocSizeOf;
 use rlp::{Rlp, RlpStream, DecoderError};

--- a/ethcore/sync/src/blocks.rs
+++ b/ethcore/sync/src/blocks.rs
@@ -23,7 +23,7 @@ use log::{trace, warn};
 use parity_util_mem::MallocSizeOf;
 use rlp::{Rlp, RlpStream, DecoderError};
 use triehash_ethereum::ordered_trie_root;
-use types::{
+use common_types::{
 	transaction::UnverifiedTransaction,
 	header::Header as BlockHeader,
 	verification::Unverified,
@@ -535,7 +535,7 @@ mod test {
 	use super::{BlockCollection, SyncHeader};
 	use client_traits::BlockChainClient;
 	use ethcore::test_helpers::{TestBlockChainClient, EachBlockWith};
-	use types::{
+	use common_types::{
 		ids::BlockId,
 		BlockNumber,
 		verification::Unverified,

--- a/ethcore/sync/src/blocks.rs
+++ b/ethcore/sync/src/blocks.rs
@@ -540,7 +540,7 @@ mod test {
 		BlockNumber,
 		verification::Unverified,
 	};
-	use rlp::*;
+	use rlp::Rlp;
 
 	fn is_empty(bc: &BlockCollection) -> bool {
 		bc.heads.is_empty() &&

--- a/ethcore/sync/src/chain/handler.rs
+++ b/ethcore/sync/src/chain/handler.rs
@@ -14,21 +14,37 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use api::WARP_SYNC_PROTOCOL_ID;
-use block_sync::{BlockDownloaderImportError as DownloaderImportError, DownloadAction};
+use std::time::Instant;
+use std::{mem, cmp};
+
+use crate::{
+	snapshot_sync::ChunkType,
+	sync_io::SyncIo,
+	api::WARP_SYNC_PROTOCOL_ID,
+	block_sync::{BlockDownloaderImportError as DownloaderImportError, DownloadAction},
+	chain::{
+		sync_packet::{
+			PacketInfo,
+			SyncPacket::{
+				self, BlockBodiesPacket, BlockHeadersPacket, NewBlockHashesPacket, NewBlockPacket,
+				PrivateStatePacket, PrivateTransactionPacket, ReceiptsPacket, SignedPrivateTransactionPacket,
+				SnapshotDataPacket, SnapshotManifestPacket, StatusPacket,
+			}
+		},
+		BlockSet, ChainSync, ForkConfirmation, PacketDecodeError, PeerAsking, PeerInfo, SyncRequester,
+		SyncState, ETH_PROTOCOL_VERSION_62, ETH_PROTOCOL_VERSION_63, MAX_NEW_BLOCK_AGE, MAX_NEW_HASHES,
+		PAR_PROTOCOL_VERSION_1, PAR_PROTOCOL_VERSION_3, PAR_PROTOCOL_VERSION_4,
+	}
+};
+
 use bytes::Bytes;
 use enum_primitive::FromPrimitive;
 use ethereum_types::{H256, U256};
 use hash::keccak;
 use network::PeerId;
 use network::client_version::ClientVersion;
+use log::{debug, trace, error};
 use rlp::Rlp;
-use crate::{
-	snapshot_sync::ChunkType,
-	sync_io::SyncIo,
-};
-use std::time::Instant;
-use std::{mem, cmp};
 use types::{
 	BlockNumber,
 	block_status::BlockStatus,
@@ -38,38 +54,6 @@ use types::{
 	snapshot::{ManifestData, RestorationStatus},
 };
 
-use super::sync_packet::{PacketInfo, SyncPacket};
-use super::sync_packet::SyncPacket::{
-	StatusPacket,
-	NewBlockHashesPacket,
-	BlockHeadersPacket,
-	BlockBodiesPacket,
-	NewBlockPacket,
-	ReceiptsPacket,
-	SnapshotManifestPacket,
-	SnapshotDataPacket,
-	PrivateTransactionPacket,
-	SignedPrivateTransactionPacket,
-	PrivateStatePacket,
-};
-
-use super::{
-	BlockSet,
-	ChainSync,
-	ForkConfirmation,
-	PacketDecodeError,
-	PeerAsking,
-	PeerInfo,
-	SyncRequester,
-	SyncState,
-	ETH_PROTOCOL_VERSION_62,
-	ETH_PROTOCOL_VERSION_63,
-	MAX_NEW_BLOCK_AGE,
-	MAX_NEW_HASHES,
-	PAR_PROTOCOL_VERSION_1,
-	PAR_PROTOCOL_VERSION_3,
-	PAR_PROTOCOL_VERSION_4,
-};
 
 /// The Chain Sync Handler: handles responses from peers
 pub struct SyncHandler;
@@ -800,21 +784,19 @@ impl SyncHandler {
 
 #[cfg(test)]
 mod tests {
+	use std::collections::VecDeque;
+
+	use super::{
+		super::tests::{dummy_sync_with_peer, get_dummy_block, get_dummy_blocks, get_dummy_hashes},
+		SyncHandler
+	};
+
+	use crate::tests::{helpers::TestIo, snapshot::TestSnapshotService};
+
 	use client_traits::ChainInfo;
 	use ethcore::test_helpers::{EachBlockWith, TestBlockChainClient};
 	use parking_lot::RwLock;
 	use rlp::Rlp;
-	use std::collections::VecDeque;
-	use tests::helpers::TestIo;
-	use tests::snapshot::TestSnapshotService;
-
-	use super::*;
-	use super::super::tests::{
-		dummy_sync_with_peer,
-		get_dummy_block,
-		get_dummy_blocks,
-		get_dummy_hashes,
-	};
 
 	#[test]
 	fn handles_peer_new_hashes() {

--- a/ethcore/sync/src/chain/handler.rs
+++ b/ethcore/sync/src/chain/handler.rs
@@ -45,7 +45,7 @@ use network::PeerId;
 use network::client_version::ClientVersion;
 use log::{debug, trace, error};
 use rlp::Rlp;
-use types::{
+use common_types::{
 	BlockNumber,
 	block_status::BlockStatus,
 	ids::BlockId,

--- a/ethcore/sync/src/chain/handler.rs
+++ b/ethcore/sync/src/chain/handler.rs
@@ -40,7 +40,7 @@ use crate::{
 use bytes::Bytes;
 use enum_primitive::FromPrimitive;
 use ethereum_types::{H256, U256};
-use hash::keccak;
+use keccak_hash::keccak;
 use network::PeerId;
 use network::client_version::ClientVersion;
 use log::{debug, trace, error};

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -114,7 +114,7 @@ use client_traits::BlockChainClient;
 use ethereum_types::{H256, U256};
 use fastmap::{H256FastMap, H256FastSet};
 use futures::sync::mpsc as futures_mpsc;
-use hash::keccak;
+use keccak_hash::keccak;
 use log::{error, trace, debug};
 use network::client_version::ClientVersion;
 use network::{self, PeerId, PacketId};

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -122,7 +122,7 @@ use parity_util_mem::{MallocSizeOfExt, malloc_size_of_is_0};
 use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
 use rand::{Rng, seq::SliceRandom};
 use rlp::{RlpStream, DecoderError};
-use types::{
+use common_types::{
 	BlockNumber,
 	ids::BlockId,
 	transaction::UnverifiedTransaction,
@@ -1428,7 +1428,7 @@ pub mod tests {
 	use network::PeerId;
 	use parking_lot::RwLock;
 	use rlp::{Rlp, RlpStream};
-	use types::header::Header;
+	use common_types::header::Header;
 
 	pub fn get_dummy_block(order: u32, parent_hash: H256) -> Bytes {
 		let mut header = Header::new();

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -88,37 +88,40 @@
 //! All other messages are ignored.
 
 mod handler;
-pub mod sync_packet;
 mod propagator;
 mod requester;
 mod supplier;
+
+pub mod sync_packet;
 
 use std::sync::{Arc, mpsc};
 use std::collections::{HashSet, HashMap, BTreeMap};
 use std::cmp;
 use std::time::{Duration, Instant};
-use hash::keccak;
-use parity_util_mem::MallocSizeOfExt;
-use futures::sync::mpsc as futures_mpsc;
-use api::Notification;
-use ethereum_types::{H256, U256};
-use fastmap::{H256FastMap, H256FastSet};
-use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
-use bytes::Bytes;
-use rlp::{RlpStream, DecoderError};
-use network::{self, PeerId, PacketId};
-use network::client_version::ClientVersion;
-use client_traits::BlockChainClient;
+
 use crate::{
+	EthProtocolInfo as PeerInfoDigest, PriorityTask, SyncConfig, WarpSync, WARP_SYNC_PROTOCOL_ID,
+	api::{Notification, PRIORITY_TIMER_INTERVAL},
+	block_sync::{BlockDownloader, DownloadAction},
 	sync_io::SyncIo,
 	snapshot_sync::Snapshot,
+	transactions_stats::{TransactionsStats, Stats as TransactionStats},
+	private_tx::PrivateTxHandler,
 };
-use super::{WarpSync, SyncConfig};
-use block_sync::{BlockDownloader, DownloadAction};
+
+use bytes::Bytes;
+use client_traits::BlockChainClient;
+use ethereum_types::{H256, U256};
+use fastmap::{H256FastMap, H256FastSet};
+use futures::sync::mpsc as futures_mpsc;
+use hash::keccak;
+use log::{error, trace, debug};
+use network::client_version::ClientVersion;
+use network::{self, PeerId, PacketId};
+use parity_util_mem::{MallocSizeOfExt, malloc_size_of_is_0};
+use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
 use rand::{Rng, seq::SliceRandom};
-use api::{EthProtocolInfo as PeerInfoDigest, WARP_SYNC_PROTOCOL_ID, PriorityTask};
-use private_tx::PrivateTxHandler;
-use transactions_stats::{TransactionsStats, Stats as TransactionStats};
+use rlp::{RlpStream, DecoderError};
 use types::{
 	BlockNumber,
 	ids::BlockId,
@@ -434,7 +437,7 @@ impl ChainSyncApi {
 	}
 
 	/// Returns transactions propagation statistics
-	pub fn transactions_stats(&self) -> BTreeMap<H256, ::TransactionStats> {
+	pub fn transactions_stats(&self) -> BTreeMap<H256, crate::api::TransactionStats> {
 		self.sync.read().transactions_stats()
 			.iter()
 			.map(|(hash, stats)| (*hash, stats.into()))
@@ -463,7 +466,7 @@ impl ChainSyncApi {
 		}
 
 		// deadline to get the task from the queue
-		let deadline = Instant::now() + ::api::PRIORITY_TIMER_INTERVAL;
+		let deadline = Instant::now() + PRIORITY_TIMER_INTERVAL;
 		let mut work = || {
 			let task = {
 				let tasks = self.priority_tasks.try_lock_until(deadline)?;
@@ -1405,21 +1408,26 @@ impl ChainSync {
 
 #[cfg(test)]
 pub mod tests {
-	use std::collections::{VecDeque};
-	use ethkey;
-	use network::PeerId;
-	use tests::helpers::TestIo;
-	use tests::snapshot::TestSnapshotService;
-	use ethereum_types::{H256, U256, Address};
-	use parking_lot::RwLock;
+	use std::{collections::VecDeque, time::Instant};
+
+	use super::{
+		BlockId, BlockQueueInfo, ChainSync, ClientVersion, PeerInfo, PeerAsking,
+		SyncHandler, SyncState, SyncStatus, SyncPropagator, UnverifiedTransaction
+	};
+
+	use crate::{
+		api::SyncConfig,
+		tests::{helpers::TestIo, snapshot::TestSnapshotService},
+	};
+
 	use bytes::Bytes;
-	use rlp::{Rlp, RlpStream};
-	use super::*;
-	use ::SyncConfig;
-	use super::{PeerInfo, PeerAsking};
-	use ethcore::test_helpers::{EachBlockWith, TestBlockChainClient};
 	use client_traits::{BlockInfo, BlockChainClient, ChainInfo};
+	use ethcore::test_helpers::{EachBlockWith, TestBlockChainClient};
 	use ethcore::miner::{MinerService, PendingOrdering};
+	use ethereum_types::{H256, U256, Address};
+	use network::PeerId;
+	use parking_lot::RwLock;
+	use rlp::{Rlp, RlpStream};
 	use types::header::Header;
 
 	pub fn get_dummy_block(order: u32, parent_hash: H256) -> Bytes {

--- a/ethcore/sync/src/chain/propagator.rs
+++ b/ethcore/sync/src/chain/propagator.rs
@@ -27,9 +27,7 @@ use network::client_version::ClientCapabilities;
 use network::PeerId;
 use rand::RngCore;
 use rlp::{Encodable, RlpStream};
-use types::transaction::SignedTransaction;
-use types::BlockNumber;
-use types::blockchain_info::BlockChainInfo;
+use common_types::{blockchain_info::BlockChainInfo, transaction::SignedTransaction, BlockNumber};
 
 use super::sync_packet::SyncPacket::{
 	NewBlockHashesPacket,
@@ -355,7 +353,7 @@ mod tests {
 	use network::client_version::ClientVersion;
 	use parking_lot::RwLock;
 	use rlp::Rlp;
-	use types::{ids::BlockId, transaction::UnverifiedTransaction};
+	use common_types::{ids::BlockId, transaction::UnverifiedTransaction};
 
 	#[test]
 	fn sends_new_hashes_to_lagging_peer() {

--- a/ethcore/sync/src/chain/propagator.rs
+++ b/ethcore/sync/src/chain/propagator.rs
@@ -17,19 +17,20 @@
 use std::cmp;
 use std::collections::HashSet;
 
+use crate::{sync_io::SyncIo, chain::sync_packet::SyncPacket};
+
 use bytes::Bytes;
 use ethereum_types::H256;
 use fastmap::H256FastSet;
+use log::{debug, error, trace};
 use network::client_version::ClientCapabilities;
 use network::PeerId;
 use rand::RngCore;
 use rlp::{Encodable, RlpStream};
-use sync_io::SyncIo;
 use types::transaction::SignedTransaction;
 use types::BlockNumber;
 use types::blockchain_info::BlockChainInfo;
 
-use super::sync_packet::SyncPacket;
 use super::sync_packet::SyncPacket::{
 	NewBlockHashesPacket,
 	TransactionsPacket,
@@ -335,17 +336,26 @@ impl SyncPropagator {
 
 #[cfg(test)]
 mod tests {
-	use client_traits::{BlockInfo, ChainInfo};
-	use ethcore::test_helpers::{EachBlockWith, TestBlockChainClient};
-	use parking_lot::RwLock;
-	use rlp::Rlp;
-	use std::collections::VecDeque;
-	use tests::{
-		helpers::TestIo,
-		snapshot::TestSnapshotService,
+	use std::{collections::VecDeque, time::Instant};
+
+	use crate::{
+		api::SyncConfig,
+		chain::{ChainSync, ForkConfirmation, PeerAsking, PeerInfo},
+		tests::{helpers::TestIo, snapshot::TestSnapshotService},
 	};
 
-	use super::{*, super::{*, tests::*}};
+	use super::{
+		super::tests::{dummy_sync_with_peer, insert_dummy_peer},
+		SyncPropagator,
+	};
+
+	use client_traits::{BlockChainClient, BlockInfo, ChainInfo};
+	use ethcore::test_helpers::{EachBlockWith, TestBlockChainClient};
+	use ethereum_types::{H256, U256};
+	use network::client_version::ClientVersion;
+	use parking_lot::RwLock;
+	use rlp::Rlp;
+	use types::{ids::BlockId, transaction::UnverifiedTransaction};
 
 	#[test]
 	fn sends_new_hashes_to_lagging_peer() {

--- a/ethcore/sync/src/chain/requester.rs
+++ b/ethcore/sync/src/chain/requester.rs
@@ -26,7 +26,7 @@ use ethereum_types::H256;
 use log::{debug, trace, warn};
 use network::{PeerId};
 use rlp::RlpStream;
-use types::BlockNumber;
+use common_types::BlockNumber;
 
 use super::sync_packet::SyncPacket;
 use super::sync_packet::SyncPacket::{

--- a/ethcore/sync/src/chain/requester.rs
+++ b/ethcore/sync/src/chain/requester.rs
@@ -14,13 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use block_sync::BlockRequest;
+use std::time::Instant;
+
+use crate::{
+	block_sync::BlockRequest,
+	sync_io::SyncIo
+};
+
 use bytes::Bytes;
 use ethereum_types::H256;
+use log::{debug, trace, warn};
 use network::{PeerId};
 use rlp::RlpStream;
-use std::time::Instant;
-use sync_io::SyncIo;
 use types::BlockNumber;
 
 use super::sync_packet::SyncPacket;

--- a/ethcore/sync/src/chain/supplier.rs
+++ b/ethcore/sync/src/chain/supplier.rs
@@ -400,6 +400,7 @@ mod test {
 
 	use crate::{
 		blocks::SyncHeader,
+		chain::RlpResponseResult,
 		tests::{helpers::TestIo, snapshot::TestSnapshotService}
 	};
 
@@ -436,7 +437,8 @@ mod test {
 			rlp.append(&if reverse {1u32} else {0u32});
 			rlp.out()
 		}
-		fn to_header_vec(rlp: crate::chain::RlpResponseResult) -> Vec<SyncHeader> {
+
+		fn to_header_vec(rlp: RlpResponseResult) -> Vec<SyncHeader> {
 			Rlp::new(&rlp.unwrap().unwrap().1.out()).iter().map(|r| SyncHeader::from_rlp(r.as_raw().to_vec()).unwrap()).collect()
 		}
 

--- a/ethcore/sync/src/chain/supplier.rs
+++ b/ethcore/sync/src/chain/supplier.rs
@@ -16,6 +16,8 @@
 
 use std::cmp;
 
+use crate::sync_io::SyncIo;
+
 use bytes::Bytes;
 use enum_primitive::FromPrimitive;
 use ethereum_types::H256;
@@ -23,10 +25,7 @@ use log::{debug, trace};
 use network::{self, PeerId};
 use parking_lot::RwLock;
 use rlp::{Rlp, RlpStream};
-use types::BlockNumber;
-use types::ids::BlockId;
-
-use crate::sync_io::SyncIo;
+use common_types::{ids::BlockId, BlockNumber};
 
 use super::sync_packet::{PacketInfo, SyncPacket};
 use super::sync_packet::SyncPacket::{

--- a/ethcore/sync/src/chain/supplier.rs
+++ b/ethcore/sync/src/chain/supplier.rs
@@ -14,17 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::cmp;
+
 use bytes::Bytes;
 use enum_primitive::FromPrimitive;
 use ethereum_types::H256;
+use log::{debug, trace};
 use network::{self, PeerId};
 use parking_lot::RwLock;
 use rlp::{Rlp, RlpStream};
-use std::cmp;
 use types::BlockNumber;
 use types::ids::BlockId;
 
-use sync_io::SyncIo;
+use crate::sync_io::SyncIo;
 
 use super::sync_packet::{PacketInfo, SyncPacket};
 use super::sync_packet::SyncPacket::{
@@ -394,18 +396,26 @@ impl SyncSupplier {
 
 #[cfg(test)]
 mod test {
-	use std::collections::VecDeque;
-	use tests::helpers::TestIo;
-	use tests::snapshot::TestSnapshotService;
-	use ethereum_types::H256;
-	use parking_lot::RwLock;
+	use std::{collections::VecDeque, str::FromStr};
+
+	use crate::{
+		blocks::SyncHeader,
+		tests::{helpers::TestIo, snapshot::TestSnapshotService}
+	};
+
+	use super::{
+		SyncPacket::{GetReceiptsPacket, GetNodeDataPacket},
+		BlockNumber, BlockId, SyncSupplier, PacketInfo
+	};
+
+	use super::super::tests::dummy_sync_with_peer;
+
 	use bytes::Bytes;
-	use rlp::{Rlp, RlpStream};
-	use super::{*, super::tests::*};
-	use blocks::SyncHeader;
 	use client_traits::BlockChainClient;
 	use ethcore::test_helpers::{EachBlockWith, TestBlockChainClient};
-	use std::str::FromStr;
+	use ethereum_types::H256;
+	use parking_lot::RwLock;
+	use rlp::{Rlp, RlpStream};
 
 	#[test]
 	fn return_block_headers() {
@@ -426,7 +436,7 @@ mod test {
 			rlp.append(&if reverse {1u32} else {0u32});
 			rlp.out()
 		}
-		fn to_header_vec(rlp: ::chain::RlpResponseResult) -> Vec<SyncHeader> {
+		fn to_header_vec(rlp: crate::chain::RlpResponseResult) -> Vec<SyncHeader> {
 			Rlp::new(&rlp.unwrap().unwrap().1.out()).iter().map(|r| SyncHeader::from_rlp(r.as_raw().to_vec()).unwrap()).collect()
 		}
 

--- a/ethcore/sync/src/chain/sync_packet.rs
+++ b/ethcore/sync/src/chain/sync_packet.rs
@@ -22,7 +22,10 @@
 //! to convert to/from the packet id values transmitted over the
 //! wire.
 
-use api::{ETH_PROTOCOL, WARP_SYNC_PROTOCOL_ID};
+use crate::api::{ETH_PROTOCOL, WARP_SYNC_PROTOCOL_ID};
+use self::SyncPacket::*;
+
+use enum_primitive::{enum_from_primitive, enum_from_primitive_impl, enum_from_primitive_impl_ty};
 use network::{PacketId, ProtocolId};
 
 enum_from_primitive! {
@@ -60,12 +63,14 @@ enum_from_primitive! {
 	}
 }
 
-use self::SyncPacket::*;
 
 /// Provide both subprotocol and packet id information within the
 /// same object.
 pub trait PacketInfo {
+	/// Get packet id
 	fn id(&self) -> PacketId;
+
+	/// Get protocol id
 	fn protocol(&self) -> ProtocolId;
 }
 
@@ -113,7 +118,6 @@ impl PacketInfo for SyncPacket {
 #[cfg(test)]
 mod tests {
 	use super::*;
-
 	use enum_primitive::FromPrimitive;
 
 	#[test]

--- a/ethcore/sync/src/lib.rs
+++ b/ethcore/sync/src/lib.rs
@@ -21,47 +21,10 @@
 //! https://github.com/ethereum/wiki/wiki/Ethereum-Wire-Protocol
 //!
 
-extern crate client_traits;
-extern crate common_types as types;
-extern crate ethcore_io as io;
-extern crate ethcore_light as light;
-extern crate ethcore_network as network;
-extern crate ethcore_network_devp2p as devp2p;
-extern crate ethcore_private_tx;
-extern crate ethereum_types;
-extern crate ethkey;
-extern crate fastmap;
-extern crate futures;
-extern crate keccak_hash as hash;
-extern crate parity_bytes as bytes;
-extern crate parity_runtime;
-extern crate parking_lot;
-extern crate rand;
-extern crate rlp;
-extern crate snapshot;
-extern crate triehash_ethereum;
+// needed to make the procedural macro `MallocSizeOf` to work
+#[macro_use] extern crate parity_util_mem as malloc_size_of;
 
-#[cfg(test)] extern crate engine;
-#[cfg(test)] extern crate env_logger;
-#[cfg(test)] extern crate ethcore;
-#[cfg(test)] extern crate kvdb_memorydb;
-#[cfg(test)] extern crate machine;
-#[cfg(test)] extern crate rand_xorshift;
-#[cfg(test)] extern crate rustc_hex;
-#[cfg(test)] extern crate spec;
-
-#[macro_use]
-extern crate enum_primitive;
-#[macro_use]
-extern crate macros;
-#[macro_use]
-extern crate log;
-extern crate parity_util_mem;
-#[macro_use]
-extern crate parity_util_mem as malloc_size_of;
-#[macro_use]
-extern crate trace_time;
-
+mod api;
 mod chain;
 mod blocks;
 mod block_sync;
@@ -74,8 +37,6 @@ pub mod light_sync;
 
 #[cfg(test)]
 mod tests;
-
-mod api;
 
 pub use api::*;
 pub use chain::{SyncStatus, SyncState};

--- a/ethcore/sync/src/light_sync/mod.rs
+++ b/ethcore/sync/src/light_sync/mod.rs
@@ -43,7 +43,7 @@ use crate::{
 	chain::SyncState as ChainSyncState,
 };
 
-use types::encoded;
+use common_types::encoded;
 use light::client::{AsLightClient, LightChainClient};
 use light::net::{
 	PeerStatus, Announcement, Handler, BasicContext,
@@ -503,7 +503,7 @@ impl<L: AsLightClient> LightSync<L> {
 
 	// handles request dispatch, block import, state machine transitions, and timeouts.
 	fn maintain_sync(&self, ctx: &dyn BasicContext) {
-		use types::errors::{EthcoreError, ImportError};
+		use common_types::errors::{EthcoreError, ImportError};
 
 		const DRAIN_AMOUNT: usize = 128;
 

--- a/ethcore/sync/src/light_sync/mod.rs
+++ b/ethcore/sync/src/light_sync/mod.rs
@@ -38,6 +38,11 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::{Instant, Duration};
 
+use crate::{
+	api::Notification,
+	chain::SyncState as ChainSyncState,
+};
+
 use types::encoded;
 use light::client::{AsLightClient, LightChainClient};
 use light::net::{
@@ -45,8 +50,8 @@ use light::net::{
 	EventContext, Capabilities, ReqId, Status,
 	Error as NetError,
 };
-use chain::SyncState as ChainSyncState;
 use light::request::{self, CompleteHeadersRequest as HeadersRequest};
+use log::{debug, trace};
 use network::PeerId;
 use ethereum_types::{H256, U256};
 use parking_lot::{Mutex, RwLock};
@@ -54,7 +59,6 @@ use rand::{rngs::OsRng, seq::SliceRandom};
 use futures::sync::mpsc;
 
 use self::sync_round::{AbortReason, SyncRound, ResponseContext};
-use api::Notification;
 
 mod response;
 mod sync_round;
@@ -78,13 +82,13 @@ struct ChainInfo {
 }
 
 impl PartialOrd for ChainInfo {
-	fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
 		self.head_td.partial_cmp(&other.head_td)
 	}
 }
 
 impl Ord for ChainInfo {
-	fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
+	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
 		self.head_td.cmp(&other.head_td)
 	}
 }
@@ -102,14 +106,20 @@ impl Peer {
 	}
 }
 
-// search for a common ancestor with the best chain.
+/// Search for a common ancestor with the best chain.
 #[derive(Debug)]
 enum AncestorSearch {
-	Queued(u64), // queued to search for blocks starting from here.
-	Awaiting(ReqId, u64, HeadersRequest), // awaiting response for this request.
-	Prehistoric, // prehistoric block found. TODO: start to roll back CHTs.
-	FoundCommon(u64, H256), // common block found.
-	Genesis, // common ancestor is the genesis.
+	/// Queued to search for blocks starting from here.
+	Queued(u64), //
+	/// Awaiting response for this request.
+	Awaiting(ReqId, u64, HeadersRequest),
+	/// Pre-historic block found.
+	// TODO: start to roll back CHTs.
+	Prehistoric,
+	/// Common block found.
+	FoundCommon(u64, H256),
+	/// Common ancestor is the genesis.
+	Genesis,
 }
 
 impl AncestorSearch {

--- a/ethcore/sync/src/light_sync/response.rs
+++ b/ethcore/sync/src/light_sync/response.rs
@@ -16,7 +16,7 @@
 
 //! Helpers for decoding and verifying responses for headers.
 
-use types::{encoded, header::Header};
+use common_types::{encoded, header::Header};
 use ethereum_types::H256;
 use light::request::{HashOrNumber, CompleteHeadersRequest as HeadersRequest};
 use rlp::DecoderError;
@@ -153,8 +153,8 @@ impl Constraint for Max {
 
 #[cfg(test)]
 mod tests {
-	use types::encoded;
-	use types::header::Header;
+	use common_types::encoded;
+	use common_types::header::Header;
 	use light::request::CompleteHeadersRequest as HeadersRequest;
 
 	use super::*;

--- a/ethcore/sync/src/light_sync/sync_round.rs
+++ b/ethcore/sync/src/light_sync/sync_round.rs
@@ -20,12 +20,11 @@ use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 use std::fmt;
 
-use types::encoded;
-use types::header::Header;
+use common_types::{encoded, header::Header};
 
 use light::net::ReqId;
 use light::request::CompleteHeadersRequest as HeadersRequest;
-use log::{trace};
+use log::trace;
 
 use network::PeerId;
 use ethereum_types::H256;

--- a/ethcore/sync/src/light_sync/sync_round.rs
+++ b/ethcore/sync/src/light_sync/sync_round.rs
@@ -25,6 +25,7 @@ use types::header::Header;
 
 use light::net::ReqId;
 use light::request::CompleteHeadersRequest as HeadersRequest;
+use log::{trace};
 
 use network::PeerId;
 use ethereum_types::H256;
@@ -37,7 +38,7 @@ const SCAFFOLD_ATTEMPTS: usize = 3;
 /// Context for a headers response.
 pub trait ResponseContext {
 	/// Get the peer who sent this response.
-	fn responder(&self) ->	PeerId;
+	fn responder(&self) -> PeerId;
 	/// Get the request ID this response corresponds to.
 	fn req_id(&self) -> &ReqId;
 	/// Get the (unverified) response data.

--- a/ethcore/sync/src/light_sync/tests/mod.rs
+++ b/ethcore/sync/src/light_sync/tests/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use tests::helpers::TestNet;
+use crate::tests::helpers::TestNet;
 
 use ethcore::test_helpers::EachBlockWith;
 use client_traits::BlockInfo;

--- a/ethcore/sync/src/light_sync/tests/mod.rs
+++ b/ethcore/sync/src/light_sync/tests/mod.rs
@@ -18,7 +18,7 @@ use crate::tests::helpers::TestNet;
 
 use ethcore::test_helpers::EachBlockWith;
 use client_traits::BlockInfo;
-use types::ids::BlockId;
+use common_types::ids::BlockId;
 
 mod test_net;
 

--- a/ethcore/sync/src/snapshot_sync.rs
+++ b/ethcore/sync/src/snapshot_sync.rs
@@ -14,13 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use snapshot::SnapshotService;
-use ethereum_types::H256;
-use hash::keccak;
-use types::snapshot::ManifestData;
-
 use std::collections::HashSet;
 use std::iter::FromIterator;
+
+use ethereum_types::H256;
+use hash::keccak;
+use log::trace;
+use snapshot::SnapshotService;
+use types::snapshot::ManifestData;
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum ChunkType {
@@ -28,7 +29,7 @@ pub enum ChunkType {
 	Block(H256),
 }
 
-#[derive(MallocSizeOf)]
+#[derive(Default, MallocSizeOf)]
 pub struct Snapshot {
 	pending_state_chunks: Vec<H256>,
 	pending_block_chunks: Vec<H256>,
@@ -41,16 +42,8 @@ pub struct Snapshot {
 
 impl Snapshot {
 	/// Create a new instance.
-	pub fn new() -> Snapshot {
-		Snapshot {
-			pending_state_chunks: Vec::new(),
-			pending_block_chunks: Vec::new(),
-			downloading_chunks: HashSet::new(),
-			completed_chunks: HashSet::new(),
-			snapshot_hash: None,
-			bad_hashes: HashSet::new(),
-			initialized: false,
-		}
+	pub fn new() -> Self {
+		Default::default()
 	}
 
 	/// Sync the Snapshot completed chunks with the Snapshot Service

--- a/ethcore/sync/src/snapshot_sync.rs
+++ b/ethcore/sync/src/snapshot_sync.rs
@@ -21,7 +21,7 @@ use ethereum_types::H256;
 use hash::keccak;
 use log::trace;
 use snapshot::SnapshotService;
-use types::snapshot::ManifestData;
+use common_types::snapshot::ManifestData;
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum ChunkType {
@@ -172,7 +172,7 @@ mod test {
 	use hash::keccak;
 	use bytes::Bytes;
 	use super::*;
-	use types::snapshot::ManifestData;
+	use common_types::snapshot::ManifestData;
 
 	fn is_empty(snapshot: &Snapshot) -> bool {
 		snapshot.pending_block_chunks.is_empty() &&

--- a/ethcore/sync/src/snapshot_sync.rs
+++ b/ethcore/sync/src/snapshot_sync.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 use std::iter::FromIterator;
 
 use ethereum_types::H256;
-use hash::keccak;
+use keccak_hash::keccak;
 use log::trace;
 use snapshot::SnapshotService;
 use common_types::snapshot::ManifestData;
@@ -169,9 +169,10 @@ impl Snapshot {
 
 #[cfg(test)]
 mod test {
-	use hash::keccak;
+	use super::{ChunkType, H256, Snapshot};
+
 	use bytes::Bytes;
-	use super::*;
+	use keccak_hash::keccak;
 	use common_types::snapshot::ManifestData;
 
 	fn is_empty(snapshot: &Snapshot) -> bool {

--- a/ethcore/sync/src/sync_io.rs
+++ b/ethcore/sync/src/sync_io.rs
@@ -26,7 +26,7 @@ use network::client_version::ClientVersion;
 use network::{NetworkContext, PeerId, PacketId, Error, SessionInfo, ProtocolId};
 use parking_lot::RwLock;
 use snapshot::SnapshotService;
-use types::BlockNumber;
+use common_types::BlockNumber;
 
 /// IO interface for the syncing handler.
 /// Provides peer connection management and an interface to the blockchain client.

--- a/ethcore/sync/src/sync_io.rs
+++ b/ethcore/sync/src/sync_io.rs
@@ -16,15 +16,17 @@
 
 use std::sync::Arc;
 use std::collections::HashMap;
-use chain::sync_packet::{PacketInfo, SyncPacket};
-use network::{NetworkContext, PeerId, PacketId, Error, SessionInfo, ProtocolId};
-use network::client_version::ClientVersion;
+
+use crate::chain::sync_packet::{PacketInfo, SyncPacket};
+
 use bytes::Bytes;
 use client_traits::BlockChainClient;
 use ethcore_private_tx::PrivateStateDB;
-use types::BlockNumber;
-use snapshot::SnapshotService;
+use network::client_version::ClientVersion;
+use network::{NetworkContext, PeerId, PacketId, Error, SessionInfo, ProtocolId};
 use parking_lot::RwLock;
+use snapshot::SnapshotService;
+use types::BlockNumber;
 
 /// IO interface for the syncing handler.
 /// Provides peer connection management and an interface to the blockchain client.

--- a/ethcore/sync/src/tests/chain.rs
+++ b/ethcore/sync/src/tests/chain.rs
@@ -23,6 +23,7 @@ use crate::{
 };
 
 use client_traits::{BlockChainClient, BlockInfo, ChainInfo};
+use common_types::ids::BlockId;
 use ethcore::test_helpers::{TestBlockChainClient, EachBlockWith};
 
 #[test]

--- a/ethcore/sync/src/tests/chain.rs
+++ b/ethcore/sync/src/tests/chain.rs
@@ -24,7 +24,6 @@ use crate::{
 
 use client_traits::{BlockChainClient, BlockInfo, ChainInfo};
 use ethcore::test_helpers::{TestBlockChainClient, EachBlockWith};
-use types::ids::BlockId;
 
 #[test]
 fn two_peers() {

--- a/ethcore/sync/src/tests/chain.rs
+++ b/ethcore/sync/src/tests/chain.rs
@@ -15,18 +15,20 @@
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
-use types::ids::BlockId;
-use client_traits::{BlockChainClient, ChainInfo};
+
+use crate::{
+	api::{SyncConfig, WarpSync},
+	chain::SyncState,
+	tests::helpers::TestNet,
+};
+
+use client_traits::{BlockChainClient, BlockInfo, ChainInfo};
 use ethcore::test_helpers::{TestBlockChainClient, EachBlockWith};
-use client_traits::BlockInfo;
-use chain::SyncState;
-use super::helpers::*;
-use {SyncConfig, WarpSync};
-use spec;
+use types::ids::BlockId;
 
 #[test]
 fn two_peers() {
-	::env_logger::try_init().ok();
+	env_logger::try_init().ok();
 	let mut net = TestNet::new(3);
 	net.peer(1).chain.add_blocks(1000, EachBlockWith::Uncle);
 	net.peer(2).chain.add_blocks(1000, EachBlockWith::Uncle);
@@ -37,7 +39,7 @@ fn two_peers() {
 
 #[test]
 fn long_chain() {
-	::env_logger::try_init().ok();
+	env_logger::try_init().ok();
 	let mut net = TestNet::new(2);
 	net.peer(1).chain.add_blocks(50000, EachBlockWith::Nothing);
 	net.sync();
@@ -47,7 +49,7 @@ fn long_chain() {
 
 #[test]
 fn status_after_sync() {
-	::env_logger::try_init().ok();
+	env_logger::try_init().ok();
 	let mut net = TestNet::new(3);
 	net.peer(1).chain.add_blocks(1000, EachBlockWith::Uncle);
 	net.peer(2).chain.add_blocks(1000, EachBlockWith::Uncle);
@@ -67,7 +69,7 @@ fn takes_few_steps() {
 
 #[test]
 fn empty_blocks() {
-	::env_logger::try_init().ok();
+	env_logger::try_init().ok();
 	let mut net = TestNet::new(3);
 	for n in 0..200 {
 		let with = if n % 2 == 0 { EachBlockWith::Nothing } else { EachBlockWith::Uncle };
@@ -81,7 +83,7 @@ fn empty_blocks() {
 
 #[test]
 fn forked() {
-	::env_logger::try_init().ok();
+	env_logger::try_init().ok();
 	let mut net = TestNet::new(3);
 	net.peer(0).chain.add_blocks(30, EachBlockWith::Uncle);
 	net.peer(1).chain.add_blocks(30, EachBlockWith::Uncle);
@@ -102,7 +104,7 @@ fn forked() {
 
 #[test]
 fn forked_with_misbehaving_peer() {
-	::env_logger::try_init().ok();
+	env_logger::try_init().ok();
 	let mut net = TestNet::new(3);
 
 	let mut alt_spec = spec::new_test();
@@ -126,7 +128,7 @@ fn forked_with_misbehaving_peer() {
 
 #[test]
 fn net_hard_fork() {
-	::env_logger::try_init().ok();
+	env_logger::try_init().ok();
 	let ref_client = TestBlockChainClient::new();
 	ref_client.add_blocks(50, EachBlockWith::Uncle);
 	{
@@ -145,7 +147,7 @@ fn net_hard_fork() {
 
 #[test]
 fn restart() {
-	::env_logger::try_init().ok();
+	env_logger::try_init().ok();
 	let mut net = TestNet::new(3);
 	net.peer(1).chain.add_blocks(1000, EachBlockWith::Uncle);
 	net.peer(2).chain.add_blocks(1000, EachBlockWith::Uncle);
@@ -229,7 +231,7 @@ fn propagate_blocks() {
 
 #[test]
 fn restart_on_malformed_block() {
-	::env_logger::try_init().ok();
+	env_logger::try_init().ok();
 	let mut net = TestNet::new(2);
 	net.peer(1).chain.add_blocks(5, EachBlockWith::Nothing);
 	net.peer(1).chain.add_block(EachBlockWith::Nothing, |mut header| {
@@ -255,7 +257,7 @@ fn reject_on_broken_chain() {
 
 #[test]
 fn disconnect_on_unrelated_chain() {
-	::env_logger::try_init().ok();
+	env_logger::try_init().ok();
 	let mut net = TestNet::new(2);
 	net.peer(0).chain.set_history(Some(20));
 	net.peer(1).chain.set_history(Some(20));

--- a/ethcore/sync/src/tests/consensus.rs
+++ b/ethcore/sync/src/tests/consensus.rs
@@ -28,7 +28,7 @@ use ethcore::miner::{self, MinerService};
 use ethcore_io::{IoHandler, IoChannel};
 use ethereum_types::{U256, Address};
 use ethkey::{KeyPair, Secret};
-use hash::keccak;
+use keccak_hash::keccak;
 use common_types::{
 	io_message::ClientIoMessage,
 	transaction::{Action, PendingTransaction, Transaction}

--- a/ethcore/sync/src/tests/consensus.rs
+++ b/ethcore/sync/src/tests/consensus.rs
@@ -15,21 +15,24 @@
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
-use hash::keccak;
-use ethereum_types::{U256, Address};
-use io::{IoHandler, IoChannel};
+
+use crate::{
+	api::SyncConfig,
+	tests::helpers::{TestIoHandler, TestNet},
+};
+
 use client_traits::ChainInfo;
 use engine::signer;
-use spec;
 use ethcore::client::Client;
 use ethcore::miner::{self, MinerService};
+use ethcore_io::{IoHandler, IoChannel};
+use ethereum_types::{U256, Address};
 use ethkey::{KeyPair, Secret};
+use hash::keccak;
 use types::{
 	io_message::ClientIoMessage,
 	transaction::{Action, PendingTransaction, Transaction}
 };
-use super::helpers::*;
-use SyncConfig;
 
 fn new_tx(secret: &Secret, nonce: U256, chain_id: u64) -> PendingTransaction {
 	let signed = Transaction {

--- a/ethcore/sync/src/tests/consensus.rs
+++ b/ethcore/sync/src/tests/consensus.rs
@@ -29,7 +29,7 @@ use ethcore_io::{IoHandler, IoChannel};
 use ethereum_types::{U256, Address};
 use ethkey::{KeyPair, Secret};
 use hash::keccak;
-use types::{
+use common_types::{
 	io_message::ClientIoMessage,
 	transaction::{Action, PendingTransaction, Transaction}
 };

--- a/ethcore/sync/src/tests/helpers.rs
+++ b/ethcore/sync/src/tests/helpers.rs
@@ -16,36 +16,43 @@
 
 use std::collections::{VecDeque, HashSet, HashMap};
 use std::sync::Arc;
-use ethereum_types::H256;
-use parking_lot::{RwLock, Mutex};
-use bytes::Bytes;
-use network::{self, PeerId, ProtocolId, PacketId, SessionInfo};
-use network::client_version::ClientVersion;
-use tests::snapshot::*;
-use types::{
-	chain_notify::{NewBlocks, ChainMessageType},
-	io_message::ClientIoMessage,
+
+use crate::{
+	api::{SyncConfig, WARP_SYNC_PROTOCOL_ID},
+	chain::{
+		sync_packet::{
+			PacketInfo,
+			SyncPacket::{self, PrivateTransactionPacket, SignedPrivateTransactionPacket}
+		},
+		ChainSync, SyncSupplier, ETH_PROTOCOL_VERSION_63, PAR_PROTOCOL_VERSION_4
+	},
+	private_tx::SimplePrivateTxHandler,
+	sync_io::SyncIo,
+	tests::snapshot::TestSnapshotService,
 };
+
 use client_traits::{BlockChainClient, ChainNotify};
 use ethcore::{
 	client::{Client as EthcoreClient, ClientConfig},
 	test_helpers::TestBlockChainClient
 };
-use snapshot::SnapshotService;
-use spec::{self, Spec};
-use ethcore_private_tx::PrivateStateDB;
 use ethcore::miner::Miner;
 use ethcore::test_helpers;
-use sync_io::SyncIo;
-use io::{IoChannel, IoContext, IoHandler};
-use api::WARP_SYNC_PROTOCOL_ID;
-use chain::{ChainSync, SyncSupplier, ETH_PROTOCOL_VERSION_63, PAR_PROTOCOL_VERSION_4};
-use chain::sync_packet::{PacketInfo, SyncPacket};
-use chain::sync_packet::SyncPacket::{PrivateTransactionPacket, SignedPrivateTransactionPacket};
-
-use SyncConfig;
-use private_tx::SimplePrivateTxHandler;
-use types::BlockNumber;
+use ethcore_io::{IoChannel, IoContext, IoHandler};
+use ethcore_private_tx::PrivateStateDB;
+use ethereum_types::H256;
+use bytes::Bytes;
+use network::{self, PeerId, ProtocolId, PacketId, SessionInfo};
+use network::client_version::ClientVersion;
+use log::trace;
+use snapshot::SnapshotService;
+use spec::Spec;
+use parking_lot::{RwLock, Mutex};
+use types::{
+	chain_notify::{NewBlocks, ChainMessageType},
+	io_message::ClientIoMessage,
+	BlockNumber,
+};
 
 pub trait FlushingBlockChainClient: BlockChainClient {
 	fn flush(&self) {}
@@ -123,7 +130,7 @@ impl<'p, C> SyncIo for TestIo<'p, C> where C: FlushingBlockChainClient, C: 'p {
 
 	fn send(&mut self,peer_id: PeerId, packet_id: SyncPacket, data: Vec<u8>) -> Result<(), network::Error> {
 		self.packets.push(TestPacket {
-			data: data,
+			data,
 			packet_id: packet_id.id(),
 			recipient: peer_id,
 		});
@@ -135,11 +142,10 @@ impl<'p, C> SyncIo for TestIo<'p, C> where C: FlushingBlockChainClient, C: 'p {
 	}
 
 	fn peer_version(&self, peer_id: PeerId) -> ClientVersion {
-		let client_id = self.peers_info.get(&peer_id)
+		self.peers_info.get(&peer_id)
 			.cloned()
-			.unwrap_or_else(|| peer_id.to_string());
-
-		ClientVersion::from(client_id)
+			.unwrap_or_else(|| peer_id.to_string())
+			.into()
 	}
 
 	fn snapshot_service(&self) -> &dyn SnapshotService {

--- a/ethcore/sync/src/tests/helpers.rs
+++ b/ethcore/sync/src/tests/helpers.rs
@@ -32,12 +32,16 @@ use crate::{
 };
 
 use client_traits::{BlockChainClient, ChainNotify};
+use common_types::{
+	chain_notify::{NewBlocks, ChainMessageType},
+	io_message::ClientIoMessage,
+	BlockNumber,
+};
 use ethcore::{
 	client::{Client as EthcoreClient, ClientConfig},
-	test_helpers::TestBlockChainClient
+	test_helpers::{self, TestBlockChainClient},
 };
 use ethcore::miner::Miner;
-use ethcore::test_helpers;
 use ethcore_io::{IoChannel, IoContext, IoHandler};
 use ethcore_private_tx::PrivateStateDB;
 use ethereum_types::H256;
@@ -48,11 +52,6 @@ use log::trace;
 use snapshot::SnapshotService;
 use spec::Spec;
 use parking_lot::{RwLock, Mutex};
-use types::{
-	chain_notify::{NewBlocks, ChainMessageType},
-	io_message::ClientIoMessage,
-	BlockNumber,
-};
 
 pub trait FlushingBlockChainClient: BlockChainClient {
 	fn flush(&self) {}

--- a/ethcore/sync/src/tests/private.rs
+++ b/ethcore/sync/src/tests/private.rs
@@ -38,7 +38,7 @@ use ethcore_private_tx::{
 	Provider, ProviderConfig, NoopEncryptor, Importer, SignedPrivateTransaction, StoringKeyProvider
 };
 use ethkey::KeyPair;
-use hash::keccak;
+use keccak_hash::keccak;
 use machine::executive::contract_address;
 use rustc_hex::FromHex;
 use rlp::Rlp;
@@ -46,7 +46,7 @@ use spec::Spec;
 
 fn seal_spec() -> Spec {
 	let spec_data = include_str!("../res/private_spec.json");
-	Spec::load(&::std::env::temp_dir(), spec_data.as_bytes()).unwrap()
+	Spec::load(&std::env::temp_dir(), spec_data.as_bytes()).unwrap()
 }
 
 #[test]

--- a/ethcore/sync/src/tests/private.rs
+++ b/ethcore/sync/src/tests/private.rs
@@ -22,6 +22,11 @@ use crate::{
 };
 
 use client_traits::BlockChainClient;
+use common_types::{
+	ids::BlockId,
+	io_message::ClientIoMessage,
+	transaction::{Transaction, Action},
+};
 use engine::signer;
 use ethcore::{
 	client::Client,
@@ -38,11 +43,6 @@ use machine::executive::contract_address;
 use rustc_hex::FromHex;
 use rlp::Rlp;
 use spec::Spec;
-use types::{
-	ids::BlockId,
-	io_message::ClientIoMessage,
-	transaction::{Transaction, Action},
-};
 
 fn seal_spec() -> Spec {
 	let spec_data = include_str!("../res/private_spec.json");

--- a/ethcore/sync/src/tests/private.rs
+++ b/ethcore/sync/src/tests/private.rs
@@ -15,13 +15,12 @@
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
-use hash::keccak;
-use io::{IoHandler, IoChannel};
-use types::transaction::{Transaction, Action};
-use types::{
-	ids::BlockId,
-	io_message::ClientIoMessage,
+
+use crate::{
+	api::SyncConfig,
+	tests::helpers::{TestIoHandler, TestNet}
 };
+
 use client_traits::BlockChainClient;
 use engine::signer;
 use ethcore::{
@@ -29,14 +28,21 @@ use ethcore::{
 	miner::{self, MinerService},
 	test_helpers::{CreateContractAddress, push_block_with_transactions, new_db},
 };
-use ethcore_private_tx::{Provider, ProviderConfig, NoopEncryptor, Importer, SignedPrivateTransaction, StoringKeyProvider};
+use ethcore_io::{IoHandler, IoChannel};
+use ethcore_private_tx::{
+	Provider, ProviderConfig, NoopEncryptor, Importer, SignedPrivateTransaction, StoringKeyProvider
+};
 use ethkey::KeyPair;
+use hash::keccak;
 use machine::executive::contract_address;
-use tests::helpers::{TestNet, TestIoHandler};
 use rustc_hex::FromHex;
 use rlp::Rlp;
 use spec::Spec;
-use SyncConfig;
+use types::{
+	ids::BlockId,
+	io_message::ClientIoMessage,
+	transaction::{Transaction, Action},
+};
 
 fn seal_spec() -> Spec {
 	let spec_data = include_str!("../res/private_spec.json");

--- a/ethcore/sync/src/tests/snapshot.rs
+++ b/ethcore/sync/src/tests/snapshot.rs
@@ -28,7 +28,7 @@ use ethereum_types::H256;
 use hash::keccak;
 use parking_lot::Mutex;
 use snapshot::SnapshotService;
-use types::{
+use common_types::{
 	BlockNumber,
 	snapshot::{ManifestData, RestorationStatus},
 };

--- a/ethcore/sync/src/tests/snapshot.rs
+++ b/ethcore/sync/src/tests/snapshot.rs
@@ -25,7 +25,7 @@ use crate::{
 use bytes::Bytes;
 use ethcore::test_helpers::EachBlockWith;
 use ethereum_types::H256;
-use hash::keccak;
+use keccak_hash::keccak;
 use parking_lot::Mutex;
 use snapshot::SnapshotService;
 use common_types::{

--- a/ethcore/sync/src/tests/snapshot.rs
+++ b/ethcore/sync/src/tests/snapshot.rs
@@ -16,37 +16,35 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use hash::keccak;
-use ethereum_types::H256;
-use parking_lot::Mutex;
+
+use crate::{
+	api::{SyncConfig, WarpSync},
+	tests::helpers::TestNet
+};
+
 use bytes::Bytes;
-use snapshot::SnapshotService;
 use ethcore::test_helpers::EachBlockWith;
+use ethereum_types::H256;
+use hash::keccak;
+use parking_lot::Mutex;
+use snapshot::SnapshotService;
 use types::{
 	BlockNumber,
 	snapshot::{ManifestData, RestorationStatus},
 };
-use super::helpers::*;
-use {SyncConfig, WarpSync};
 
+#[derive(Default)]
 pub struct TestSnapshotService {
 	manifest: Option<ManifestData>,
 	chunks: HashMap<H256, Bytes>,
-
 	restoration_manifest: Mutex<Option<ManifestData>>,
 	state_restoration_chunks: Mutex<HashMap<H256, Bytes>>,
 	block_restoration_chunks: Mutex<HashMap<H256, Bytes>>,
 }
 
 impl TestSnapshotService {
-	pub fn new() -> TestSnapshotService {
-		TestSnapshotService {
-			manifest: None,
-			chunks: HashMap::new(),
-			restoration_manifest: Mutex::new(None),
-			state_restoration_chunks: Mutex::new(HashMap::new()),
-			block_restoration_chunks: Mutex::new(HashMap::new()),
-		}
+	pub fn new() -> Self {
+		Default::default()
 	}
 
 	pub fn new_with_snapshot(num_chunks: usize, block_hash: H256, block_number: BlockNumber) -> TestSnapshotService {

--- a/ethcore/sync/src/transactions_stats.rs
+++ b/ethcore/sync/src/transactions_stats.rs
@@ -14,9 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use api::TransactionStats;
 use std::hash::BuildHasher;
 use std::collections::{HashSet, HashMap};
+
+use crate::api::TransactionStats;
+
 use ethereum_types::{H256, H512};
 use fastmap::H256FastMap;
 use types::BlockNumber;
@@ -89,9 +91,9 @@ impl TransactionsStats {
 
 #[cfg(test)]
 mod tests {
-
 	use std::collections::{HashMap, HashSet};
 	use super::{Stats, TransactionsStats, NodeId, H256};
+	use macros::hash_map;
 
 	#[test]
 	fn should_keep_track_of_propagations() {

--- a/ethcore/sync/src/transactions_stats.rs
+++ b/ethcore/sync/src/transactions_stats.rs
@@ -21,7 +21,7 @@ use crate::api::TransactionStats;
 
 use ethereum_types::{H256, H512};
 use fastmap::H256FastMap;
-use types::BlockNumber;
+use common_types::BlockNumber;
 
 type NodeId = H512;
 


### PR DESCRIPTION
Address https://github.com/paritytech/parity-ethereum/pull/11061#pullrequestreview-288839718

#### Will not be addressed in this PR:

I think there are additional cleanups to do in the crate such:
- replace `enum_from_primitive` with a proc macro for `SyncPacket`
- rename/unify types such as `TransactionStats`, `LightSync` and similar, because several things are named the same thing which is confusing at least to me
- split `sync` into different crates for light and full sync
