### PR TITLE
Use provided usd-per-eth value if an endpoint is specified

### DIFF
--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -1910,6 +1910,7 @@ mod tests {
 				},
 				fetch,
 				p,
+				"fake_endpoint".to_owned()
 			)
 		)
 	}

--- a/miner/price-info/src/lib.rs
+++ b/miner/price-info/src/lib.rs
@@ -57,8 +57,7 @@ impl<F> cmp::PartialEq for Client<F> {
 
 impl<F: Fetch> Client<F> {
 	/// Creates a new instance of the `Client` given a `fetch::Client`.
-	pub fn new(fetch: F, pool: Executor) -> Client<F> {
-		let api_endpoint = "https://api.etherscan.io/api?module=stats&action=ethprice".to_owned();
+    pub fn new(fetch: F, pool: Executor, api_endpoint: String) -> Client<F> {
 		Client { pool, api_endpoint, fetch }
 	}
 
@@ -105,11 +104,11 @@ mod test {
 	use super::Client;
 
 	fn price_info_ok(response: &str, executor: Executor) -> Client<FakeFetch<String>> {
-		Client::new(FakeFetch::new(Some(response.to_owned())), executor)
+		Client::new(FakeFetch::new(Some(response.to_owned())), executor, "fake_endpoint".to_owned())
 	}
 
 	fn price_info_not_found(executor: Executor) -> Client<FakeFetch<String>> {
-		Client::new(FakeFetch::new(None::<String>), executor)
+		Client::new(FakeFetch::new(None::<String>), executor, "fake_endpoint".to_owned())
 	}
 
 	#[test]

--- a/miner/price-info/src/lib.rs
+++ b/miner/price-info/src/lib.rs
@@ -57,7 +57,7 @@ impl<F> cmp::PartialEq for Client<F> {
 
 impl<F: Fetch> Client<F> {
 	/// Creates a new instance of the `Client` given a `fetch::Client`.
-    pub fn new(fetch: F, pool: Executor, api_endpoint: String) -> Client<F> {
+	pub fn new(fetch: F, pool: Executor, api_endpoint: String) -> Client<F> {
 		Client { pool, api_endpoint, fetch }
 	}
 

--- a/miner/src/gas_price_calibrator.rs
+++ b/miner/src/gas_price_calibrator.rs
@@ -43,11 +43,11 @@ pub struct GasPriceCalibrator {
 
 impl GasPriceCalibrator {
 	/// Create a new gas price calibrator.
-	pub fn new(options: GasPriceCalibratorOptions, fetch: FetchClient, p: Executor) -> GasPriceCalibrator {
+	pub fn new(options: GasPriceCalibratorOptions, fetch: FetchClient, p: Executor, api_endpoint: String) -> GasPriceCalibrator {
 		GasPriceCalibrator {
 			options: options,
 			next_calibration: Instant::now(),
-			price_info: PriceInfoClient::new(fetch, p),
+			price_info: PriceInfoClient::new(fetch, p, api_endpoint),
 		}
 	}
 

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -685,11 +685,10 @@ impl Configuration {
 
 			Ok(GasPricerConfig::Fixed(wei_per_gas))
 		} else {
-			let arg_usd_per_eth_endpoint = self.args.arg_usd_per_eth.as_str();
 			Ok(GasPricerConfig::Calibrated {
 				usd_per_tx: usd_per_tx,
 				recalibration_period: to_duration(self.args.arg_price_update_period.as_str())?,
-				api_endpoint: arg_usd_per_eth_endpoint.to_owned(),
+				api_endpoint: self.args.arg_usd_per_eth.clone(),
 			})
 		}
 	}

--- a/parity/helpers.rs
+++ b/parity/helpers.rs
@@ -146,7 +146,7 @@ pub fn to_addresses(s: &Option<String>) -> Result<Vec<Address>, String> {
 
 /// Tries to parse string as a price.
 pub fn to_price(s: &str) -> Result<f32, String> {
-	s.parse::<f32>().map_err(|_| format!("Invalid transaciton price {:?} given. Must be a decimal number.", s))
+	s.parse::<f32>().map_err(|_| format!("Invalid transaction price {:?} given. Must be a decimal number.", s))
 }
 
 pub fn join_set(set: Option<&HashSet<String>>) -> Option<String> {

--- a/parity/helpers.rs
+++ b/parity/helpers.rs
@@ -146,7 +146,7 @@ pub fn to_addresses(s: &Option<String>) -> Result<Vec<Address>, String> {
 
 /// Tries to parse string as a price.
 pub fn to_price(s: &str) -> Result<f32, String> {
-	s.parse::<f32>().map_err(|_| format!("Invalid transaciton price 's' given. Must be a decimal number."))
+	s.parse::<f32>().map_err(|_| format!("Invalid transaciton price {:?} given. Must be a decimal number.", s))
 }
 
 pub fn join_set(set: Option<&HashSet<String>>) -> Option<String> {

--- a/parity/params.rs
+++ b/parity/params.rs
@@ -29,6 +29,8 @@ use parity_version::version_data;
 use user_defaults::UserDefaults;
 use types::client_types::Mode;
 
+use crate::configuration;
+
 #[derive(Debug, PartialEq)]
 pub enum SpecType {
 	Foundation,
@@ -248,6 +250,7 @@ pub enum GasPricerConfig {
 	Calibrated {
 		usd_per_tx: f32,
 		recalibration_period: Duration,
+		api_endpoint: String
 	}
 }
 
@@ -256,6 +259,7 @@ impl Default for GasPricerConfig {
 		GasPricerConfig::Calibrated {
 			usd_per_tx: 0.0001f32,
 			recalibration_period: Duration::from_secs(3600),
+			api_endpoint: configuration::ETHERSCAN_ETH_PRICE_ENDPOINT.to_string(),
 		}
 	}
 }
@@ -264,7 +268,7 @@ impl GasPricerConfig {
 	pub fn to_gas_pricer(&self, fetch: FetchClient, p: Executor) -> GasPricer {
 		match *self {
 			GasPricerConfig::Fixed(u) => GasPricer::Fixed(u),
-			GasPricerConfig::Calibrated { usd_per_tx, recalibration_period, .. } => {
+			GasPricerConfig::Calibrated { usd_per_tx, recalibration_period, ref api_endpoint } => {
 				GasPricer::new_calibrated(
 					GasPriceCalibrator::new(
 						GasPriceCalibratorOptions {
@@ -273,6 +277,7 @@ impl GasPricerConfig {
 						},
 						fetch,
 						p,
+						api_endpoint.clone(),
 					)
 				)
 			}


### PR DESCRIPTION
Fixes #9089 

This PR will use `GasPriceConfig::Calibrated` when the user provides an endpoint to an API endpoint which provides the Eth->USD price for a custom network.

The change is inspired by previous work of [Baranowski](https://github.com/Baranowski)