### PR TITLE
ethcore client: fix a double Read Lock bug in fn Client::logs()

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2038,7 +2038,7 @@ impl BlockChainClient for Client {
 			blocks
 		};
 
-		Ok(self.chain.read().logs(blocks, |entry| filter.matches(entry), filter.limit))
+		Ok(chain.logs(blocks, |entry| filter.matches(entry), filter.limit))
 	}
 
 	fn filter_traces(&self, filter: TraceFilter) -> Option<Vec<LocalizedTrace>> {


### PR DESCRIPTION
***Description***
This PR fixes a double Read lock bug in ethcore client.
The two Read locks on self.chain reside in the same function Client::logs(), at the beginning and the end line of the function, respectively. The lock self.chain is a parking_lot::RwLock.

This bug is similar to #592

According to parking_lot::RwLock:
“readers trying to acquire the lock will block even if the lock is unlocked when there are writers waiting to acquire the lock.”
“attempts to recursively acquire a read lock within a single thread may result in a deadlock.”

Therefore, once a function (e.g. restore_db, etc) requires a write lock in between the execution of function logs(), a double lock may happen.

***How I fix***
Reuse the chain and remove the second lock.

