### PR TITLE
[ethash] remove manual unrolling 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,9 +100,7 @@ cargo-check-benches:
   stage:                           test
   <<:                              *docker-cache-status
   script:
-    - time (cargo check --all --benches --exclude ethash --exclude verification --target $CARGO_TARGET --locked --verbose --color=always)
-    - time (cd ethash; cargo check --benches --features bench --target $CARGO_TARGET --locked --verbose --color=always)
-    - time (cd ethcore/verification; cargo check --benches --features bench --target $CARGO_TARGET --locked --verbose --color=always)
+    - time cargo check --all --benches --target $CARGO_TARGET --locked --verbose --color=always
     - sccache -s
 
 cargo-audit:
@@ -344,7 +342,7 @@ publish-release-awss3-nightly:     &publish-release-awss3
     - linux-docker
 
 publish-release-awss3-manually:
-  <<:                              *publish-release-awss3  
+  <<:                              *publish-release-awss3
   only:                            *releaseable_branches
   when:                            manual
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,7 +936,6 @@ version = "1.12.0"
 dependencies = [
  "common-types 0.1.0",
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethash/Cargo.toml
+++ b/ethash/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 common-types = { path = "../ethcore/types" }
-crunchy = "0.1.0"
 either = "1.0.0"
 ethereum-types = "0.6.0"
 keccak-hash = "0.2.0"

--- a/ethash/Cargo.toml
+++ b/ethash/Cargo.toml
@@ -28,7 +28,9 @@ bench = []
 [[bench]]
 name = "basic"
 harness = false
+required-features = ['bench']
 
 [[bench]]
 name = "progpow"
 harness = false
+required-features = ['bench']

--- a/ethash/benches/basic.rs
+++ b/ethash/benches/basic.rs
@@ -20,7 +20,7 @@ extern crate ethash;
 extern crate common_types;
 
 use criterion::Criterion;
-use ethash::NodeCacheBuilder;
+use ethash::{NodeCacheBuilder, keccak};
 use common_types::engines::OptimizeFor;
 
 const HASH: [u8; 32] = [
@@ -40,7 +40,8 @@ const NONCE: u64 = 0xd7b3ac70a301a249;
 criterion_group! {
 	name = basic;
 	config = dont_take_an_eternity_to_run();
-	targets = bench_light_compute_memmap,
+	targets = bench_keccak_512_inplace,
+		bench_light_compute_memmap,
 		bench_light_compute_memory,
 		bench_light_new_round_trip_memmap,
 		bench_light_new_round_trip_memory,
@@ -54,6 +55,13 @@ fn dont_take_an_eternity_to_run() -> Criterion {
 	Criterion::default().nresamples(1_000)
 		.without_plots()
 		.sample_size(10)
+}
+
+fn bench_keccak_512_inplace(b: &mut Criterion) {
+	b.bench_function("bench_keccak_512_inplace", move |b| b.iter(|| {
+		let mut data = [4u8; 64];
+		keccak::keccak_512::inplace(&mut data);
+	}));
 }
 
 fn bench_light_compute_memmap(b: &mut Criterion) {

--- a/ethash/src/compute.rs
+++ b/ethash/src/compute.rs
@@ -239,24 +239,16 @@ fn hash_compute(light: &Light, full_size: usize, header_hash: &H256, nonce: u64)
 			fnv_hash(first_val ^ i, mix_words[i as usize % MIX_WORDS]) % num_full_pages
 		};
 
-		unroll! {
-			// MIX_NODES
-			for n in 0..2 {
-				let tmp_node = calculate_dag_item(
-					index * MIX_NODES as u32 + n as u32,
-					cache,
-				);
+		// MIX_NODES
+		for n in 0..2 {
+			let tmp_node = calculate_dag_item(
+				index * MIX_NODES as u32 + n as u32,
+				cache,
+			);
 
-				unroll! {
-					// NODE_WORDS
-					for w in 0..16 {
-						mix[n].as_words_mut()[w] =
-							fnv_hash(
-								mix[n].as_words()[w],
-								tmp_node.as_words()[w],
-							);
-					}
-				}
+			// NODE_WORDS
+			for (a, b) in mix[n].as_words_mut().iter_mut().zip(tmp_node.as_words()) {
+				*a = fnv_hash(*a, *b);
 			}
 		}
 	}
@@ -277,16 +269,14 @@ fn hash_compute(light: &Light, full_size: usize, header_hash: &H256, nonce: u64)
 
 		// Compress mix
 		debug_assert_eq!(MIX_WORDS / 4, 8);
-		unroll! {
-			for i in 0..8 {
-				let w = i * 4;
+		for i in 0..8 {
+			let w = i * 4;
 
-				let mut reduction = mix_words[w + 0];
-				reduction = reduction.wrapping_mul(FNV_PRIME) ^ mix_words[w + 1];
-				reduction = reduction.wrapping_mul(FNV_PRIME) ^ mix_words[w + 2];
-				reduction = reduction.wrapping_mul(FNV_PRIME) ^ mix_words[w + 3];
-				compress[i] = reduction;
-			}
+			let mut reduction = mix_words[w + 0];
+			reduction = reduction.wrapping_mul(FNV_PRIME) ^ mix_words[w + 1];
+			reduction = reduction.wrapping_mul(FNV_PRIME) ^ mix_words[w + 2];
+			reduction = reduction.wrapping_mul(FNV_PRIME) ^ mix_words[w + 3];
+			compress[i] = reduction;
 		}
 	}
 

--- a/ethash/src/compute.rs
+++ b/ethash/src/compute.rs
@@ -312,7 +312,6 @@ fn hash_compute(light: &Light, full_size: usize, header_hash: &H256, nonce: u64)
 	ProofOfWork { mix_hash: mix_hash, value: value }
 }
 
-// TODO: Use the `simd` crate
 pub fn calculate_dag_item(node_index: u32, cache: &[Node]) -> Node {
 	let num_parent_nodes = cache.len();
 	let mut ret = cache[node_index as usize % num_parent_nodes].clone();
@@ -326,10 +325,8 @@ pub fn calculate_dag_item(node_index: u32, cache: &[Node]) -> Node {
 			num_parent_nodes as u32;
 		let parent = &cache[parent_index as usize];
 
-		unroll! {
-			for w in 0..16 {
-				ret.as_words_mut()[w] = fnv_hash(ret.as_words()[w], parent.as_words()[w]);
-			}
+		for (a, b) in ret.as_words_mut().iter_mut().zip(parent.as_words()) {
+			*a = fnv_hash(*a, *b);
 		}
 	}
 

--- a/ethash/src/lib.rs
+++ b/ethash/src/lib.rs
@@ -44,6 +44,9 @@ mod compute;
 
 mod seed_compute;
 mod cache;
+#[cfg(feature = "bench")]
+pub mod keccak;
+#[cfg(not(feature = "bench"))]
 mod keccak;
 mod shared;
 

--- a/ethash/src/lib.rs
+++ b/ethash/src/lib.rs
@@ -22,8 +22,6 @@ extern crate parking_lot;
 extern crate primal;
 
 #[macro_use]
-extern crate crunchy;
-#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate static_assertions;

--- a/ethcore/verification/Cargo.toml
+++ b/ethcore/verification/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-3.0"
 [[bench]]
 name = "verification"
 harness = false
+required-features = ['bench']
 
 [dependencies]
 blockchain = { package = "ethcore-blockchain", path = "../blockchain" }


### PR DESCRIPTION
Manual unrolling is no longer necessary, since LLVM is good at that as well as autovectorizing, esp. with `-C target-cpu=native` https://rust.godbolt.org/z/6P6y8Q. Criterion detected no change in performance (but would be good if someone else could confirm this on another machine).

* remove manuall `unroll!`ing
* specify `required-features` for benches
* add a keccak512 bench