### PR TITLE
Make InstantSeal Instant again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,12 +2138,14 @@ version = "0.1.0"
 dependencies = [
  "client-traits 0.1.0",
  "common-types 0.1.0",
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "engine 0.1.0",
  "ethcore 1.12.0",
  "ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethjson 0.1.0",
  "keccak-hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "machine 0.1.0",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spec 0.1.0",
  "trace 0.1.0",
@@ -5392,6 +5402,7 @@ dependencies = [
 "checksum combine 3.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fc1d011beeed29187b8db2ac3925c8dd4d3e87db463dc9d2d2833985388fc5bc"
 "checksum criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "938703e165481c8d612ea3479ac8342e5615185db37765162e762ec3523e2fc6"
 "checksum criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccdc6ce8bbe352ca89025bee672aa6d24f4eb8c53e3a8b5d1bc58011da072a2"
+"checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,14 +635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,14 +2130,12 @@ version = "0.1.0"
 dependencies = [
  "client-traits 0.1.0",
  "common-types 0.1.0",
- "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "engine 0.1.0",
  "ethcore 1.12.0",
  "ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethjson 0.1.0",
  "keccak-hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "machine 0.1.0",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spec 0.1.0",
  "trace 0.1.0",
@@ -5402,7 +5392,6 @@ dependencies = [
 "checksum combine 3.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fc1d011beeed29187b8db2ac3925c8dd4d3e87db463dc9d2d2833985388fc5bc"
 "checksum criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "938703e165481c8d612ea3479ac8342e5615185db37765162e762ec3523e2fc6"
 "checksum criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccdc6ce8bbe352ca89025bee672aa6d24f4eb8c53e3a8b5d1bc58011da072a2"
-"checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2128,6 +2128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "instant-seal"
 version = "0.1.0"
 dependencies = [
+ "client-traits 0.1.0",
  "common-types 0.1.0",
  "engine 0.1.0",
  "ethcore 1.12.0",

--- a/ethcore/client-traits/src/lib.rs
+++ b/ethcore/client-traits/src/lib.rs
@@ -146,12 +146,12 @@ pub trait TransactionInfo {
 /// Provides various blockchain information, like block header, chain state etc.
 pub trait BlockChain: ChainInfo + BlockInfo + TransactionInfo {}
 
-/// do we want to force update sealing
+/// Do we want to force update sealing?
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum ForceUpdateSealing {
-	/// Ideally
+	/// Ideally you want to use `No` at all times as `Yes` skips `reseal_required` checks.
 	Yes,
-	/// yes
+	/// Don't skip `reseal_required` checks
 	No
 }
 /// Client facilities used by internally sealing Engines.

--- a/ethcore/client-traits/src/lib.rs
+++ b/ethcore/client-traits/src/lib.rs
@@ -149,7 +149,7 @@ pub trait BlockChain: ChainInfo + BlockInfo + TransactionInfo {}
 /// Client facilities used by internally sealing Engines.
 pub trait EngineClient: Sync + Send + ChainInfo {
 	/// Make a new block and seal it.
-	fn update_sealing(&self);
+	fn update_sealing(&self) -> bool;
 
 	/// Submit a seal for a block in the mining queue.
 	fn submit_seal(&self, block_hash: H256, seal: Vec<Bytes>);

--- a/ethcore/client-traits/src/lib.rs
+++ b/ethcore/client-traits/src/lib.rs
@@ -146,10 +146,18 @@ pub trait TransactionInfo {
 /// Provides various blockchain information, like block header, chain state etc.
 pub trait BlockChain: ChainInfo + BlockInfo + TransactionInfo {}
 
+/// do we want to force update sealing
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum ForceUpdateSealing {
+	/// Ideally
+	Yes,
+	/// yes
+	No
+}
 /// Client facilities used by internally sealing Engines.
 pub trait EngineClient: Sync + Send + ChainInfo {
 	/// Make a new block and seal it.
-	fn update_sealing(&self);
+	fn update_sealing(&self, force: ForceUpdateSealing);
 
 	/// Submit a seal for a block in the mining queue.
 	fn submit_seal(&self, block_hash: H256, seal: Vec<Bytes>);

--- a/ethcore/client-traits/src/lib.rs
+++ b/ethcore/client-traits/src/lib.rs
@@ -149,6 +149,7 @@ pub trait BlockChain: ChainInfo + BlockInfo + TransactionInfo {}
 /// Client facilities used by internally sealing Engines.
 pub trait EngineClient: Sync + Send + ChainInfo {
 	/// Make a new block and seal it.
+	/// returns true if a block was imported and sealed.
 	fn update_sealing(&self) -> bool;
 
 	/// Submit a seal for a block in the mining queue.

--- a/ethcore/client-traits/src/lib.rs
+++ b/ethcore/client-traits/src/lib.rs
@@ -149,8 +149,7 @@ pub trait BlockChain: ChainInfo + BlockInfo + TransactionInfo {}
 /// Client facilities used by internally sealing Engines.
 pub trait EngineClient: Sync + Send + ChainInfo {
 	/// Make a new block and seal it.
-	/// returns true if a block was imported and sealed.
-	fn update_sealing(&self) -> bool;
+	fn update_sealing(&self);
 
 	/// Submit a seal for a block in the mining queue.
 	fn submit_seal(&self, block_hash: H256, seal: Vec<Bytes>);

--- a/ethcore/engine/src/engine.rs
+++ b/ethcore/engine/src/engine.rs
@@ -45,7 +45,6 @@ use machine::{
 use vm::{EnvInfo, Schedule, CallType, ActionValue};
 
 use crate::signer::EngineSigner;
-use std::time::Duration;
 
 /// A system-calling closure. Enacts calls on a block's state from the system address.
 pub type SystemCall<'a> = dyn FnMut(Address, Vec<u8>) -> Result<Vec<u8>, String> + 'a;

--- a/ethcore/engine/src/engine.rs
+++ b/ethcore/engine/src/engine.rs
@@ -45,6 +45,7 @@ use machine::{
 use vm::{EnvInfo, Schedule, CallType, ActionValue};
 
 use crate::signer::EngineSigner;
+use std::time::Duration;
 
 /// A system-calling closure. Enacts calls on a block's state from the system address.
 pub type SystemCall<'a> = dyn FnMut(Address, Vec<u8>) -> Result<Vec<u8>, String> + 'a;
@@ -188,10 +189,13 @@ pub trait Engine: Sync + Send {
 	/// Returns the engine's current sealing state.
 	fn sealing_state(&self) -> SealingState { SealingState::External }
 
-	/// Called in `chain_new_blocks` if there are local pending txs
+	/// Called in `miner.chain_new_blocks` if the engine wishes to `update_sealing`
+	/// after a block was recently sealed, and there are local pending tx in the pool.
 	///
-	/// Does nothing by default
-	fn maybe_update_sealing(&self) {}
+	/// returns false by default
+	fn should_reseal_on_update(&self) -> bool {
+		false
+	}
 
 	/// Attempt to seal the block internally.
 	///

--- a/ethcore/engine/src/engine.rs
+++ b/ethcore/engine/src/engine.rs
@@ -189,7 +189,7 @@ pub trait Engine: Sync + Send {
 	fn sealing_state(&self) -> SealingState { SealingState::External }
 
 	/// Called in `miner.chain_new_blocks` if the engine wishes to `update_sealing`
-	/// after a block was recently sealed, and there are local pending tx in the pool.
+	/// after a block was recently sealed.
 	///
 	/// returns false by default
 	fn should_reseal_on_update(&self) -> bool {

--- a/ethcore/engine/src/engine.rs
+++ b/ethcore/engine/src/engine.rs
@@ -188,6 +188,11 @@ pub trait Engine: Sync + Send {
 	/// Returns the engine's current sealing state.
 	fn sealing_state(&self) -> SealingState { SealingState::External }
 
+	/// Called in `chain_new_blocks` if there are local pending txs
+	///
+	/// Does nothing by default
+	fn maybe_update_sealing(&self) {}
+
 	/// Attempt to seal the block internally.
 	///
 	/// If `Some` is returned, then you get a valid seal.

--- a/ethcore/engines/authority-round/src/lib.rs
+++ b/ethcore/engines/authority-round/src/lib.rs
@@ -39,7 +39,7 @@ use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering as AtomicOrdering};
 use std::sync::{Weak, Arc};
 use std::time::{UNIX_EPOCH, Duration};
 
-use client_traits::EngineClient;
+use client_traits::{EngineClient, ForceUpdateSealing};
 use engine::{Engine, ConstructedVerifier};
 use block_reward::{self, BlockRewardContract, RewardKind};
 use ethjson;
@@ -989,7 +989,7 @@ impl IoHandler<()> for TransitionHandler {
 				self.step.can_propose.store(true, AtomicOrdering::SeqCst);
 				if let Some(ref weak) = *self.client.read() {
 					if let Some(c) = weak.upgrade() {
-						c.update_sealing();
+						c.update_sealing(ForceUpdateSealing::No);
 					}
 				}
 			}
@@ -1017,7 +1017,7 @@ impl Engine for AuthorityRound {
 		self.step.can_propose.store(true, AtomicOrdering::SeqCst);
 		if let Some(ref weak) = *self.client.read() {
 			if let Some(c) = weak.upgrade() {
-				c.update_sealing();
+				c.update_sealing(ForceUpdateSealing::No);
 			}
 		}
 	}

--- a/ethcore/engines/clique/src/lib.rs
+++ b/ethcore/engines/clique/src/lib.rs
@@ -66,7 +66,7 @@ use std::{
 	time::{self, Instant, Duration, SystemTime, UNIX_EPOCH},
 };
 
-use client_traits::EngineClient;
+use client_traits::{EngineClient, ForceUpdateSealing};
 use engine::{
 	Engine,
 	signer::EngineSigner,
@@ -780,7 +780,7 @@ impl Engine for Clique {
 		if self.signer.read().is_some() {
 			if let Some(ref weak) = *self.client.read() {
 				if let Some(c) = weak.upgrade() {
-					c.update_sealing();
+					c.update_sealing(ForceUpdateSealing::No);
 				}
 			}
 		}

--- a/ethcore/engines/instant-seal/Cargo.toml
+++ b/ethcore/engines/instant-seal/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
+client-traits = { path = "../../client-traits" }
 common-types = { path = "../../types" }
 engine = { path = "../../engine" }
 ethjson = { path = "../../../json" }
-client-traits = { path = "../../client-traits" }
 ethereum-types = "0.8.0"
 keccak-hash = "0.4.0"
 parking_lot = "0.9"

--- a/ethcore/engines/instant-seal/Cargo.toml
+++ b/ethcore/engines/instant-seal/Cargo.toml
@@ -13,6 +13,8 @@ ethjson = { path = "../../../json" }
 client-traits = { path = "../../client-traits" }
 ethereum-types = "0.8.0"
 keccak-hash = "0.4.0"
+parking_lot = "0.9"
+crossbeam-channel = "0.3.9"
 machine = { path = "../../machine" }
 trace = { path = "../../trace" }
 

--- a/ethcore/engines/instant-seal/Cargo.toml
+++ b/ethcore/engines/instant-seal/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-3.0"
 common-types = { path = "../../types" }
 engine = { path = "../../engine" }
 ethjson = { path = "../../../json" }
+client-traits = { path = "../../client-traits" }
 ethereum-types = "0.8.0"
 keccak-hash = "0.4.0"
 machine = { path = "../../machine" }

--- a/ethcore/engines/instant-seal/Cargo.toml
+++ b/ethcore/engines/instant-seal/Cargo.toml
@@ -13,8 +13,6 @@ engine = { path = "../../engine" }
 ethjson = { path = "../../../json" }
 ethereum-types = "0.8.0"
 keccak-hash = "0.4.0"
-parking_lot = "0.9"
-crossbeam-channel = "0.3.9"
 machine = { path = "../../machine" }
 trace = { path = "../../trace" }
 

--- a/ethcore/engines/instant-seal/src/lib.rs
+++ b/ethcore/engines/instant-seal/src/lib.rs
@@ -15,8 +15,6 @@
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Weak, Arc};
-use std::thread;
 
 use common_types::{
 	header::Header,
@@ -29,14 +27,10 @@ use common_types::{
 };
 use engine::Engine;
 use ethjson;
-use parking_lot::RwLock;
-use client_traits::EngineClient;
 use machine::{
 	ExecutedBlock,
 	Machine
 };
-use std::time::Duration;
-use crossbeam_channel::{bounded, Sender};
 
 
 /// `InstantSeal` params.

--- a/ethcore/engines/instant-seal/src/lib.rs
+++ b/ethcore/engines/instant-seal/src/lib.rs
@@ -27,6 +27,8 @@ use common_types::{
 };
 use engine::Engine;
 use ethjson;
+use std::sync::Weak;
+use client_traits::EngineClient;
 use machine::{
 	ExecutedBlock,
 	Machine
@@ -73,6 +75,10 @@ impl Engine for InstantSeal {
 	fn machine(&self) -> &Machine { &self.machine }
 
 	fn sealing_state(&self) -> SealingState { SealingState::Ready }
+
+	fn register_client(&self, _client: Weak<dyn EngineClient>) {
+
+	}
 
 	fn generate_seal(&self, block: &ExecutedBlock, _parent: &Header) -> Seal {
 		if !block.transactions.is_empty() {

--- a/ethcore/engines/validator-set/src/multi.rs
+++ b/ethcore/engines/validator-set/src/multi.rs
@@ -161,7 +161,7 @@ mod tests {
 		ids::BlockId,
 		verification::Unverified,
 	};
-	use client_traits::{BlockChainClient, BlockInfo, ChainInfo, ImportBlock, EngineClient};
+	use client_traits::{BlockChainClient, BlockInfo, ChainInfo, ImportBlock, EngineClient, ForceUpdateSealing};
 	use engine::EpochChange;
 	use ethcore::{
 		miner::{self, MinerService},
@@ -174,7 +174,6 @@ mod tests {
 
 	use crate::ValidatorSet;
 	use super::Multi;
-	use ethcore::miner::ForceUpdateSealing;
 
 	#[test]
 	fn uses_current_set() {

--- a/ethcore/engines/validator-set/src/multi.rs
+++ b/ethcore/engines/validator-set/src/multi.rs
@@ -174,6 +174,7 @@ mod tests {
 
 	use crate::ValidatorSet;
 	use super::Multi;
+	use ethcore::miner::ForceUpdateSealing;
 
 	#[test]
 	fn uses_current_set() {
@@ -191,24 +192,24 @@ mod tests {
 		let signer = Box::new((tap.clone(), v1, "".into()));
 		client.miner().set_author(miner::Author::Sealer(signer));
 		client.transact_contract(Default::default(), Default::default()).unwrap();
-		EngineClient::update_sealing(&*client);
+		EngineClient::update_sealing(&*client, ForceUpdateSealing::No);
 		assert_eq!(client.chain_info().best_block_number, 0);
 		// Right signer for the first block.
 		let signer = Box::new((tap.clone(), v0, "".into()));
 		client.miner().set_author(miner::Author::Sealer(signer));
-		EngineClient::update_sealing(&*client);
+		EngineClient::update_sealing(&*client, ForceUpdateSealing::No);
 		assert_eq!(client.chain_info().best_block_number, 1);
 		// This time v0 is wrong.
 		client.transact_contract(Default::default(), Default::default()).unwrap();
-		EngineClient::update_sealing(&*client);
+		EngineClient::update_sealing(&*client, ForceUpdateSealing::No);
 		assert_eq!(client.chain_info().best_block_number, 1);
 		let signer = Box::new((tap.clone(), v1, "".into()));
 		client.miner().set_author(miner::Author::Sealer(signer));
-		EngineClient::update_sealing(&*client);
+		EngineClient::update_sealing(&*client, ForceUpdateSealing::No);
 		assert_eq!(client.chain_info().best_block_number, 2);
 		// v1 is still good.
 		client.transact_contract(Default::default(), Default::default()).unwrap();
-		EngineClient::update_sealing(&*client);
+		EngineClient::update_sealing(&*client, ForceUpdateSealing::No);
 		assert_eq!(client.chain_info().best_block_number, 3);
 
 		// Check syncing.

--- a/ethcore/engines/validator-set/src/safe_contract.rs
+++ b/ethcore/engines/validator-set/src/safe_contract.rs
@@ -464,7 +464,7 @@ mod tests {
 		transaction::{Transaction, Action},
 		verification::Unverified,
 	};
-	use client_traits::{BlockInfo, ChainInfo, ImportBlock, EngineClient};
+	use client_traits::{BlockInfo, ChainInfo, ImportBlock, EngineClient, ForceUpdateSealing};
 	use engine::{EpochChange, Proof};
 	use ethcore::{
 		miner::{self, MinerService},
@@ -478,7 +478,6 @@ mod tests {
 
 	use super::super::ValidatorSet;
 	use super::{ValidatorSafeContract, EVENT_NAME_HASH};
-	use ethcore::miner::ForceUpdateSealing;
 
 	#[test]
 	fn fetches_validators() {

--- a/ethcore/engines/validator-set/src/safe_contract.rs
+++ b/ethcore/engines/validator-set/src/safe_contract.rs
@@ -478,6 +478,7 @@ mod tests {
 
 	use super::super::ValidatorSet;
 	use super::{ValidatorSafeContract, EVENT_NAME_HASH};
+	use ethcore::miner::ForceUpdateSealing;
 
 	#[test]
 	fn fetches_validators() {
@@ -513,7 +514,7 @@ mod tests {
 			data: "bfc708a000000000000000000000000082a978b3f5962a5b0957d9ee9eef472ee55b42f1".from_hex().unwrap(),
 		}.sign(&s0, Some(chain_id));
 		client.miner().import_own_transaction(client.as_ref(), tx.into()).unwrap();
-		EngineClient::update_sealing(&*client);
+		EngineClient::update_sealing(&*client, ForceUpdateSealing::No);
 		assert_eq!(client.chain_info().best_block_number, 1);
 		// Add "1" validator back in.
 		let tx = Transaction {
@@ -525,14 +526,14 @@ mod tests {
 			data: "4d238c8e00000000000000000000000082a978b3f5962a5b0957d9ee9eef472ee55b42f1".from_hex().unwrap(),
 		}.sign(&s0, Some(chain_id));
 		client.miner().import_own_transaction(client.as_ref(), tx.into()).unwrap();
-		EngineClient::update_sealing(&*client);
+		EngineClient::update_sealing(&*client, ForceUpdateSealing::No);
 		// The transaction is not yet included so still unable to seal.
 		assert_eq!(client.chain_info().best_block_number, 1);
 
 		// Switch to the validator that is still there.
 		let signer = Box::new((tap.clone(), v0, "".into()));
 		client.miner().set_author(miner::Author::Sealer(signer));
-		EngineClient::update_sealing(&*client);
+		EngineClient::update_sealing(&*client, ForceUpdateSealing::No);
 		assert_eq!(client.chain_info().best_block_number, 2);
 		// Switch back to the added validator, since the state is updated.
 		let signer = Box::new((tap.clone(), v1, "".into()));
@@ -546,7 +547,7 @@ mod tests {
 			data: Vec::new(),
 		}.sign(&s0, Some(chain_id));
 		client.miner().import_own_transaction(client.as_ref(), tx.into()).unwrap();
-		EngineClient::update_sealing(&*client);
+		EngineClient::update_sealing(&*client, ForceUpdateSealing::No);
 		// Able to seal again.
 		assert_eq!(client.chain_info().best_block_number, 3);
 

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -48,6 +48,7 @@ use self::header_chain::{AncestryIter, HeaderChain, HardcodedSync};
 use cache::Cache;
 
 pub use self::service::Service;
+use client_traits::ForceUpdateSealing;
 
 mod header_chain;
 mod service;
@@ -626,7 +627,7 @@ impl<T: ChainDataFetcher> client_traits::ChainInfo for Client<T> {
 }
 
 impl<T: ChainDataFetcher> client_traits::EngineClient for Client<T> {
-	fn update_sealing(&self) {}
+	fn update_sealing(&self, _force: ForceUpdateSealing) {}
 	fn submit_seal(&self, _block_hash: H256, _seal: Vec<Vec<u8>>) { }
 	fn broadcast_consensus_message(&self, _message: Vec<u8>) { }
 

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -626,7 +626,7 @@ impl<T: ChainDataFetcher> client_traits::ChainInfo for Client<T> {
 }
 
 impl<T: ChainDataFetcher> client_traits::EngineClient for Client<T> {
-	fn update_sealing(&self) -> bool { false }
+	fn update_sealing(&self) {}
 	fn submit_seal(&self, _block_hash: H256, _seal: Vec<Vec<u8>>) { }
 	fn broadcast_consensus_message(&self, _message: Vec<u8>) { }
 

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -626,7 +626,7 @@ impl<T: ChainDataFetcher> client_traits::ChainInfo for Client<T> {
 }
 
 impl<T: ChainDataFetcher> client_traits::EngineClient for Client<T> {
-	fn update_sealing(&self) { }
+	fn update_sealing(&self) -> bool { false }
 	fn submit_seal(&self, _block_hash: H256, _seal: Vec<Vec<u8>>) { }
 	fn broadcast_consensus_message(&self, _message: Vec<u8>) { }
 

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2367,7 +2367,9 @@ impl ImportSealedBlock for Client {
 		let raw = block.rlp_bytes();
 		let header = block.header.clone();
 		let hash = header.hash();
-		self.notify(|n| n.block_pre_import(&raw, &hash, header.difficulty()));
+		self.notify(|n| {
+			n.block_pre_import(&raw, &hash, header.difficulty())
+		});
 
 		let route = {
 			// Do a super duper basic verification to detect potential bugs
@@ -2455,19 +2457,22 @@ impl ::miner::TransactionVerifierClient for Client {}
 impl ::miner::BlockChainClient for Client {}
 
 impl client_traits::EngineClient for Client {
-	fn update_sealing(&self) {
+	fn update_sealing(&self) -> bool {
 		self.importer.miner.update_sealing(self)
 	}
 
 	fn submit_seal(&self, block_hash: H256, seal: Vec<Bytes>) {
-		let import = self.importer.miner.submit_seal(block_hash, seal).and_then(|block| self.import_sealed_block(block));
+		let import = self.importer.miner.submit_seal(block_hash, seal)
+			.and_then(|block| self.import_sealed_block(block));
 		if let Err(err) = import {
 			warn!(target: "poa", "Wrong internal seal submission! {:?}", err);
 		}
 	}
 
 	fn broadcast_consensus_message(&self, message: Bytes) {
-		self.notify(|notify| notify.broadcast(ChainMessageType::Consensus(message.clone())));
+		self.notify(|notify| {
+			notify.broadcast(ChainMessageType::Consensus(message.clone()))
+		});
 	}
 
 	fn epoch_transition_for(&self, parent_hash: H256) -> Option<EpochTransition> {
@@ -2593,13 +2598,21 @@ impl ImportExportBlocks for Client {
 			if i % 10000 == 0 {
 				info!("#{}", i);
 			}
-			let b = self.block(BlockId::Number(i)).ok_or("Error exporting incomplete chain")?.into_inner();
+			let b = self.block(BlockId::Number(i))
+				.ok_or("Error exporting incomplete chain")?
+				.into_inner();
 			match format {
 				DataFormat::Binary => {
-					out.write(&b).map_err(|e| format!("Couldn't write to stream. Cause: {}", e))?;
+					out.write(&b)
+						.map_err(|e| {
+							format!("Couldn't write to stream. Cause: {}", e)
+						})?;
 				}
 				DataFormat::Hex => {
-					out.write_fmt(format_args!("{}\n", b.pretty())).map_err(|e| format!("Couldn't write to stream. Cause: {}", e))?;
+					out.write_fmt(format_args!("{}\n", b.pretty()))
+						.map_err(|e| {
+							format!("Couldn't write to stream. Cause: {}", e)
+						})?;
 				}
 			}
 		}
@@ -2619,7 +2632,10 @@ impl ImportExportBlocks for Client {
 		let format = match format {
 			Some(format) => format,
 			None => {
-				first_read = source.read(&mut first_bytes).map_err(|_| "Error reading from the file/stream.")?;
+				first_read = source.read(&mut first_bytes)
+					.map_err(|_| {
+						"Error reading from the file/stream."
+					})?;
 				match first_bytes[0] {
 					0xf9 => DataFormat::Binary,
 					_ => DataFormat::Hex,
@@ -2630,7 +2646,9 @@ impl ImportExportBlocks for Client {
 		let do_import = |bytes: Vec<u8>| {
 			let block = Unverified::from_rlp(bytes).map_err(|_| "Invalid block rlp")?;
 			let number = block.header.number();
-			while self.queue_info().is_full() { std::thread::sleep(Duration::from_secs(1)); }
+			while self.queue_info().is_full() {
+				std::thread::sleep(Duration::from_secs(1));
+			}
 			match self.import_block(block) {
 				Err(EthcoreError::Import(ImportError::AlreadyInChain)) => {
 					trace!("Skipping block #{}: already in chain.", number);
@@ -2651,33 +2669,45 @@ impl ImportExportBlocks for Client {
 					} else {
 						let mut bytes = vec![0; READAHEAD_BYTES];
 						let n = source.read(&mut bytes)
-							.map_err(|err| format!("Error reading from the file/stream: {:?}", err))?;
+							.map_err(|err| {
+								format!("Error reading from the file/stream: {:?}", err)
+							})?;
 						(bytes, n)
 					};
 					if n == 0 { break; }
 					first_read = 0;
 					let s = PayloadInfo::from(&bytes)
-						.map_err(|e| format!("Invalid RLP in the file/stream: {:?}", e))?.total();
+						.map_err(|e| {
+							format!("Invalid RLP in the file/stream: {:?}", e)
+						})?.total();
 					bytes.resize(s, 0);
 					source.read_exact(&mut bytes[n..])
-						.map_err(|err| format!("Error reading from the file/stream: {:?}", err))?;
+						.map_err(|err| {
+							format!("Error reading from the file/stream: {:?}", err)
+						})?;
 					do_import(bytes)?;
 				}
 			}
 			DataFormat::Hex => {
 				for line in BufReader::new(source).lines() {
 					let s = line
-						.map_err(|err| format!("Error reading from the file/stream: {:?}", err))?;
+						.map_err(|err| {
+							format!("Error reading from the file/stream: {:?}", err)
+						})?;
 					let s = if first_read > 0 {
 						from_utf8(&first_bytes)
-							.map_err(|err| format!("Invalid UTF-8: {:?}", err))?
+							.map_err(|err| {
+								format!("Invalid UTF-8: {:?}", err)
+							})?
 							.to_owned() + &(s[..])
 					} else {
 						s
 					};
 					first_read = 0;
 					let bytes = s.from_hex()
-						.map_err(|err| format!("Invalid hex in file/stream: {:?}", err))?;
+						.map_err(|err| {
+							format!("Invalid hex in file/stream: {:?}", err)
+						})?;
 					do_import(bytes)?;
 				}
 			}

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2457,7 +2457,7 @@ impl ::miner::TransactionVerifierClient for Client {}
 impl ::miner::BlockChainClient for Client {}
 
 impl client_traits::EngineClient for Client {
-	fn update_sealing(&self) -> bool {
+	fn update_sealing(&self) {
 		self.importer.miner.update_sealing(self)
 	}
 

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -78,7 +78,8 @@ use client_traits::{
 	StateClient,
 	StateOrBlock,
 	Tick,
-	TransactionInfo
+	TransactionInfo,
+	ForceUpdateSealing
 };
 use db::{keys::BlockDetails, Readable, Writable};
 use engine::Engine;
@@ -2457,8 +2458,8 @@ impl ::miner::TransactionVerifierClient for Client {}
 impl ::miner::BlockChainClient for Client {}
 
 impl client_traits::EngineClient for Client {
-	fn update_sealing(&self) {
-		self.importer.miner.update_sealing(self)
+	fn update_sealing(&self, force: ForceUpdateSealing) {
+		self.importer.miner.update_sealing(self, force)
 	}
 
 	fn submit_seal(&self, block_hash: H256, seal: Vec<Bytes>) {

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -1416,13 +1416,13 @@ impl miner::MinerService for Miner {
 				});
 		}
 
-		if has_new_best_block {
+		if has_new_best_block || (imported.len() > 0 && self.options.reseal_on_uncle)  {
 			// Reset `next_allowed_reseal` in case a block is imported.
 			// Even if min_period is high, we will always attempt to create
 			// new pending block.
 			self.sealing.lock().next_allowed_reseal = Instant::now();
 
-			if !is_internal_import && imported.len() > 0 && self.options.reseal_on_uncle {
+			if !is_internal_import {
 				// --------------------------------------------------------------------------
 				// | NOTE Code below requires sealing locks.                                |
 				// | Make sure to release the locks before calling that method.             |

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -1446,7 +1446,6 @@ impl miner::MinerService for Miner {
 				let engine = self.engine.clone();
 				let accounts = self.accounts.clone();
 				let service_transaction_checker = self.service_transaction_checker.clone();
-				let cloned_tx_queue = self.transaction_queue.clone();
 				let cull = move |chain: &Client| {
 					let client = PoolClient::new(
 						chain,
@@ -1456,7 +1455,7 @@ impl miner::MinerService for Miner {
 						service_transaction_checker.as_ref(),
 					);
 					queue.cull(client);
-					if cloned_tx_queue.all_transaction_hashes().len() > 0 {
+					if queue.has_local_pending_transactions() {
 						if !chain.update_sealing() {
 							// TODO: call some method that waits `reseal_min_period` and re-tries
 							// `update_sealing` again
@@ -1469,7 +1468,7 @@ impl miner::MinerService for Miner {
 				}
 			} else {
 				self.transaction_queue.cull(client);
-				if self.transaction_queue.all_transaction_hashes().len() > 0 {
+				if self.transaction_queue.has_local_pending_transactions() {
 					if !self.update_sealing(chain) {
 						// TODO: call some method that waits `reseal_min_period` and tries
 						// `update_sealing` again

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -1453,6 +1453,7 @@ impl miner::MinerService for Miner {
 					);
 					queue.cull(client);
 					if engine.should_reseal_on_update() {
+						// force update_sealing here to skip `reseal_required` checks
 						chain.update_sealing(ForceUpdateSealing::Yes);
 					}
 				};
@@ -1463,6 +1464,7 @@ impl miner::MinerService for Miner {
 			} else {
 				self.transaction_queue.cull(client);
 				if self.engine.should_reseal_on_update() {
+					// force update_sealing here to skip `reseal_required` checks
 					self.update_sealing(chain, ForceUpdateSealing::Yes);
 				}
 			}

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -1416,7 +1416,7 @@ impl miner::MinerService for Miner {
 				});
 		}
 
-		if has_new_best_block || (imported.len() > 0 && self.options.reseal_on_uncle)  {
+		if has_new_best_block || (imported.len() > 0 && self.options.reseal_on_uncle) {
 			// Reset `next_allowed_reseal` in case a block is imported.
 			// Even if min_period is high, we will always attempt to create
 			// new pending block.
@@ -1429,7 +1429,9 @@ impl miner::MinerService for Miner {
 				// --------------------------------------------------------------------------
 				self.update_sealing(chain, ForceUpdateSealing::No);
 			}
+		}
 
+		if has_new_best_block {
 			// Make sure to cull transactions after we update sealing.
 			// Not culling won't lead to old transactions being added to the block
 			// (thanks to Ready), but culling can take significant amount of time,

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -58,7 +58,7 @@ use using_queue::{UsingQueue, GetAction};
 
 use block::{ClosedBlock, SealedBlock};
 use client::{BlockProducer, SealedBlockImporter, Client};
-use client_traits::{BlockChain, ChainInfo, EngineClient, Nonce, TransactionInfo};
+use client_traits::{BlockChain, ChainInfo, Nonce, TransactionInfo};
 use engine::{Engine, signer::EngineSigner};
 use machine::executive::contract_address;
 use spec::Spec;
@@ -1456,10 +1456,7 @@ impl miner::MinerService for Miner {
 					);
 					queue.cull(client);
 					if queue.has_local_pending_transactions() {
-						if !chain.update_sealing() {
-							// TODO: call some method that waits `reseal_min_period` and re-tries
-							// `update_sealing` again
-						}
+						engine.maybe_update_sealing();
 					}
 				};
 
@@ -1469,10 +1466,7 @@ impl miner::MinerService for Miner {
 			} else {
 				self.transaction_queue.cull(client);
 				if self.transaction_queue.has_local_pending_transactions() {
-					if !self.update_sealing(chain) {
-						// TODO: call some method that waits `reseal_min_period` and tries
-						// `update_sealing` again
-					}
+					self.engine.maybe_update_sealing()
 				}
 			}
 		}

--- a/ethcore/src/miner/mod.rs
+++ b/ethcore/src/miner/mod.rs
@@ -47,7 +47,7 @@ use types::{
 
 use call_contract::CallContract;
 use registrar::RegistrarClient;
-use client_traits::{BlockChain, ChainInfo, AccountData, Nonce, ScheduleInfo};
+use client_traits::{BlockChain, ChainInfo, AccountData, Nonce, ScheduleInfo, ForceUpdateSealing};
 use account_state::state::StateInfo;
 
 use crate::{
@@ -87,7 +87,7 @@ pub trait MinerService : Send + Sync {
 		where C: BlockChain + CallContract + BlockProducer + SealedBlockImporter + Nonce + Sync;
 
 	/// Update current pending block
-	fn update_sealing<C>(&self, chain: &C)
+	fn update_sealing<C>(&self, chain: &C, force: ForceUpdateSealing)
 		where C: BlockChain + CallContract + BlockProducer + SealedBlockImporter + Nonce + Sync;
 
 	// Notifications

--- a/ethcore/src/miner/mod.rs
+++ b/ethcore/src/miner/mod.rs
@@ -87,7 +87,7 @@ pub trait MinerService : Send + Sync {
 		where C: BlockChain + CallContract + BlockProducer + SealedBlockImporter + Nonce + Sync;
 
 	/// Update current pending block
-	fn update_sealing<C>(&self, chain: &C)
+	fn update_sealing<C>(&self, chain: &C) -> bool
 		where C: BlockChain + CallContract + BlockProducer + SealedBlockImporter + Nonce + Sync;
 
 	// Notifications

--- a/ethcore/src/miner/mod.rs
+++ b/ethcore/src/miner/mod.rs
@@ -87,7 +87,7 @@ pub trait MinerService : Send + Sync {
 		where C: BlockChain + CallContract + BlockProducer + SealedBlockImporter + Nonce + Sync;
 
 	/// Update current pending block
-	fn update_sealing<C>(&self, chain: &C) -> bool
+	fn update_sealing<C>(&self, chain: &C)
 		where C: BlockChain + CallContract + BlockProducer + SealedBlockImporter + Nonce + Sync;
 
 	// Notifications

--- a/ethcore/src/test_helpers/test_client.rs
+++ b/ethcore/src/test_helpers/test_client.rs
@@ -963,7 +963,7 @@ impl ProvingBlockChainClient for TestBlockChainClient {
 }
 
 impl client_traits::EngineClient for TestBlockChainClient {
-	fn update_sealing(&self) -> bool {
+	fn update_sealing(&self)  {
 		self.miner.update_sealing(self)
 	}
 

--- a/ethcore/src/test_helpers/test_client.rs
+++ b/ethcore/src/test_helpers/test_client.rs
@@ -72,7 +72,7 @@ use client::{
 use client_traits::{
 	BlockInfo, Nonce, Balance, ChainInfo, TransactionInfo, BlockChainClient, ImportBlock,
 	AccountData, BlockChain, IoClient, BadBlocks, ScheduleInfo, StateClient, ProvingBlockChainClient,
-	StateOrBlock
+	StateOrBlock, ForceUpdateSealing
 };
 use engine::Engine;
 use machine::executed::Executed;
@@ -963,8 +963,8 @@ impl ProvingBlockChainClient for TestBlockChainClient {
 }
 
 impl client_traits::EngineClient for TestBlockChainClient {
-	fn update_sealing(&self)  {
-		self.miner.update_sealing(self)
+	fn update_sealing(&self, force: ForceUpdateSealing)  {
+		self.miner.update_sealing(self, force)
 	}
 
 	fn submit_seal(&self, block_hash: H256, seal: Vec<Bytes>) {

--- a/ethcore/src/test_helpers/test_client.rs
+++ b/ethcore/src/test_helpers/test_client.rs
@@ -963,7 +963,7 @@ impl ProvingBlockChainClient for TestBlockChainClient {
 }
 
 impl client_traits::EngineClient for TestBlockChainClient {
-	fn update_sealing(&self) {
+	fn update_sealing(&self) -> bool {
 		self.miner.update_sealing(self)
 	}
 

--- a/miner/src/pool/listener.rs
+++ b/miner/src/pool/listener.rs
@@ -105,11 +105,17 @@ impl TransactionsPoolNotifier {
 				.map(|(hash, _)| hash)
 				.collect()
 		);
-		self.pending_listeners.retain(|listener| listener.unbounded_send(to_pending_send.clone()).is_ok());
+		self.pending_listeners.retain(|listener| {
+			listener.unbounded_send(to_pending_send.clone()).is_ok()
+		});
 
-		let to_full_send = Arc::new(std::mem::replace(&mut self.tx_statuses, Vec::new()));
+		let to_full_send = Arc::new(
+			std::mem::replace(&mut self.tx_statuses, Vec::new())
+		);
 		self.full_listeners
-			.retain(|listener| listener.unbounded_send(to_full_send.clone()).is_ok());
+			.retain(|listener| {
+				listener.unbounded_send(to_full_send.clone()).is_ok()
+			});
 	}
 }
 

--- a/rpc/src/v1/tests/helpers/miner_service.rs
+++ b/rpc/src/v1/tests/helpers/miner_service.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use bytes::Bytes;
-use client_traits::{Nonce, StateClient};
+use client_traits::{Nonce, StateClient, ForceUpdateSealing};
 use engine::{Engine, signer::EngineSigner};
 use ethcore::block::SealedBlock;
 use ethcore::client::{PrepareOpenBlock, EngineInfo};
@@ -192,7 +192,7 @@ impl MinerService for TestMinerService {
 	}
 
 	/// New chain head event. Restart mining operation.
-	fn update_sealing<C>(&self, _chain: &C) {
+	fn update_sealing<C>(&self, _chain: &C, _force: ForceUpdateSealing) {
 		unimplemented!();
 	}
 


### PR DESCRIPTION
[this](https://github.com/paritytech/parity-ethereum/pull/10995/files#diff-662498a077300e2e5277a2281eb3be28R1432-R1434) call to `update_sealing` calls `requires_reseal`

https://github.com/paritytech/parity-ethereum/blob/6960d35abb9f11c27b47226e402ec617bfe585f1/ethcore/src/miner/miner.rs#L1266-L1276

and `requires_reseal` does a few checks and updates `SealingWork.next_allowed_reseal`

https://github.com/paritytech/parity-ethereum/blob/6960d35abb9f11c27b47226e402ec617bfe585f1/ethcore/src/miner/miner.rs#L637-L663

for `InstantSeal` `sealing_state()` is always `SealingState::Ready` 

https://github.com/paritytech/parity-ethereum/blob/6960d35abb9f11c27b47226e402ec617bfe585f1/ethcore/engines/instant-seal/src/lib.rs#L75

so `should_disable_sealing` would be `false` for `InstantSeal` and so `next_allowed_reseal` is updated based on `reseal_min_period`




Now `update_sealing` calls `Miner.seal_and_import_block_internally` which in turn calls `ImportSealedBlock::import_sealed_block` which in turn calls `Miner.chain_new_blocks`.



 `Miner.chain_new_blocks` resets `next_allowed_reseal` to `Instant::now()` if a block was successfully imported.

https://github.com/paritytech/parity-ethereum/blob/6993ec95312f3ee446345ecb2591f0c66a9b4fcb/ethcore/src/miner/miner.rs#L1415-L1420


Previously `update_sealing` was called immediately after an internal import with the hopes of sealing a new block with local transactions (#9660) but it did so without the knowledge of the transaction_queue. And so if there were no transactions to seal, `next_allowed_reseal` is updated, but `chain_new_blocks` is never called to reset it back to `Instant::now()`

And now the next time a transaction is sent, it won't trigger a block sealing because `reseal_allowed()` returns `false`

https://github.com/paritytech/parity-ethereum/blob/6960d35abb9f11c27b47226e402ec617bfe585f1/ethcore/src/miner/miner.rs#L1009-L1011

https://github.com/paritytech/parity-ethereum/blob/6960d35abb9f11c27b47226e402ec617bfe585f1/ethcore/src/miner/miner.rs#L233-L238

This PR adds a new method to the `Engine` trait `should_reseal_on_update` and checks if there are local pending transactions before calling `update_sealing` after a block import.

`should_reseal_on_update` tells the miner that the engine is interested in sealing a new block if there are local pending transactions. 

closes #11173