### PR TITLE
Use logging instead of flush! and flushln! for json-tests

### DIFF
--- a/ethcore/src/json_tests/chain.rs
+++ b/ethcore/src/json_tests/chain.rs
@@ -56,7 +56,7 @@ pub fn json_chain_test<H: FnMut(&str, HookType)>(path: &Path, json_data: &[u8], 
 			let mut fail_unless = |cond: bool| {
 				if !cond && !fail {
 					failed.push(name.clone());
-					flushln!("FAIL");
+					warn!(target: "json-tests", "FAIL");
 					fail = true;
 					true
 				} else {
@@ -64,7 +64,7 @@ pub fn json_chain_test<H: FnMut(&str, HookType)>(path: &Path, json_data: &[u8], 
 				}
 			};
 
-			flush!("   - {}...", name);
+			trace!(target: "json-tests", "   - {}...", name);
 
 			let spec = {
 				let mut spec = match EvmTestClient::fork_spec_from_json(&blockchain.network) {
@@ -123,9 +123,9 @@ pub fn json_chain_test<H: FnMut(&str, HookType)>(path: &Path, json_data: &[u8], 
 		}
 
 		if !fail {
-			flushln!("ok");
+			info!(target: "json-tests", "ok");
 		} else {
-			flushln!("fail");
+			warn!(target: "json-tests", "fail");
 		}
 
 		start_stop_hook(&name, HookType::OnStop);

--- a/ethcore/src/json_tests/difficulty.rs
+++ b/ethcore/src/json_tests/difficulty.rs
@@ -37,7 +37,7 @@ pub fn json_difficulty_test<H: FnMut(&str, HookType)>(
 	for (name, test) in tests.into_iter() {
 		start_stop_hook(&name, HookType::OnStart);
 
-		flush!("   - {}...", name);
+		trace!(target: "json-tests", "   - {}...", name);
 		println!("   - {}...", name);
 
 		let mut parent_header = Header::new();
@@ -53,7 +53,7 @@ pub fn json_difficulty_test<H: FnMut(&str, HookType)>(
 		engine.populate_from_parent(&mut header, &parent_header);
 		let expected_difficulty: U256 = test.current_difficulty.into();
 		assert_eq!(header.difficulty(), &expected_difficulty);
-		flushln!("ok");
+		info!(target: "json-tests", "ok");
 
 		start_stop_hook(&name, HookType::OnStop);
 	}

--- a/ethcore/src/json_tests/state.rs
+++ b/ethcore/src/json_tests/state.rs
@@ -84,25 +84,25 @@ pub fn json_chain_test<H: FnMut(&str, HookType)>(path: &Path, json_data: &[u8], 
 					match result() {
 						Err(err) => {
 							println!("{} !!! Unexpected internal error: {:?}", info, err);
-							flushln!("{} fail", info);
+							warn!(target: "json-tests", "{} fail", info);
 							failed.push(name.clone());
 						},
 						Ok(Ok(TransactSuccess { state_root, .. })) if state_root != post_root => {
 							println!("{} !!! State mismatch (got: {}, expect: {}", info, state_root, post_root);
-							flushln!("{} fail", info);
+							warn!(target: "json-tests", "{} fail", info);
 							failed.push(name.clone());
 						},
 						Ok(Err(TransactErr { state_root, ref error, .. })) if state_root != post_root => {
 							println!("{} !!! State mismatch (got: {}, expect: {}", info, state_root, post_root);
 							println!("{} !!! Execution error: {:?}", info, error);
-							flushln!("{} fail", info);
+							warn!(target: "json-tests", "{} fail", info);
 							failed.push(name.clone());
 						},
 						Ok(Err(TransactErr { error, .. })) => {
-							flushln!("{} ok ({:?})", info, error);
+							info!(target: "json-tests", "{} ok ({:?})", info, error);
 						},
 						Ok(_) => {
-							flushln!("{} ok", info);
+							info!(target: "json-tests", "{} ok", info);
 						},
 					}
 				}

--- a/ethcore/src/json_tests/test_common.rs
+++ b/ethcore/src/json_tests/test_common.rs
@@ -41,7 +41,7 @@ pub fn run_test_path<H: FnMut(&str, HookType)>(
 	if !skip.is_empty() {
 		// todo[dvdplm] it's really annoying to have to use flushln here. Should be `info!(target:
 		// "json-tests", …)`. Issue https://github.com/paritytech/parity-ethereum/issues/11084
-		flushln!("[run_test_path] Skipping tests in {}: {:?}", path.display(), skip);
+		warn!(target: "json-tests", " Skipping tests in {}: {:?}", path.display(), skip);
 	}
 	let mut errors = Vec::new();
 	run_test_path_inner(path, skip, runner, start_stop_hook, &mut errors);


### PR DESCRIPTION
Fixes #11084 

Replace `flush!` and `flushln!` macro with:
- `warn!` for failures, skipped tests 
- `trace!` for messages about tests
- `info!` for successful runs