### PR TITLE
Use TryFrom instead of From+panic for Builtin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,7 @@ version = "0.1.0"
 dependencies = [
  "bn 0.4.4 (git+https://github.com/paritytech/bn)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "common-types 0.1.0",
  "eip-152 0.1.0",
  "ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethjson 0.1.0",

--- a/ethcore/builtin/Cargo.toml
+++ b/ethcore/builtin/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 bn = { git = "https://github.com/paritytech/bn", default-features = false }
+common-types = { path = "../types" }
 ethereum-types = "0.8.0"
 ethjson = { path = "../../json" }
 ethkey = { path = "../../accounts/ethkey" }

--- a/ethcore/builtin/src/lib.rs
+++ b/ethcore/builtin/src/lib.rs
@@ -679,6 +679,7 @@ impl Bn128Pairing {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::TryFrom;
 	use ethereum_types::U256;
 	use ethjson::uint::Uint;
 	use num::{BigUint, Zero, One};
@@ -690,7 +691,7 @@ mod tests {
 	fn blake2f_cost() {
 		let f = Builtin {
 			pricer: Box::new(123),
-			native: ethereum_builtin("blake2_f"),
+			native: ethereum_builtin("blake2_f").expect("known builtin"),
 			activate_at: 0,
 		};
 		// 5 rounds
@@ -703,7 +704,7 @@ mod tests {
 
 	#[test]
 	fn blake2_f_is_err_on_invalid_length() {
-		let blake2 = ethereum_builtin("blake2_f");
+		let blake2 = ethereum_builtin("blake2_f").expect("known builtin");
 		// Test vector 1 and expected output from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-152.md#test-vector-1
 		let input = hex!("00000c48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001");
 		let mut out = [0u8; 64];
@@ -715,7 +716,7 @@ mod tests {
 
 	#[test]
 	fn blake2_f_is_err_on_invalid_length_2() {
-		let blake2 = ethereum_builtin("blake2_f");
+		let blake2 = ethereum_builtin("blake2_f").expect("known builtin");
 		// Test vector 2 and expected output from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-152.md#test-vector-2
 		let input = hex!("000000000c48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001");
 		let mut out = [0u8; 64];
@@ -727,7 +728,7 @@ mod tests {
 
 	#[test]
 	fn blake2_f_is_err_on_bad_finalization_flag() {
-		let blake2 = ethereum_builtin("blake2_f");
+		let blake2 = ethereum_builtin("blake2_f").expect("known builtin");
 		// Test vector 3 and expected output from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-152.md#test-vector-3
 		let input = hex!("0000000c48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000002");
 		let mut out = [0u8; 64];
@@ -739,7 +740,7 @@ mod tests {
 
 	#[test]
 	fn blake2_f_zero_rounds_is_ok_test_vector_4() {
-		let blake2 = ethereum_builtin("blake2_f");
+		let blake2 = ethereum_builtin("blake2_f").expect("known builtin");
 		// Test vector 4 and expected output from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-152.md#test-vector-4
 		let input = hex!("0000000048c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001");
 		let expected = hex!("08c9bcf367e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d282e6ad7f520e511f6c3e2b8c68059b9442be0454267ce079217e1319cde05b");
@@ -750,7 +751,7 @@ mod tests {
 
 	#[test]
 	fn blake2_f_test_vector_5() {
-		let blake2 = ethereum_builtin("blake2_f");
+		let blake2 = ethereum_builtin("blake2_f").expect("known builtin");
 		// Test vector 5 and expected output from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-152.md#test-vector-5
 		let input = hex!("0000000c48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001");
 		let expected = hex!("ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d17d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923");
@@ -761,7 +762,7 @@ mod tests {
 
 	#[test]
 	fn blake2_f_test_vector_6() {
-		let blake2 = ethereum_builtin("blake2_f");
+		let blake2 = ethereum_builtin("blake2_f").expect("known builtin");
 		// Test vector 6 and expected output from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-152.md#test-vector-6
 		let input = hex!("0000000c48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000");
 		let expected = hex!("75ab69d3190a562c51aef8d88f1c2775876944407270c42c9844252c26d2875298743e7f6d5ea2f2d3e8d226039cd31b4e426ac4f2d3d666a610c2116fde4735");
@@ -772,7 +773,7 @@ mod tests {
 
 	#[test]
 	fn blake2_f_test_vector_7() {
-		let blake2 = ethereum_builtin("blake2_f");
+		let blake2 = ethereum_builtin("blake2_f").expect("known builtin");
 		// Test vector 7 and expected output from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-152.md#test-vector-7
 		let input = hex!("0000000148c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001");
 		let expected = hex!("b63a380cb2897d521994a85234ee2c181b5f844d2c624c002677e9703449d2fba551b3a8333bcdf5f2f7e08993d53923de3d64fcc68c034e717b9293fed7a421");
@@ -784,7 +785,7 @@ mod tests {
 	#[ignore]
 	#[test]
 	fn blake2_f_test_vector_8() {
-		let blake2 = ethereum_builtin("blake2_f");
+		let blake2 = ethereum_builtin("blake2_f").expect("known builtin");
 		// Test vector 8 and expected output from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-152.md#test-vector-8
 		// Note this test is slow, 4294967295/0xffffffff rounds take a while.
 		let input = hex!("ffffffff48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001");
@@ -829,7 +830,7 @@ mod tests {
 
 	#[test]
 	fn identity() {
-		let f = ethereum_builtin("identity");
+		let f = ethereum_builtin("identity").expect("known builtin");
 
 		let i = [0u8, 1, 2, 3];
 
@@ -849,7 +850,7 @@ mod tests {
 
 	#[test]
 	fn sha256() {
-		let f = ethereum_builtin("sha256");
+		let f = ethereum_builtin("sha256").expect("known builtin");
 
 		let i = [0u8; 0];
 
@@ -872,7 +873,7 @@ mod tests {
 
 	#[test]
 	fn ripemd160() {
-		let f = ethereum_builtin("ripemd160");
+		let f = ethereum_builtin("ripemd160").expect("known builtin");
 
 		let i = [0u8; 0];
 
@@ -891,7 +892,7 @@ mod tests {
 
 	#[test]
 	fn ecrecover() {
-		let f = ethereum_builtin("ecrecover");
+		let f = ethereum_builtin("ecrecover").expect("known builtin");
 
 		let i = hex!("47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad000000000000000000000000000000000000000000000000000000000000001b650acf9d3f5f0a2c799776a1254355d5f4061762a237396a99a0e0e3fc2bcd6729514a0dacb2e623ac4abd157cb18163ff942280db4d5caad66ddf941ba12e03");
 
@@ -944,7 +945,7 @@ mod tests {
 
 		let f = Builtin {
 			pricer: Box::new(ModexpPricer { divisor: 20 }),
-			native: ethereum_builtin("modexp"),
+			native: ethereum_builtin("modexp").expect("known builtin"),
 			activate_at: 0,
 		};
 
@@ -1055,7 +1056,7 @@ mod tests {
 
 		let f = Builtin {
 			pricer: Box::new(Linear { base: 0, word: 0 }),
-			native: ethereum_builtin("alt_bn128_add"),
+			native: ethereum_builtin("alt_bn128_add").expect("known builtin"),
 			activate_at: 0,
 		};
 
@@ -1114,7 +1115,7 @@ mod tests {
 
 		let f = Builtin {
 			pricer: Box::new(Linear { base: 0, word: 0 }),
-			native: ethereum_builtin("alt_bn128_mul"),
+			native: ethereum_builtin("alt_bn128_mul").expect("known builtin"),
 			activate_at: 0,
 		};
 
@@ -1154,7 +1155,7 @@ mod tests {
 	fn builtin_pairing() -> Builtin {
 		Builtin {
 			pricer: Box::new(Linear { base: 0, word: 0 }),
-			native: ethereum_builtin("alt_bn128_pairing"),
+			native: ethereum_builtin("alt_bn128_pairing").expect("known builtin"),
 			activate_at: 0,
 		}
 	}
@@ -1226,7 +1227,7 @@ mod tests {
 	#[test]
 	#[should_panic]
 	fn from_unknown_linear() {
-		let _ = ethereum_builtin("foo");
+		let _ = ethereum_builtin("foo").unwrap();
 	}
 
 	#[test]
@@ -1234,7 +1235,7 @@ mod tests {
 		let pricer = Box::new(Linear { base: 10, word: 20} );
 		let b = Builtin {
 			pricer: pricer as Box<dyn Pricer>,
-			native: ethereum_builtin("identity"),
+			native: ethereum_builtin("identity").expect("known builtin"),
 			activate_at: 100_000,
 		};
 
@@ -1248,7 +1249,7 @@ mod tests {
 		let pricer = Box::new(Linear { base: 10, word: 20 });
 		let b = Builtin {
 			pricer: pricer as Box<dyn Pricer>,
-			native: ethereum_builtin("identity"),
+			native: ethereum_builtin("identity").expect("known builtin"),
 			activate_at: 1,
 		};
 
@@ -1265,7 +1266,7 @@ mod tests {
 
 	#[test]
 	fn from_json() {
-		let b = Builtin::from(ethjson::spec::Builtin {
+		let b = Builtin::try_from(ethjson::spec::Builtin {
 			name: "identity".to_owned(),
 			pricing: ethjson::spec::Pricing::Linear(ethjson::spec::Linear {
 				base: 10,
@@ -1273,7 +1274,7 @@ mod tests {
 			}),
 			activate_at: None,
 			eip1108_transition: None,
-		});
+		}).expect("bad spec");
 
 		assert_eq!(b.cost(&[0; 0], 0), U256::from(10));
 		assert_eq!(b.cost(&[0; 1], 0), U256::from(30));
@@ -1288,7 +1289,7 @@ mod tests {
 
 	#[test]
 	fn bn128_pairing_eip1108_transition() {
-		let b = Builtin::from(ethjson::spec::Builtin {
+		let b = Builtin::try_from(ethjson::spec::Builtin {
 			name: "alt_bn128_pairing".to_owned(),
 			pricing: ethjson::spec::Pricing::AltBn128Pairing(ethjson::spec::builtin::AltBn128Pairing {
 				base: 100_000,
@@ -1298,7 +1299,7 @@ mod tests {
 			}),
 			activate_at: Some(Uint(U256::from(10))),
 			eip1108_transition: Some(Uint(U256::from(20))),
-		});
+		}).expect("bad spec");
 
 		assert_eq!(b.cost(&[0; 192 * 3], 10), U256::from(340_000), "80 000 * 3 + 100 000 == 340 000");
 		assert_eq!(b.cost(&[0; 192 * 7], 20), U256::from(283_000), "34 000 * 7 + 45 000 == 283 000");
@@ -1306,7 +1307,7 @@ mod tests {
 
 	#[test]
 	fn bn128_add_eip1108_transition() {
-		let b = Builtin::from(ethjson::spec::Builtin {
+		let b = Builtin::try_from(ethjson::spec::Builtin {
 			name: "alt_bn128_add".to_owned(),
 			pricing: ethjson::spec::Pricing::AltBn128ConstOperations(ethjson::spec::builtin::AltBn128ConstOperations {
 				price: 500,
@@ -1314,7 +1315,7 @@ mod tests {
 			}),
 			activate_at: Some(Uint(U256::from(10))),
 			eip1108_transition: Some(Uint(U256::from(20))),
-		});
+		}).expect("bad spec");
 
 		assert_eq!(b.cost(&[0; 192], 10), U256::from(500));
 		assert_eq!(b.cost(&[0; 10], 20), U256::from(150), "after istanbul hardfork gas cost for add should be 150");
@@ -1322,7 +1323,7 @@ mod tests {
 
 	#[test]
 	fn bn128_mul_eip1108_transition() {
-		let b = Builtin::from(ethjson::spec::Builtin {
+		let b = Builtin::try_from(ethjson::spec::Builtin {
 			name: "alt_bn128_mul".to_owned(),
 			pricing: ethjson::spec::Pricing::AltBn128ConstOperations(ethjson::spec::builtin::AltBn128ConstOperations {
 				price: 40_000,
@@ -1330,7 +1331,7 @@ mod tests {
 			}),
 			activate_at: Some(Uint(U256::from(10))),
 			eip1108_transition: Some(Uint(U256::from(20))),
-		});
+		}).expect("bad spec");
 
 		assert_eq!(b.cost(&[0; 192], 10), U256::from(40_000));
 		assert_eq!(b.cost(&[0; 10], 20), U256::from(6_000), "after istanbul hardfork gas cost for mul should be 6 000");

--- a/ethcore/builtin/src/lib.rs
+++ b/ethcore/builtin/src/lib.rs
@@ -1274,7 +1274,7 @@ mod tests {
 			}),
 			activate_at: None,
 			eip1108_transition: None,
-		}).expect("bad spec");
+		}).expect("known builtin");
 
 		assert_eq!(b.cost(&[0; 0], 0), U256::from(10));
 		assert_eq!(b.cost(&[0; 1], 0), U256::from(30));
@@ -1299,7 +1299,7 @@ mod tests {
 			}),
 			activate_at: Some(Uint(U256::from(10))),
 			eip1108_transition: Some(Uint(U256::from(20))),
-		}).expect("bad spec");
+		}).expect("known builtin");
 
 		assert_eq!(b.cost(&[0; 192 * 3], 10), U256::from(340_000), "80 000 * 3 + 100 000 == 340 000");
 		assert_eq!(b.cost(&[0; 192 * 7], 20), U256::from(283_000), "34 000 * 7 + 45 000 == 283 000");
@@ -1315,7 +1315,7 @@ mod tests {
 			}),
 			activate_at: Some(Uint(U256::from(10))),
 			eip1108_transition: Some(Uint(U256::from(20))),
-		}).expect("bad spec");
+		}).expect("known builtin");
 
 		assert_eq!(b.cost(&[0; 192], 10), U256::from(500));
 		assert_eq!(b.cost(&[0; 10], 20), U256::from(150), "after istanbul hardfork gas cost for add should be 150");
@@ -1331,7 +1331,7 @@ mod tests {
 			}),
 			activate_at: Some(Uint(U256::from(10))),
 			eip1108_transition: Some(Uint(U256::from(20))),
-		}).expect("bad spec");
+		}).expect("known builtin");
 
 		assert_eq!(b.cost(&[0; 192], 10), U256::from(40_000));
 		assert_eq!(b.cost(&[0; 10], 20), U256::from(6_000), "after istanbul hardfork gas cost for mul should be 6 000");

--- a/ethcore/machine/src/test_helpers.rs
+++ b/ethcore/machine/src/test_helpers.rs
@@ -16,14 +16,16 @@
 
 //! Provide facilities to create `Machine` instances for testing various networks.
 
+use std::convert::TryFrom;
 use common_types::engines::params::CommonParams;
+use ethcore_builtin::Builtin;
 use ethjson;
 use crate::Machine;
 
 pub fn load_machine(reader: &[u8]) -> Machine {
 	let spec = ethjson::spec::Spec::load(reader).expect("chain spec is invalid");
 
-	let builtins = spec.accounts.builtins().into_iter().map(|p| (p.0.into(), From::from(p.1))).collect();
+	let builtins = spec.accounts.builtins().into_iter().map(|p| (p.0.into(), Builtin::try_from(p.1).expect("chain spec is invalid"))).collect();
 	let params = CommonParams::from(spec.params);
 
 	if let ethjson::spec::Engine::Ethash(ref ethash) = spec.engine {

--- a/ethcore/spec/src/spec.rs
+++ b/ethcore/spec/src/spec.rs
@@ -252,14 +252,7 @@ impl fmt::Display for SpecHardcodedSync {
 		writeln!(f, "{{")?;
 		writeln!(f, r#"header": "{:?},"#, self.header)?;
 		writeln!(f, r#"total_difficulty": "{:?},"#, self.total_difficulty)?;
-		writeln!(
-			f,
-			r#"chts": {:#?}"#,
-			self.chts
-				.iter()
-				.map(|x| format!(r#"{}"#, x))
-				.collect::<Vec<_>>()
-		)?;
+		writeln!(f, r#"chts": {:#?}"#, self.chts.iter().map(|x| format!(r#"{}"#, x)).collect::<Vec<_>>())?;
 		writeln!(f, "}}")
 	}
 }

--- a/ethcore/spec/src/spec.rs
+++ b/ethcore/spec/src/spec.rs
@@ -18,6 +18,7 @@
 
 use std::{
 	collections::BTreeMap,
+	convert::TryFrom,
 	fmt,
 	io::Read,
 	path::Path,
@@ -251,18 +252,34 @@ impl fmt::Display for SpecHardcodedSync {
 		writeln!(f, "{{")?;
 		writeln!(f, r#"header": "{:?},"#, self.header)?;
 		writeln!(f, r#"total_difficulty": "{:?},"#, self.total_difficulty)?;
-		writeln!(f, r#"chts": {:#?}"#, self.chts.iter().map(|x| format!(r#"{}"#, x)).collect::<Vec<_>>())?;
+		writeln!(
+			f,
+			r#"chts": {:#?}"#,
+			self.chts
+				.iter()
+				.map(|x| format!(r#"{}"#, x))
+				.collect::<Vec<_>>()
+		)?;
 		writeln!(f, "}}")
 	}
 }
 
+fn convert_json_to_spec(
+	pair: (ethjson::hash::Address, ethjson::spec::Builtin),
+) -> Result<(Address, Builtin), Error> {
+	let builtin = Builtin::try_from(pair.1)?;
+	Ok((pair.0.into(), builtin))
+}
+
 /// Load from JSON object.
 fn load_from(spec_params: SpecParams, s: ethjson::spec::Spec) -> Result<Spec, Error> {
-	let builtins = s.accounts
+	let builtins: Result<BTreeMap<Address, Builtin>, _> = s
+		.accounts
 		.builtins()
 		.into_iter()
-		.map(|p| (p.0.into(), From::from(p.1)))
+		.map(convert_json_to_spec)
 		.collect();
+	let builtins = builtins?;
 	let g = Genesis::from(s.genesis);
 	let GenericSeal(seal_rlp) = g.seal.into();
 	let params = CommonParams::from(s.params);
@@ -472,10 +489,16 @@ impl Spec {
 	pub fn load_machine<R: Read>(reader: R) -> Result<Machine, Error> {
 		ethjson::spec::Spec::load(reader)
 			.map_err(|e| Error::Msg(e.to_string()))
-			.map(|s| {
-				let builtins = s.accounts.builtins().into_iter().map(|p| (p.0.into(), From::from(p.1))).collect();
+			.and_then(|s| {
+				let builtins: Result<BTreeMap<Address, Builtin>, _> = s
+					.accounts
+					.builtins()
+					.into_iter()
+					.map(convert_json_to_spec)
+					.collect();
+				let builtins = builtins?;
 				let params = CommonParams::from(s.params);
-				Spec::machine(&s.engine, params, builtins)
+				Ok(Spec::machine(&s.engine, params, builtins))
 			})
 	}
 


### PR DESCRIPTION
Fixes #11134 

Currently there is a panic if a bad builtin name is entered in the chain spec. This PR replaces that panic by returning an Error instead of panicking in that situation and then using TryFrom instead of From to create the Builder type.

I'm not sure what compiler version you are using as I got errors and a ton of change from running rustfmt, so I finagled it to run over just my changes but there might still be some stylistic issues.

Also, the code is a bit convoluted but I wanted to put this up to make sure this is what you are looking for before cleaning it up a bit.