### PR TITLE
[informant]: `MillisecondDuration` -> `as_millis()`

### DIFF
--- a/parity/blockchain.rs
+++ b/parity/blockchain.rs
@@ -294,14 +294,13 @@ fn execute_import_light(cmd: ImportBlockchain) -> Result<(), String> {
 	}
 	client.flush_queue();
 
-	let elapsed_secs = timer.elapsed().as_secs();
-	let elapsed_millis = timer.elapsed().as_millis();
+	let elapsed = timer.elapsed();
 	let report = client.report();
 
 	info!("Import completed in {} seconds, {} headers, {} hdr/s",
-		elapsed_secs,
+		elapsed.as_secs(),
 		report.blocks_imported,
-		(report.blocks_imported as u128 * 1000) / elapsed_millis,
+		(report.blocks_imported as u128 * 1000) / elapsed.as_millis(),
 	);
 
 	Ok(())
@@ -416,16 +415,16 @@ fn execute_import(cmd: ImportBlockchain) -> Result<(), String> {
 	user_defaults.save(&user_defaults_path)?;
 
 	let report = client.report();
-	let elapsed_secs = timer.elapsed().as_secs();
-	let elapsed_millis = timer.elapsed().as_millis();
+	let elapsed = timer.elapsed();
+	let ms = timer.elapsed().as_millis();
 	info!("Import completed in {} seconds, {} blocks, {} blk/s, {} transactions, {} tx/s, {} Mgas, {} Mgas/s",
-		elapsed_secs,
+		elapsed.as_secs(),
 		report.blocks_imported,
-		(report.blocks_imported as u128 * 1000) / elapsed_millis,
+		(report.blocks_imported as u128 * 1000) / ms,
 		report.transactions_applied,
-		(report.transactions_applied as u128 * 1000) / elapsed_millis,
+		(report.transactions_applied as u128 * 1000) / ms,
 		report.gas_processed / 1_000_000,
-		report.gas_processed / (elapsed_millis * 1000),
+		report.gas_processed / (ms * 1000),
 	);
 	Ok(())
 }

--- a/parity/blockchain.rs
+++ b/parity/blockchain.rs
@@ -33,7 +33,7 @@ use ethcore::{
 };
 use ethcore_service::ClientService;
 use cache::CacheConfig;
-use informant::{Informant, FullNodeInformantData, MillisecondDuration};
+use informant::{Informant, FullNodeInformantData};
 use params::{SpecType, Pruning, Switch, tracing_switch_to_bool, fatdb_switch_to_bool};
 use helpers::{to_client_config, execute_upgrades};
 use dir::Directories;
@@ -294,13 +294,14 @@ fn execute_import_light(cmd: ImportBlockchain) -> Result<(), String> {
 	}
 	client.flush_queue();
 
-	let ms = timer.elapsed().as_milliseconds();
+	let elapsed_secs = timer.elapsed().as_secs();
+	let elapsed_millis = timer.elapsed().as_millis();
 	let report = client.report();
 
 	info!("Import completed in {} seconds, {} headers, {} hdr/s",
-		ms / 1000,
+		elapsed_secs,
 		report.blocks_imported,
-		(report.blocks_imported * 1000) as u64 / ms,
+		(report.blocks_imported as u128 * 1000) / elapsed_millis,
 	);
 
 	Ok(())
@@ -415,16 +416,16 @@ fn execute_import(cmd: ImportBlockchain) -> Result<(), String> {
 	user_defaults.save(&user_defaults_path)?;
 
 	let report = client.report();
-
-	let ms = timer.elapsed().as_milliseconds();
+	let elapsed_secs = timer.elapsed().as_secs();
+	let elapsed_millis = timer.elapsed().as_millis();
 	info!("Import completed in {} seconds, {} blocks, {} blk/s, {} transactions, {} tx/s, {} Mgas, {} Mgas/s",
-		ms / 1000,
+		elapsed_secs,
 		report.blocks_imported,
-		(report.blocks_imported * 1000) as u64 / ms,
+		(report.blocks_imported as u128 * 1000) / elapsed_millis,
 		report.transactions_applied,
-		(report.transactions_applied * 1000) as u64 / ms,
+		(report.transactions_applied as u128 * 1000) / elapsed_millis,
 		report.gas_processed / 1_000_000,
-		(report.gas_processed / (ms * 1000)).low_u64(),
+		report.gas_processed / (elapsed_millis * 1000),
 	);
 	Ok(())
 }

--- a/parity/informant.rs
+++ b/parity/informant.rs
@@ -14,14 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-extern crate ansi_term;
-use self::ansi_term::Colour::{White, Yellow, Green, Cyan, Blue};
-use self::ansi_term::{Colour, Style};
-
-use std::sync::{Arc};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering as AtomicOrdering};
 use std::time::{Instant, Duration};
 
+use ansi_term::Colour::{White, Yellow, Green, Cyan, Blue};
+use ansi_term::{Colour, Style};
 use atty;
 use ethcore::client::Client;
 use client_traits::{BlockInfo, ChainInfo, BlockChainClient, ChainNotify};
@@ -52,18 +50,6 @@ pub fn format_bytes(b: usize) -> String {
 	match binary_prefix(b as f64) {
 		Standalone(bytes)   => format!("{} bytes", bytes),
 		Prefixed(prefix, n) => format!("{:.0} {}B", n, prefix),
-	}
-}
-
-/// Something that can be converted to milliseconds.
-pub trait MillisecondDuration {
-	/// Get the value in milliseconds.
-	fn as_milliseconds(&self) -> u64;
-}
-
-impl MillisecondDuration for Duration {
-	fn as_milliseconds(&self) -> u64 {
-		self.as_secs() * 1000 + self.subsec_nanos() as u64 / 1_000_000
 	}
 }
 
@@ -308,13 +294,13 @@ impl<T: InformantData> Informant<T> {
 						paint(White.bold(), format!("{}", chain_info.best_block_hash)),
 						if self.target.executes_transactions() {
 							format!("{} blk/s {} tx/s {} Mgas/s",
-								paint(Yellow.bold(), format!("{:7.2}", (client_report.blocks_imported * 1000) as f64 / elapsed.as_milliseconds() as f64)),
-								paint(Yellow.bold(), format!("{:6.1}", (client_report.transactions_applied * 1000) as f64 / elapsed.as_milliseconds() as f64)),
-								paint(Yellow.bold(), format!("{:6.1}", (client_report.gas_processed / 1000).low_u64() as f64 / elapsed.as_milliseconds() as f64))
+								paint(Yellow.bold(), format!("{:7.2}", (client_report.blocks_imported * 1000) as f64 / elapsed.as_millis() as f64)),
+								paint(Yellow.bold(), format!("{:6.1}", (client_report.transactions_applied * 1000) as f64 / elapsed.as_millis() as f64)),
+								paint(Yellow.bold(), format!("{:6.1}", (client_report.gas_processed / 1000).low_u64() as f64 / elapsed.as_millis() as f64))
 							)
 						} else {
 							format!("{} hdr/s",
-								paint(Yellow.bold(), format!("{:6.1}", (client_report.blocks_imported * 1000) as f64 / elapsed.as_milliseconds() as f64))
+								paint(Yellow.bold(), format!("{:6.1}", (client_report.blocks_imported * 1000) as f64 / elapsed.as_millis() as f64))
 							)
 						},
 						paint(Green.bold(), format!("{:5}", queue_info.unverified_queue_size)),
@@ -401,7 +387,7 @@ impl ChainNotify for Informant<FullNodeInformantData> {
 					Colour::White.bold().paint(format!("{}", header_view.hash())),
 					Colour::Yellow.bold().paint(format!("{}", block.transactions_count())),
 					Colour::Yellow.bold().paint(format!("{:.2}", header_view.gas_used().low_u64() as f32 / 1000000f32)),
-					Colour::Purple.bold().paint(format!("{}", new_blocks.duration.as_milliseconds())),
+					Colour::Purple.bold().paint(format!("{}", new_blocks.duration.as_millis())),
 					Colour::Blue.bold().paint(format!("{:.2}", size as f32 / 1024f32)),
 					if skipped > 0 {
 						format!(" + another {} block(s) containing {} tx(s)",


### PR DESCRIPTION
This commit removes the trait `MillisecondDuration` and replaces it with `Duration::as_millis` instead.
