### PR TITLE
[export hardcoded sync]: use debug for `H256`

### DIFF
--- a/ethcore/spec/src/spec.rs
+++ b/ethcore/spec/src/spec.rs
@@ -252,7 +252,7 @@ impl fmt::Display for SpecHardcodedSync {
 		writeln!(f, "{{")?;
 		writeln!(f, r#"header": "{:?},"#, self.header)?;
 		writeln!(f, r#"total_difficulty": "{:?},"#, self.total_difficulty)?;
-		writeln!(f, r#"chts": {:#?}"#, self.chts.iter().map(|x| format!(r#"{}"#, x)).collect::<Vec<_>>())?;
+		writeln!(f, r#"chts": {:#?}"#, self.chts.iter().map(|x| format!(r#"{:?}"#, x)).collect::<Vec<_>>())?;
 		writeln!(f, "}}")
 	}
 }

--- a/parity/export_hardcoded_sync.rs
+++ b/parity/export_hardcoded_sync.rs
@@ -96,7 +96,7 @@ pub fn execute(cmd: ExportHsyncCmd) -> Result<String, String> {
 	let hs = service.client().read_hardcoded_sync()
 		.map_err(|e| format!("Error reading hardcoded sync: {}", e))?;
 	if let Some(hs) = hs {
-		Ok(format!("{}", hs))
+		Ok(hs.to_string())
 	} else {
 		Err("Error: cannot generate hardcoded sync because the database is empty.".into())
 	}


### PR DESCRIPTION
Closes #11202

The `Display` implementation for `SpecHardcodedSync` used the `Display` implementation of
`ethereum_types::H256` which doesn't show the full hash which this fixes.