### PR TITLE
util Host: fix a double Read Lock bug in fn Host::session_readable()

### DIFF
--- a/util/network-devp2p/src/host.rs
+++ b/util/network-devp2p/src/host.rs
@@ -842,6 +842,7 @@ impl Host {
 				if duplicate {
 					trace!(target: "network", "Rejected duplicate connection: {}", token);
 					session.lock().disconnect(io, DisconnectReason::DuplicatePeer);
+					drop(handlers);
 					self.kill_connection(token, io, false);
 					return;
 				}


### PR DESCRIPTION
***Description***
This PR fixes a double Read lock bug in util network-devp2p Host.
The lock self.handlers is a parking_lot::RwLock.
The first Read locks on self.handlers is on L836 in the function Host::session_readable()
https://github.com/paritytech/parity-ethereum/blob/6b57429d724c954ad5d64c1b1d42c746f8a4d08e/util/network-devp2p/src/host.rs#L836-L845

Then it calls fn Host::kill_connection() and the second Read lock on self.handlers is on L943
https://github.com/paritytech/parity-ethereum/blob/6b57429d724c954ad5d64c1b1d42c746f8a4d08e/util/network-devp2p/src/host.rs#L931-L943

This bug is similar to #11172.

According to parking_lot::RwLock:
“readers trying to acquire the lock will block even if the lock is unlocked when there are writers waiting to acquire the lock.”
“attempts to recursively acquire a read lock within a single thread may result in a deadlock.”

Therefore, once a function (e.g. Host::message() on L1106) requires a write lock in between the execution of the two read locks, a dead lock may happen.

How I fix
Drop the handlers before calling kill_connection().
The fix method is the same as L382 of fn set_non_reserved_mode(), 
dropping the first lock before calling functions that use the second lock.