### PR TITLE
ethcore/res: activate Istanbul on Ropsten, Görli, Rinkeby, Kovan

### DIFF
--- a/ethcore/res/ethereum/goerli.json
+++ b/ethcore/res/ethereum/goerli.json
@@ -26,6 +26,11 @@
 		"eip1052Transition": "0x0",
 		"eip1283Transition": "0x0",
 		"eip1283DisableTransition": "0x0",
+		"eip1283ReenableTransition": 1561651,
+		"eip1344Transition": 1561651,
+		"eip1706Transition": 1561651,
+		"eip1884Transition": 1561651,
+		"eip2028Transition": 1561651,
 		"gasLimitBoundDivisor": "0x400",
 		"maxCodeSize": "0x6000",
 		"maxCodeSizeTransition": "0x0",
@@ -126,7 +131,7 @@
 			"builtin": {
 				"name": "alt_bn128_add",
 				"activate_at": "0x00",
-				"eip1108_transition": "0x7fffffffffffff",
+				"eip1108_transition": 1561651,
 				"pricing": {
 					"alt_bn128_const_operations": {
 						"price": 500,
@@ -140,7 +145,7 @@
 			"builtin": {
 				"name": "alt_bn128_mul",
 				"activate_at": "0x00",
-				"eip1108_transition": "0x7fffffffffffff",
+				"eip1108_transition": 1561651,
 				"pricing": {
 					"alt_bn128_const_operations": {
 						"price": 40000,
@@ -154,7 +159,7 @@
 			"builtin": {
 				"name": "alt_bn128_pairing",
 				"activate_at": "0x00",
-				"eip1108_transition": "0x7fffffffffffff",
+				"eip1108_transition": 1561651,
 				"pricing": {
 					"alt_bn128_pairing": {
 						"base": 100000,
@@ -166,7 +171,16 @@
 			}
 		},
 		"0x0000000000000000000000000000000000000009": {
-			"balance": "0x1"
+			"balance": "0x1",
+			"builtin": {
+				"name": "blake2_f",
+				"activate_at": 1561651,
+				"pricing": {
+					"blake2_f": {
+						"gas_per_round": 1
+					}
+				}
+			}
 		},
 		"0x000000000000000000000000000000000000000a": {
 			"balance": "0x1"

--- a/ethcore/res/ethereum/goerli.json
+++ b/ethcore/res/ethereum/goerli.json
@@ -26,11 +26,11 @@
 		"eip1052Transition": "0x0",
 		"eip1283Transition": "0x0",
 		"eip1283DisableTransition": "0x0",
-		"eip1283ReenableTransition": 1561651,
-		"eip1344Transition": 1561651,
-		"eip1706Transition": 1561651,
-		"eip1884Transition": 1561651,
-		"eip2028Transition": 1561651,
+		"eip1283ReenableTransition": "0x17d433",
+		"eip1344Transition": "0x17d433",
+		"eip1706Transition": "0x17d433",
+		"eip1884Transition": "0x17d433",
+		"eip2028Transition": "0x17d433",
 		"gasLimitBoundDivisor": "0x400",
 		"maxCodeSize": "0x6000",
 		"maxCodeSizeTransition": "0x0",
@@ -131,7 +131,7 @@
 			"builtin": {
 				"name": "alt_bn128_add",
 				"activate_at": "0x00",
-				"eip1108_transition": 1561651,
+				"eip1108_transition": "0x17d433",
 				"pricing": {
 					"alt_bn128_const_operations": {
 						"price": 500,
@@ -145,7 +145,7 @@
 			"builtin": {
 				"name": "alt_bn128_mul",
 				"activate_at": "0x00",
-				"eip1108_transition": 1561651,
+				"eip1108_transition": "0x17d433",
 				"pricing": {
 					"alt_bn128_const_operations": {
 						"price": 40000,
@@ -159,7 +159,7 @@
 			"builtin": {
 				"name": "alt_bn128_pairing",
 				"activate_at": "0x00",
-				"eip1108_transition": 1561651,
+				"eip1108_transition": "0x17d433",
 				"pricing": {
 					"alt_bn128_pairing": {
 						"base": 100000,
@@ -174,7 +174,7 @@
 			"balance": "0x1",
 			"builtin": {
 				"name": "blake2_f",
-				"activate_at": 1561651,
+				"activate_at": "0x17d433",
 				"pricing": {
 					"blake2_f": {
 						"gas_per_round": 1

--- a/ethcore/res/ethereum/istanbul_test.json
+++ b/ethcore/res/ethereum/istanbul_test.json
@@ -37,6 +37,7 @@
 		"eip1014Transition": "0x0",
 		"eip1052Transition": "0x0",
 		"eip1283Transition": "0x0",
+		"eip1283DisableTransition": "0x0",
 		"eip1283ReenableTransition": "0x0",
 		"eip1344Transition": "0x0",
 		"eip1706Transition": "0x0",

--- a/ethcore/res/ethereum/kovan.json
+++ b/ethcore/res/ethereum/kovan.json
@@ -64,6 +64,11 @@
 		"eip1052Transition": "0x8c6180",
 		"eip1283Transition": "0x8c6180",
 		"eip1283DisableTransition": "0x9c7b61",
+		"eip1283ReenableTransition": "0xd75771",
+		"eip1344Transition": "0xd75771",
+		"eip1706Transition": "0xd75771",
+		"eip1884Transition": "0xd75771",
+		"eip2028Transition": "0xd75771",
 		"kip4Transition": "0x8c6180",
 		"kip6Transition": "0x8c6180"
 	},
@@ -6722,7 +6727,7 @@
 			"builtin": {
 				"name": "alt_bn128_add",
 				"activate_at": "0x4d50f8",
-				"eip1108_transition": "0x7fffffffffffff",
+				"eip1108_transition": "0xd75771",
 				"pricing": {
 					"alt_bn128_const_operations": {
 						"price": 500,
@@ -6735,7 +6740,7 @@
 			"builtin": {
 				"name": "alt_bn128_mul",
 				"activate_at": "0x4d50f8",
-				"eip1108_transition": "0x7fffffffffffff",
+				"eip1108_transition": "0xd75771",
 				"pricing": {
 					"alt_bn128_const_operations": {
 						"price": 40000,
@@ -6748,13 +6753,24 @@
 			"builtin": {
 				"name": "alt_bn128_pairing",
 				"activate_at": "0x4d50f8",
-				"eip1108_transition": "0x7fffffffffffff",
+				"eip1108_transition": "0xd75771",
 				"pricing": {
 					"alt_bn128_pairing": {
 						"base": 100000,
 						"pair": 80000,
 						"eip1108_transition_base": 45000,
 						"eip1108_transition_pair": 34000
+					}
+				}
+			}
+		},
+		"0x0000000000000000000000000000000000000009": {
+			"builtin": {
+				"name": "blake2_f",
+				"activate_at": "0xd75771",
+				"pricing": {
+					"blake2_f": {
+						"gas_per_round": 1
 					}
 				}
 			}

--- a/ethcore/res/ethereum/kovan.json
+++ b/ethcore/res/ethereum/kovan.json
@@ -64,11 +64,11 @@
 		"eip1052Transition": "0x8c6180",
 		"eip1283Transition": "0x8c6180",
 		"eip1283DisableTransition": "0x9c7b61",
-		"eip1283ReenableTransition": "0xd75771",
-		"eip1344Transition": "0xd75771",
-		"eip1706Transition": "0xd75771",
-		"eip1884Transition": "0xd75771",
-		"eip2028Transition": "0xd75771",
+		"eip1283ReenableTransition": "0xd751a5",
+		"eip1344Transition": "0xd751a5",
+		"eip1706Transition": "0xd751a5",
+		"eip1884Transition": "0xd751a5",
+		"eip2028Transition": "0xd751a5",
 		"kip4Transition": "0x8c6180",
 		"kip6Transition": "0x8c6180"
 	},
@@ -6727,7 +6727,7 @@
 			"builtin": {
 				"name": "alt_bn128_add",
 				"activate_at": "0x4d50f8",
-				"eip1108_transition": "0xd75771",
+				"eip1108_transition": "0xd751a5",
 				"pricing": {
 					"alt_bn128_const_operations": {
 						"price": 500,
@@ -6740,7 +6740,7 @@
 			"builtin": {
 				"name": "alt_bn128_mul",
 				"activate_at": "0x4d50f8",
-				"eip1108_transition": "0xd75771",
+				"eip1108_transition": "0xd751a5",
 				"pricing": {
 					"alt_bn128_const_operations": {
 						"price": 40000,
@@ -6753,7 +6753,7 @@
 			"builtin": {
 				"name": "alt_bn128_pairing",
 				"activate_at": "0x4d50f8",
-				"eip1108_transition": "0xd75771",
+				"eip1108_transition": "0xd751a5",
 				"pricing": {
 					"alt_bn128_pairing": {
 						"base": 100000,
@@ -6767,7 +6767,7 @@
 		"0x0000000000000000000000000000000000000009": {
 			"builtin": {
 				"name": "blake2_f",
-				"activate_at": "0xd75771",
+				"activate_at": "0xd751a5",
 				"pricing": {
 					"blake2_f": {
 						"gas_per_round": 1

--- a/ethcore/res/ethereum/rinkeby.json
+++ b/ethcore/res/ethereum/rinkeby.json
@@ -26,6 +26,11 @@
 		"eip1052Transition": "0x37db77",
 		"eip1283Transition": "0x37db77",
 		"eip1283DisableTransition": "0x41efd2",
+		"eip1283ReenableTransition": "0x52efd1",
+		"eip1344Transition": "0x52efd1",
+		"eip1706Transition": "0x52efd1",
+		"eip1884Transition": "0x52efd1",
+		"eip2028Transition": "0x52efd1",
 		"gasLimitBoundDivisor": "0x400",
 		"maxCodeSize": "0x6000",
 		"maxCodeSizeTransition": "0x0",
@@ -120,7 +125,7 @@
 			"builtin": {
 				"name": "alt_bn128_add",
 				"activate_at": "0xfcc25",
-				"eip1108_transition": "0x7fffffffffffff",
+				"eip1108_transition": "0x52efd1",
 				"pricing": {
 					"alt_bn128_const_operations": {
 						"price": 500,
@@ -133,7 +138,7 @@
 			"builtin": {
 				"name": "alt_bn128_mul",
 				"activate_at": "0xfcc25",
-				"eip1108_transition": "0x7fffffffffffff",
+				"eip1108_transition": "0x52efd1",
 				"pricing": {
 					"alt_bn128_const_operations": {
 						"price": 40000,
@@ -146,7 +151,7 @@
 			"builtin": {
 				"name": "alt_bn128_pairing",
 				"activate_at": "0xfcc25",
-				"eip1108_transition": "0x7fffffffffffff",
+				"eip1108_transition": "0x52efd1",
 				"pricing": {
 					"alt_bn128_pairing": {
 						"base": 100000,
@@ -158,7 +163,16 @@
 			}
 		},
 		"0x0000000000000000000000000000000000000009": {
-			"balance": "0x1"
+			"balance": "0x1",
+			"builtin": {
+				"name": "blake2_f",
+				"activate_at": "0x52efd1",
+				"pricing": {
+					"blake2_f": {
+						"gas_per_round": 1
+					}
+				}
+			}
 		},
 		"0x000000000000000000000000000000000000000a": {
 			"balance": "0x1"

--- a/ethcore/res/ethereum/ropsten.json
+++ b/ethcore/res/ethereum/ropsten.json
@@ -45,7 +45,12 @@
 		"eip1014Transition": "0x408b70",
 		"eip1052Transition": "0x408b70",
 		"eip1283Transition": "0x408b70",
-		"eip1283DisableTransition": "0x4b5e82"
+		"eip1283DisableTransition": "0x4b5e82",
+		"eip1283ReenableTransition": 6485846,
+		"eip1344Transition": 6485846,
+		"eip1706Transition": 6485846,
+		"eip1884Transition": 6485846,
+		"eip2028Transition": 6485846,
 	},
 	"genesis": {
 		"seal": {
@@ -2735,7 +2740,7 @@
 			"builtin": {
 				"name": "alt_bn128_add",
 				"activate_at": "0x19f0a0",
-				"eip1108_transition": "0x7fffffffffffff",
+				"eip1108_transition": 6485846,
 				"pricing": {
 					"alt_bn128_const_operations": {
 						"price": 500,
@@ -2750,7 +2755,7 @@
 			"builtin": {
 				"name": "alt_bn128_mul",
 				"activate_at": "0x19f0a0",
-				"eip1108_transition": "0x7fffffffffffff",
+				"eip1108_transition": 6485846,
 				"pricing": {
 					"alt_bn128_const_operations": {
 						"price": 40000,
@@ -2765,7 +2770,7 @@
 			"builtin": {
 				"name": "alt_bn128_pairing",
 				"activate_at": "0x19f0a0",
-				"eip1108_transition": "0x7fffffffffffff",
+				"eip1108_transition": 6485846,
 				"pricing": {
 					"alt_bn128_pairing": {
 						"base": 100000,
@@ -2777,7 +2782,16 @@
 			}
 		},
 		"0x0000000000000000000000000000000000000009": {
-			"balance": "0x1"
+			"balance": "0x1",
+			"builtin": {
+				"name": "blake2_f",
+				"activate_at": 6485846,
+				"pricing": {
+					"blake2_f": {
+						"gas_per_round": 1
+					}
+				}
+			}
 		},
 		"0x000000000000000000000000000000000000000a": {
 			"balance": "0x0"

--- a/ethcore/res/ethereum/ropsten.json
+++ b/ethcore/res/ethereum/ropsten.json
@@ -46,11 +46,11 @@
 		"eip1052Transition": "0x408b70",
 		"eip1283Transition": "0x408b70",
 		"eip1283DisableTransition": "0x4b5e82",
-		"eip1283ReenableTransition": 6485846,
-		"eip1344Transition": 6485846,
-		"eip1706Transition": 6485846,
-		"eip1884Transition": 6485846,
-		"eip2028Transition": 6485846,
+		"eip1283ReenableTransition": "0x62f756",
+		"eip1344Transition": "0x62f756",
+		"eip1706Transition": "0x62f756",
+		"eip1884Transition": "0x62f756",
+		"eip2028Transition": "0x62f756",
 	},
 	"genesis": {
 		"seal": {
@@ -2740,7 +2740,7 @@
 			"builtin": {
 				"name": "alt_bn128_add",
 				"activate_at": "0x19f0a0",
-				"eip1108_transition": 6485846,
+				"eip1108_transition": "0x62f756",
 				"pricing": {
 					"alt_bn128_const_operations": {
 						"price": 500,
@@ -2755,7 +2755,7 @@
 			"builtin": {
 				"name": "alt_bn128_mul",
 				"activate_at": "0x19f0a0",
-				"eip1108_transition": 6485846,
+				"eip1108_transition": "0x62f756",
 				"pricing": {
 					"alt_bn128_const_operations": {
 						"price": 40000,
@@ -2770,7 +2770,7 @@
 			"builtin": {
 				"name": "alt_bn128_pairing",
 				"activate_at": "0x19f0a0",
-				"eip1108_transition": 6485846,
+				"eip1108_transition": "0x62f756",
 				"pricing": {
 					"alt_bn128_pairing": {
 						"base": 100000,
@@ -2785,7 +2785,7 @@
 			"balance": "0x1",
 			"builtin": {
 				"name": "blake2_f",
-				"activate_at": 6485846,
+				"activate_at": "0x62f756",
 				"pricing": {
 					"blake2_f": {
 						"gas_per_round": 1

--- a/ethcore/res/ethereum/ropsten.json
+++ b/ethcore/res/ethereum/ropsten.json
@@ -50,7 +50,7 @@
 		"eip1344Transition": "0x62f756",
 		"eip1706Transition": "0x62f756",
 		"eip1884Transition": "0x62f756",
-		"eip2028Transition": "0x62f756",
+		"eip2028Transition": "0x62f756"
 	},
 	"genesis": {
 		"seal": {

--- a/ethcore/res/ethereum/st_peters_test.json
+++ b/ethcore/res/ethereum/st_peters_test.json
@@ -36,6 +36,7 @@
 		"eip145Transition": "0x0",
 		"eip1014Transition": "0x0",
 		"eip1052Transition": "0x0",
+		"eip1283Transition": "0x0",
 		"eip1283DisableTransition": "0x0"
 	},
 	"genesis": {


### PR DESCRIPTION
Activates Istanbul hardfork:

- Ropsten on `6485846` (Oct 2)
- Görli on `1561651` (Oct 30)
- Rinkeby `5435345` (November)
- Kovan `14111141` (December)

Some sources:

- https://github.com/goerli/testnet/issues/60#issuecomment-532200530
- https://twitter.com/hudsonjameson/status/1174336671342575617
- https://twitter.com/a4fri/status/1173939316101386240
- https://github.com/ethereum/go-ethereum/pull/20090

I took the diff of required changes from #11033 not from the Istanbul meta-EIP https://eips.ethereum.org/EIPS/eip-1679; I mention this because on first view both specs do not match, so **please review this PR carefully**! From my experience, I think #11033 is a better reference than an official EIP ;-)

Needs a release once merged.

Thanks. :pray: 

Fixes #10770 

Bonus: c17a53b be pedantic about EIP-1283 in the test specs.
