### PR TITLE
[json-tests] populate state from genesis pod state

### DIFF
--- a/ethcore/res/ethereum/tests-issues/currents.json
+++ b/ethcore/res/ethereum/tests-issues/currents.json
@@ -22,13 +22,6 @@
 			]
 		},
 		{
-			"reference": "issue https://github.com/paritytech/parity-ethereum/issues/11074",
-			"failing": "stReturnDataTest",
-			"subtests": [
-				"returndatasize_after_successful_callcode_d0g0v0_ConstantinopleFix"
-			]
-		},
-		{
 			"reference": "Issue https://github.com/paritytech/parity-ethereum/issues/11075",
 			"failing": "stSpecialTest",
 			"subtests": [

--- a/ethcore/spec/src/spec.rs
+++ b/ethcore/spec/src/spec.rs
@@ -131,6 +131,7 @@ fn run_constructors<T: Backend>(
 	let start_nonce = engine.account_start_nonce(0);
 
 	let mut state = State::from_existing(db, root, start_nonce, factories.clone())?;
+	state.populate_from(genesis_state.clone());
 
 	// Execute contract constructors.
 	let env_info = EnvInfo {
@@ -177,6 +178,7 @@ fn run_constructors<T: Backend>(
 
 		let _ = state.commit()?;
 	}
+	let _ = state.commit()?;
 
 	Ok(state.drop())
 }


### PR DESCRIPTION
Fixes #11704.
In the failing test we had
```json
                "storage" : {
                    "0x00" : "0x00"
                }
```
And our test code for constructing `state_root` didn't handle [removing zero valued storage entries](https://github.com/paritytech/parity-ethereum/blob/2627288311e952ff3b6b9675dfeda24f75b8249e/ethcore/account-state/src/account.rs#L511-L516) from trie. 
[`populate_from`](https://github.com/paritytech/parity-ethereum/blob/00124b5a4bf8a38ad6c660b462a5e5addf13cab3/ethcore/account-state/src/state.rs#L782) is used to update the state cache so that `commit` logic works and another `state.commit()` is added to work with 0 constructors case.