### PR TITLE
[ethash] chainspec validate `ecip1017EraRounds` non-zero

### DIFF
--- a/ethcore/engines/ethash/src/lib.rs
+++ b/ethcore/engines/ethash/src/lib.rs
@@ -472,7 +472,7 @@ impl Ethash {
 /// This function will panic if `era_rounds` is less than `2`
 fn ecip1017_eras_block_reward(era_rounds: u64, mut reward: U256, block_number: u64) -> (u64, U256) {
 	// NOTE(niklasad1): all numbers is divisible by 1, it will cause the if below
-	// to succeed except the first block. Thus, `era_rounds - 1 == 0` and cause `divide by zero`
+	// to succeed except for the first block. Thus, `era_rounds - 1 == 0` and cause `divide by zero`
 	//
 	// TODO(niklasad): We could set `eras` to zero if this occurs, but I'm not sure of the implications
 	assert!(era_rounds > 1, "ecip1017EraRounds must be bigger than 1");

--- a/ethcore/engines/ethash/src/lib.rs
+++ b/ethcore/engines/ethash/src/lib.rs
@@ -464,7 +464,18 @@ impl Ethash {
 	}
 }
 
-fn ecip1017_eras_block_reward(era_rounds: u64, mut reward: U256, block_number:u64) -> (u64, U256) {
+
+/// Calculates the number of eras and reward
+///
+/// # Panics
+///
+/// This function will panic if `era_rounds` is less than `2`
+fn ecip1017_eras_block_reward(era_rounds: u64, mut reward: U256, block_number: u64) -> (u64, U256) {
+	// NOTE(niklasad1): all numbers is divisible by 1, it will cause the if below
+	// to succeed except the first block. Thus, `era_rounds - 1 == 0` and cause `divide by zero`
+	//
+	// TODO(niklasad): We could set `eras` to zero if this occurs, but I'm not sure of the implications
+	assert!(era_rounds > 1, "ecip1017EraRounds must be bigger than 1");
 	let eras = if block_number != 0 && block_number % era_rounds == 0 {
 		block_number / era_rounds - 1
 	} else {

--- a/ethcore/engines/ethash/src/lib.rs
+++ b/ethcore/engines/ethash/src/lib.rs
@@ -473,8 +473,6 @@ impl Ethash {
 fn ecip1017_eras_block_reward(era_rounds: u64, mut reward: U256, block_number: u64) -> (u64, U256) {
 	// NOTE(niklasad1): all numbers is divisible by 1, it will cause the if below
 	// to succeed except for the first block. Thus, `era_rounds - 1 == 0` and cause `divide by zero`
-	//
-	// TODO(niklasad): We could set `eras` to zero if this occurs, but I'm not sure of the implications
 	assert!(era_rounds > 1, "ecip1017EraRounds must be bigger than 1");
 	let eras = if block_number != 0 && block_number % era_rounds == 0 {
 		block_number / era_rounds - 1

--- a/json/src/spec/ethash.rs
+++ b/json/src/spec/ethash.rs
@@ -91,6 +91,7 @@ pub struct EthashParams {
 	pub ecip1010_continue_transition: Option<Uint>,
 
 	/// See main EthashParams docs.
+	#[serde(default, deserialize_with="uint::validate_optional_non_zero")]
 	pub ecip1017_era_rounds: Option<Uint>,
 
 	/// Delays of difficulty bombs.
@@ -101,7 +102,6 @@ pub struct EthashParams {
 	/// EXPIP-2 duration limit
 	pub expip2_duration_limit: Option<Uint>,
 	/// Block to transition to progpow
-	#[serde(rename="progpowTransition")]
 	pub progpow_transition: Option<Uint>,
 }
 


### PR DESCRIPTION
See https://github.com/paritytech/parity-ethereum/issues/11119 for background information.

This PR does the following:

1. Modifies chain spec validation to require ecip1017EraRounds to be non-zero. For a more human-friendly error message. (Could maybe be bigger than 1 instead, however, it is technically a breaking change but it makes parity useless)
2. Document `fn ecip1017_eras_block_reward` and add explicit panic for `hidden` panics that may occur by `divide by zero`

We could maybe just return `zero era rounds` when  `ecip1017EraRounds < 2`

Thoughts?