### PR TITLE
Type annotation for next_key() matching of json filter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ To start Parity Ethereum as a regular user using `systemd` init:
 
 ## 4. Testing <a id="chapter-004"></a>
 
-You can run tests with the following commands:
+Download the required test files: `git submodule update --init --recursive`. You can run tests with the following commands:
 
 * **All** packages
   ```

--- a/ethcore/src/miner/filter_options.rs
+++ b/ethcore/src/miner/filter_options.rs
@@ -160,8 +160,8 @@ impl<'de> Deserialize<'de> for FilterOptions {
                 M: MapAccess<'de>,
             {
                 let mut filter = FilterOptions::default();
-                while let Some(key) = map.next_key()? {
-                    match key {
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
                         "from" => {
                             filter.from = map.validate_from()?;
                         },
@@ -221,8 +221,8 @@ impl<'de> Deserialize<'de> for FilterOptions {
                         let mut counter = 0;
                         let mut f_op = Wrapper::O(FilterOperator::Any);
 
-                        while let Some(key) = map.next_key()? {
-                            match key {
+                        while let Some(key) = map.next_key::<String>()? {
+                            match key.as_str() {
                                 "eq" => f_op = W::O(FilterOperator::Eq(map.next_value()?)),
                                 "gt" => f_op = W::O(FilterOperator::GreaterThan(map.next_value()?)),
                                 "lt" => f_op = W::O(FilterOperator::LessThan(map.next_value()?)),

--- a/rpc/src/v1/tests/mocked/parity.rs
+++ b/rpc/src/v1/tests/mocked/parity.rs
@@ -316,11 +316,44 @@ fn rpc_parity_unsigned_transactions_count_when_signer_disabled() {
 }
 
 #[test]
-fn rpc_parity_pending_transactions() {
+fn rpc_parity_pending_transactions_without_limit_without_filter() {
 	let deps = Dependencies::new();
 	let io = deps.default_client();
 
 	let request = r#"{"jsonrpc": "2.0", "method": "parity_pendingTransactions", "params":[], "id": 1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":[],"id":1}"#;
+
+	assert_eq!(io.handle_request_sync(request), Some(response.to_owned()));
+}
+
+#[test]
+fn rpc_parity_pending_transactions_with_limit_without_filter() {
+	let deps = Dependencies::new();
+	let io = deps.default_client();
+
+	let request = r#"{"jsonrpc": "2.0", "method": "parity_pendingTransactions", "params":[5], "id": 1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":[],"id":1}"#;
+
+	assert_eq!(io.handle_request_sync(request), Some(response.to_owned()));
+}
+
+#[test]
+fn rpc_parity_pending_transactions_without_limit_with_filter() {
+	let deps = Dependencies::new();
+	let io = deps.default_client();
+
+	let request = r#"{"jsonrpc": "2.0", "method": "parity_pendingTransactions", "params":[null,{"to":{"eq":"0xe8b2d01ffa0a15736b2370b6e5064f9702c891b6"},"gas":{"gt":"0x493e0"}}], "id": 1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":[],"id":1}"#;
+
+	assert_eq!(io.handle_request_sync(request), Some(response.to_owned()));
+}
+
+#[test]
+fn rpc_parity_pending_transactions_with_limit_with_filter() {
+	let deps = Dependencies::new();
+	let io = deps.default_client();
+
+	let request = r#"{"jsonrpc": "2.0", "method": "parity_pendingTransactions", "params":[5,{"to":{"eq":"0xe8b2d01ffa0a15736b2370b6e5064f9702c891b6"},"gas":{"gt":"0x493e0"}}], "id": 1}"#;
 	let response = r#"{"jsonrpc":"2.0","result":[],"id":1}"#;
 
 	assert_eq!(io.handle_request_sync(request), Some(response.to_owned()));


### PR DESCRIPTION
Fixes #11189. Very small and easy changes.

**Example**
```
"params": [
  15,
  {
    "to": {
        "eq": "0xe8b2d01ffa0a15736b2370b6e5064f9702c891b6"
    },
    "gas": {
        "gt": "0x493e0"
    },
  }
]
```

**`curl` example:**
```
curl --data '{"method":"parity_pendingTransactions","id": 1,"params":[5,{"from":{"eq":"0x5f3dffcf347944d3739b0805c934d86c8621997f"},"to": {"eq":"0xe8b2d01ffa0a15736b2370b6e5064f9702c891b6"}}],"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST localhost:8545
```

EDIT:
PR for documentation https://github.com/paritytech/wiki/pull/345