### PR TITLE
Made ecrecover implementation trait public

### DIFF
--- a/ethcore/builtin/src/lib.rs
+++ b/ethcore/builtin/src/lib.rs
@@ -37,7 +37,7 @@ use parity_crypto::digest;
 use eip_152::compress;
 
 /// Native implementation of a built-in contract.
-trait Implementation: Send + Sync {
+pub trait Implementation: Send + Sync {
 	/// execute this built-in on the given input, writing to the given output.
 	fn execute(&self, input: &[u8], output: &mut BytesRef) -> Result<(), &'static str>;
 }
@@ -308,7 +308,7 @@ fn ethereum_builtin(name: &str) -> Result<Box<dyn Implementation>, EthcoreError>
 struct Identity;
 
 #[derive(Debug)]
-struct EcRecover;
+pub struct EcRecover;
 
 #[derive(Debug)]
 struct Sha256;

--- a/ethcore/builtin/src/lib.rs
+++ b/ethcore/builtin/src/lib.rs
@@ -305,31 +305,31 @@ fn ethereum_builtin(name: &str) -> Result<Box<dyn Implementation>, EthcoreError>
 // - blake2_f (The Blake2 compression function F, EIP-152)
 
 #[derive(Debug)]
-struct Identity;
+pub struct Identity;
 
 #[derive(Debug)]
 pub struct EcRecover;
 
 #[derive(Debug)]
-struct Sha256;
+pub struct Sha256;
 
 #[derive(Debug)]
-struct Ripemd160;
+pub struct Ripemd160;
 
 #[derive(Debug)]
-struct Modexp;
+pub struct Modexp;
 
 #[derive(Debug)]
-struct Bn128Add;
+pub struct Bn128Add;
 
 #[derive(Debug)]
-struct Bn128Mul;
+pub struct Bn128Mul;
 
 #[derive(Debug)]
-struct Bn128Pairing;
+pub struct Bn128Pairing;
 
 #[derive(Debug)]
-struct Blake2F;
+pub struct Blake2F;
 
 impl Implementation for Identity {
 	fn execute(&self, input: &[u8], output: &mut BytesRef) -> Result<(), &'static str> {


### PR DESCRIPTION
Making the trait public enables its use in FFIs to integrate with the `ecrecover` functionality.

In particular this has been done in [aeternity/ecrecover](https://github.com/aeternity/ecrecover)