### PR TITLE
Move StateResult to `common-types`

### DIFF
--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -12,7 +12,7 @@ ansi_term = "0.11"
 basic-authority = { path = "./engines/basic-authority", optional = true} # used by test-helpers feature
 blooms-db = { path = "../util/blooms-db", optional = true }
 client-traits = { path = "./client-traits" }
-common-types = { path = "types" }
+common-types = { path = "./types" }
 engine = { path = "./engine" }
 env_logger = { version = "0.5", optional = true }
 ethabi = "8.0"

--- a/ethcore/client-traits/src/lib.rs
+++ b/ethcore/client-traits/src/lib.rs
@@ -55,7 +55,10 @@ use trace::{
 	localized::LocalizedTrace,
 	VMTrace,
 };
-use common_types::data_format::DataFormat;
+use common_types::{
+	data_format::DataFormat,
+	client_types::StateResult
+};
 use vm::{LastHashes, Schedule};
 
 /// State information to be used during client query
@@ -65,16 +68,6 @@ pub enum StateOrBlock {
 
 	/// Id of an existing block from a chain to get state from
 	Block(BlockId)
-}
-
-/// Result to be used during get address code at given block's state
-// todo[botika] move to `common-types`
-pub enum StateResult<T> {
-	/// State is missing
-	Missing,
-
-	/// State is some
-	Some(T),
 }
 
 impl From<Box<dyn StateInfo>> for StateOrBlock {

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -77,7 +77,6 @@ use client_traits::{
 	ScheduleInfo,
 	StateClient,
 	StateOrBlock,
-	StateResult,
 	Tick,
 	TransactionInfo
 };
@@ -108,8 +107,7 @@ use types::{
 	BlockNumber,
 	call_analytics::CallAnalytics,
 	chain_notify::{ChainMessageType, ChainRoute, NewBlocks},
-	client_types::ClientReport,
-	client_types::Mode,
+	client_types::{ClientReport, Mode, StateResult},
 	encoded,
 	engines::{
 		epoch::{PendingTransition, Transition as EpochTransition},

--- a/ethcore/src/test_helpers/test_client.rs
+++ b/ethcore/src/test_helpers/test_client.rs
@@ -55,7 +55,7 @@ use types::{
 	view,
 	views::BlockView,
 	verification::Unverified,
-	client_types::Mode,
+	client_types::{Mode, StateResult},
 	blockchain_info::BlockChainInfo,
 	block_status::BlockStatus,
 	verification::VerificationQueueInfo as BlockQueueInfo,
@@ -71,7 +71,7 @@ use client::{
 use client_traits::{
 	BlockInfo, Nonce, Balance, ChainInfo, TransactionInfo, BlockChainClient, ImportBlock,
 	AccountData, BlockChain, IoClient, BadBlocks, ScheduleInfo, StateClient, ProvingBlockChainClient,
-	StateOrBlock, StateResult
+	StateOrBlock
 };
 use engine::Engine;
 use machine::executed::Executed;

--- a/ethcore/types/src/client_types.rs
+++ b/ethcore/types/src/client_types.rs
@@ -89,3 +89,13 @@ impl<'a> ops::Sub<&'a ClientReport> for ClientReport {
 		self
 	}
 }
+
+/// Result to be used during get address code at given block's state
+pub enum StateResult<T> {
+	/// State is missing
+	Missing,
+
+	/// State is some
+	Some(T),
+}
+

--- a/parity/blockchain.rs
+++ b/parity/blockchain.rs
@@ -26,7 +26,7 @@ use hash::{keccak, KECCAK_NULL_RLP};
 use ethereum_types::{U256, H256, Address};
 use bytes::ToPretty;
 use rlp::PayloadInfo;
-use client_traits::{BlockChainReset, Nonce, Balance, BlockChainClient, ImportExportBlocks, StateResult};
+use client_traits::{BlockChainReset, Nonce, Balance, BlockChainClient, ImportExportBlocks};
 use ethcore::{
 	client::{DatabaseCompactionProfile, VMType},
 	miner::Miner,
@@ -44,7 +44,7 @@ use ansi_term::Colour;
 use types::{
 	ids::BlockId,
 	errors::{ImportError, EthcoreError},
-	client_types::Mode,
+	client_types::{Mode, StateResult},
 };
 use types::data_format::DataFormat;
 use verification::queue::VerifierSettings;

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -25,7 +25,7 @@ use ethereum_types::{Address, H64, H160, H256, U64, U256, BigEndianHash};
 use parking_lot::Mutex;
 
 use account_state::state::StateInfo;
-use client_traits::{BlockChainClient, StateClient, ProvingBlockChainClient, StateOrBlock, StateResult};
+use client_traits::{BlockChainClient, StateClient, ProvingBlockChainClient, StateOrBlock};
 use ethash::{self, SeedHashCompute};
 use ethcore::client::{Call, EngineInfo};
 use ethcore::miner::{self, MinerService};
@@ -35,6 +35,7 @@ use miner::external::ExternalMinerService;
 use sync::SyncProvider;
 use types::{
 	BlockNumber as EthBlockNumber,
+	client_types::StateResult,
 	encoded,
 	ids::{BlockId, TransactionId, UncleId},
 	filter::Filter as EthcoreFilter,


### PR DESCRIPTION
To move `StateOrBlock` you should also move the `StateInfo` trait from `acount-state` to `common-types` to avoid cyclic dependence. 

In which module of ` common-types` should I put `StateInfo`?