### PR TITLE
Remove unused macro_use.

### DIFF
--- a/secret-store/src/lib.rs
+++ b/secret-store/src/lib.rs
@@ -42,7 +42,6 @@ extern crate tokio_service;
 extern crate url;
 extern crate jsonrpc_server_utils;
 
-#[macro_use]
 extern crate ethabi_derive;
 #[macro_use]
 extern crate ethabi_contract;


### PR DESCRIPTION
This caused a warning during the build.