### PR TITLE
Add POSDAO transition; call emitInitiateChange.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ dependencies = [
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "machine 0.1.0",
  "macros 0.1.0",
+ "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-crypto 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethcore/client-traits/src/lib.rs
+++ b/ethcore/client-traits/src/lib.rs
@@ -42,7 +42,7 @@ use common_types::{
 	pruning_info::PruningInfo,
 	receipt::LocalizedReceipt,
 	trace_filter::Filter as TraceFilter,
-	transaction::{self, LocalizedTransaction, CallError, SignedTransaction, UnverifiedTransaction},
+	transaction::{self, Action, LocalizedTransaction, CallError, SignedTransaction, UnverifiedTransaction},
 	tree_route::TreeRoute,
 	verification::{VerificationQueueInfo, Unverified},
 };
@@ -388,7 +388,27 @@ pub trait BlockChainClient:
 	fn pruning_info(&self) -> PruningInfo;
 
 	/// Schedule state-altering transaction to be executed on the next pending block.
-	fn transact_contract(&self, address: Address, data: Bytes) -> Result<(), transaction::Error>;
+	fn transact_contract(&self, address: Address, data: Bytes) -> Result<(), transaction::Error> {
+		self.transact(Action::Call(address), data, None, None, None)
+	}
+
+	/// Returns a signed transaction. If gas limit, gas price, or nonce are not
+	/// specified, the defaults are used.
+	fn create_transaction(
+		&self,
+		action: Action,
+		data: Bytes,
+		gas: Option<U256>,
+		gas_price: Option<U256>,
+		nonce: Option<U256>
+	) -> Result<SignedTransaction, transaction::Error>;
+
+	/// Schedule state-altering transaction to be executed on the next pending
+	/// block with the given gas and nonce parameters.
+	///
+	/// If they are `None`, sensible values are selected automatically.
+	fn transact(&self, action: Action, data: Bytes, gas: Option<U256>, gas_price: Option<U256>, nonce: Option<U256>)
+		-> Result<(), transaction::Error>;
 }
 
 /// resets the blockchain

--- a/ethcore/engine/src/engine.rs
+++ b/ethcore/engine/src/engine.rs
@@ -32,7 +32,7 @@ use common_types::{
 	},
 	errors::{EthcoreError as Error, EngineError},
 	snapshot::Snapshotting,
-	transaction::{self, UnverifiedTransaction},
+	transaction::{self, SignedTransaction, UnverifiedTransaction},
 };
 use client_traits::EngineClient;
 
@@ -184,6 +184,12 @@ pub trait Engine: Sync + Send {
 
 	/// Allow mutating the header during seal generation. Currently only used by Clique.
 	fn on_seal_block(&self, _block: &mut ExecutedBlock) -> Result<(), Error> { Ok(()) }
+
+	/// Returns a list of transactions for a new block if we are the author.
+	///
+	/// This is called when the miner prepares a new block that this node will author and seal. It returns a list of
+	/// transactions that will be added to the block before any other transactions from the queue.
+	fn on_prepare_block(&self, _block: &ExecutedBlock) -> Result<Vec<SignedTransaction>, Error> { Ok(Vec::new()) }
 
 	/// Returns the engine's current sealing state.
 	fn sealing_state(&self) -> SealingState { SealingState::External }

--- a/ethcore/engines/authority-round/Cargo.toml
+++ b/ethcore/engines/authority-round/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4"
 lru-cache = "0.1"
 machine = { path = "../../machine" }
 macros = { path = "../../../util/macros" }
+parity-bytes = "0.1"
 parking_lot = "0.9"
 rlp = "0.4.0"
 time-utils = { path = "../../../util/time-utils" }

--- a/ethcore/engines/validator-set/res/validator_set.json
+++ b/ethcore/engines/validator-set/res/validator_set.json
@@ -1,5 +1,28 @@
 [
 	{"constant":false,"inputs":[],"name":"finalizeChange","outputs":[],"payable":false,"type":"function"},
 	{"constant":true,"inputs":[],"name":"getValidators","outputs":[{"name":"validators","type":"address[]"}],"payable":false,"type":"function"},
-	{"anonymous":false,"inputs":[{"indexed":true,"name":"_parent_hash","type":"bytes32"},{"indexed":false,"name":"_new_set","type":"address[]"}],"name":"InitiateChange","type":"event"}
+	{"anonymous":false,"inputs":[{"indexed":true,"name":"_parent_hash","type":"bytes32"},{"indexed":false,"name":"_new_set","type":"address[]"}],"name":"InitiateChange","type":"event"},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "emitInitiateChangeCallable",
+		"outputs": [
+			{
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "emitInitiateChange",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	}
 ]

--- a/ethcore/engines/validator-set/src/lib.rs
+++ b/ethcore/engines/validator-set/src/lib.rs
@@ -49,16 +49,33 @@ use self::contract::ValidatorContract;
 use self::safe_contract::ValidatorSafeContract;
 use self::multi::Multi;
 
-/// Creates a validator set from spec.
-pub fn new_validator_set(spec: ValidatorSpec) -> Box<dyn ValidatorSet> {
+/// Creates a validator set from the given spec and initializes a transition to POSDAO AuRa consensus.
+pub fn new_validator_set_posdao(
+	spec: ValidatorSpec,
+	posdao_transition: Option<BlockNumber>
+) -> Box<dyn ValidatorSet> {
 	match spec {
-		ValidatorSpec::List(list) => Box::new(SimpleList::new(list.into_iter().map(Into::into).collect())),
-		ValidatorSpec::SafeContract(address) => Box::new(ValidatorSafeContract::new(address.into())),
-		ValidatorSpec::Contract(address) => Box::new(ValidatorContract::new(address.into())),
-		ValidatorSpec::Multi(sequence) => Box::new(
-			Multi::new(sequence.into_iter().map(|(block, set)| (block.into(), new_validator_set(set))).collect())
-		),
+		ValidatorSpec::List(list) =>
+			Box::new(SimpleList::new(list.into_iter().map(Into::into).collect())),
+		ValidatorSpec::SafeContract(address) =>
+			Box::new(ValidatorSafeContract::new(address.into(), posdao_transition)),
+		ValidatorSpec::Contract(address) =>
+			Box::new(ValidatorContract::new(address.into(), posdao_transition)),
+		ValidatorSpec::Multi(sequence) => Box::new(Multi::new(
+			sequence
+				.into_iter()
+				.map(|(block, set)| (
+					block.into(),
+					new_validator_set_posdao(set, posdao_transition)
+				))
+				.collect()
+		)),
 	}
+}
+
+/// Creates a validator set from the given spec.
+pub fn new_validator_set(spec: ValidatorSpec) -> Box<dyn ValidatorSet> {
+	new_validator_set_posdao(spec, None)
 }
 
 /// A validator set.
@@ -67,6 +84,17 @@ pub trait ValidatorSet: Send + Sync + 'static {
 	// TODO [keorn]: this is a hack intended to migrate off of
 	// a strict dependency on state always being available.
 	fn default_caller(&self, block_id: BlockId) -> Box<Call>;
+
+	/// Called for each new block this node is creating.  If this block is
+	/// the first block of an epoch, this is called *after* `on_epoch_begin()`,
+	/// but with the same parameters.
+	///
+	/// Returns a list of contract calls to be pushed onto the new block.
+	fn on_prepare_block(&self, _first: bool, _header: &Header, _call: &mut SystemCall)
+		-> Result<Vec<(Address, Bytes)>, EthcoreError>
+	{
+		Ok(Vec::new())
+	}
 
 	/// Checks if a given address is a validator,
 	/// using underlying, default call mechanism.

--- a/ethcore/engines/validator-set/src/multi.rs
+++ b/ethcore/engines/validator-set/src/multi.rs
@@ -51,6 +51,14 @@ impl Multi {
 		}
 	}
 
+	fn map_children<T, F>(&self, header: &Header, mut func: F) -> Result<T, EthcoreError>
+		where F: FnMut(&dyn ValidatorSet, bool) -> Result<T, EthcoreError>
+	{
+		let (set_block, set) = self.correct_set_by_number(header.number());
+		let first = set_block == header.number();
+		func(set, first)
+	}
+
 	fn correct_set(&self, id: BlockId) -> Option<&dyn ValidatorSet> {
 		match self.block_number.read()(id).map(|parent_block| self.correct_set_by_number(parent_block)) {
 			Ok((_, set)) => Some(set),
@@ -82,11 +90,14 @@ impl ValidatorSet for Multi {
 			.unwrap_or_else(|| Box::new(|_, _| Err("No validator set for given ID.".into())))
 	}
 
-	fn on_epoch_begin(&self, _first: bool, header: &Header, call: &mut SystemCall) -> Result<(), EthcoreError> {
-		let (set_block, set) = self.correct_set_by_number(header.number());
-		let first = set_block == header.number();
+	fn on_prepare_block(&self, _first: bool, header: &Header, call: &mut SystemCall)
+		-> Result<Vec<(Address, Bytes)>, EthcoreError>
+	{
+		self.map_children(header, &mut |set: &dyn ValidatorSet, first| set.on_prepare_block(first, header, call))
+	}
 
-		set.on_epoch_begin(first, header, call)
+	fn on_epoch_begin(&self, _first: bool, header: &Header, call: &mut SystemCall) -> Result<(), EthcoreError> {
+		self.map_children(header, &mut |set: &dyn ValidatorSet, first| set.on_epoch_begin(first, header, call))
 	}
 
 	fn genesis_epoch_data(&self, header: &Header, call: &Call) -> Result<Vec<u8>, String> {

--- a/ethcore/engines/validator-set/src/safe_contract.rs
+++ b/ethcore/engines/validator-set/src/safe_contract.rs
@@ -86,6 +86,9 @@ pub struct ValidatorSafeContract {
 	/// is the validator set valid for the blocks following that hash.
 	validators: RwLock<MemoryLruCache<H256, SimpleList>>,
 	client: RwLock<Option<Weak<dyn EngineClient>>>, // TODO [keorn]: remove
+	/// If set, this is the block number at which the consensus engine switches from AuRa to AuRa
+	/// with POSDAO modifications.
+	posdao_transition: Option<BlockNumber>,
 }
 
 // first proof is just a state proof call of `getValidators` at header's state.
@@ -201,11 +204,12 @@ fn prove_initial(contract_address: Address, header: &Header, caller: &Call) -> R
 }
 
 impl ValidatorSafeContract {
-	pub fn new(contract_address: Address) -> Self {
+	pub fn new(contract_address: Address, posdao_transition: Option<BlockNumber>) -> Self {
 		ValidatorSafeContract {
 			contract_address,
 			validators: RwLock::new(MemoryLruCache::new(MEMOIZE_CAPACITY)),
 			client: RwLock::new(None),
+			posdao_transition,
 		}
 	}
 
@@ -299,6 +303,28 @@ impl ValidatorSet for ValidatorSafeContract {
 				}
 			})
 			.map(|out| (out, Vec::new()))) // generate no proofs in general
+	}
+
+	fn on_prepare_block(&self, _first: bool, header: &Header, caller: &mut SystemCall)
+		-> Result<Vec<(Address, Bytes)>, EthcoreError>
+	{
+		// Skip the rest of the function unless there has been a transition to POSDAO AuRa.
+		if self.posdao_transition.map_or(true, |block_num| header.number() < block_num) {
+			trace!(target: "engine", "Skipping a call to emitInitiateChange");
+			return Ok(Vec::new());
+		}
+		let (data, decoder) = validator_set::functions::emit_initiate_change_callable::call();
+		if !caller(self.contract_address, data)
+			.and_then(|x| decoder.decode(&x)
+			.map_err(|x| format!("chain spec bug: could not decode: {:?}", x)))
+			.map_err(EngineError::FailedSystemCall)?
+		{
+			trace!(target: "engine", "New block #{} issued ― no need to call emitInitiateChange()", header.number());
+			return Ok(Vec::new());
+		}
+		trace!(target: "engine", "New block issued #{} ― calling emitInitiateChange()", header.number());
+		let (data, _decoder) = validator_set::functions::emit_initiate_change::call();
+		Ok(vec![(self.contract_address, data)])
 	}
 
 	fn on_epoch_begin(&self, _first: bool, _header: &Header, caller: &mut SystemCall) -> Result<(), EthcoreError> {
@@ -482,7 +508,8 @@ mod tests {
 	#[test]
 	fn fetches_validators() {
 		let client = generate_dummy_client_with_spec(spec::new_validator_safe_contract);
-		let vc = Arc::new(ValidatorSafeContract::new("0000000000000000000000000000000000000005".parse::<Address>().unwrap()));
+		let addr: Address = "0000000000000000000000000000000000000005".parse().unwrap();
+		let vc = Arc::new(ValidatorSafeContract::new(addr, None));
 		vc.register_client(Arc::downgrade(&client) as _);
 		let last_hash = client.best_block_header().hash();
 		assert!(vc.contains(&last_hash, &"7d577a597b2742b498cb5cf0c26cdcd726d39e6e".parse::<Address>().unwrap()));

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2165,29 +2165,42 @@ impl BlockChainClient for Client {
 		}
 	}
 
-	fn transact_contract(&self, address: Address, data: Bytes) -> Result<(), transaction::Error> {
+	fn create_transaction(
+		&self,
+		action: Action,
+		data: Bytes,
+		gas: Option<U256>,
+		gas_price: Option<U256>,
+		nonce: Option<U256>
+	) -> Result<SignedTransaction, transaction::Error> {
 		let authoring_params = self.importer.miner.authoring_params();
 		let service_transaction_checker = self.importer.miner.service_transaction_checker();
 		let gas_price = if let Some(checker) = service_transaction_checker {
 			match checker.check_address(self, authoring_params.author) {
 				Ok(true) => U256::zero(),
-				_ => self.importer.miner.sensible_gas_price(),
+				_ => gas_price.unwrap_or_else(|| self.importer.miner.sensible_gas_price()),
 			}
 		} else {
 			self.importer.miner.sensible_gas_price()
 		};
 		let transaction = transaction::Transaction {
-			nonce: self.latest_nonce(&authoring_params.author),
-			action: Action::Call(address),
-			gas: self.importer.miner.sensible_gas_limit(),
+			nonce: nonce.unwrap_or_else(|| self.latest_nonce(&authoring_params.author)),
+			action,
+			gas: gas.unwrap_or_else(|| self.importer.miner.sensible_gas_limit()),
 			gas_price,
 			value: U256::zero(),
-			data: data,
+			data,
 		};
 		let chain_id = self.engine.signing_chain_id(&self.latest_env_info());
 		let signature = self.engine.sign(transaction.hash(chain_id))
 			.map_err(|e| transaction::Error::InvalidSignature(e.to_string()))?;
-		let signed = SignedTransaction::new(transaction.with_signature(signature, chain_id))?;
+		Ok(SignedTransaction::new(transaction.with_signature(signature, chain_id))?)
+	}
+
+	fn transact(&self, action: Action, data: Bytes, gas: Option<U256>, gas_price: Option<U256>, nonce: Option<U256>)
+		-> Result<(), transaction::Error>
+	{
+		let signed = self.create_transaction(action, data, gas, gas_price, nonce)?;
 		self.importer.miner.import_own_transaction(self, signed.into())
 	}
 }

--- a/ethcore/src/test_helpers/test_client.rs
+++ b/ethcore/src/test_helpers/test_client.rs
@@ -912,18 +912,37 @@ impl BlockChainClient for TestBlockChainClient {
 		}
 	}
 
-	fn transact_contract(&self, address: Address, data: Bytes) -> Result<(), transaction::Error> {
+	fn create_transaction(
+		&self,
+		action: Action,
+		data: Bytes,
+		gas: Option<U256>,
+		gas_price: Option<U256>,
+		nonce: Option<U256>
+	) -> Result<SignedTransaction, transaction::Error> {
 		let transaction = Transaction {
-			nonce: self.latest_nonce(&self.miner.authoring_params().author),
-			action: Action::Call(address),
-			gas: self.spec.gas_limit,
-			gas_price: U256::zero(),
+			nonce: nonce.unwrap_or_else(|| self.latest_nonce(&self.miner.authoring_params().author)),
+			action,
+			gas: gas.unwrap_or(self.spec.gas_limit),
+			gas_price: gas_price.unwrap_or_else(U256::zero),
 			value: U256::default(),
 			data: data,
 		};
 		let chain_id = Some(self.spec.chain_id());
 		let sig = self.spec.engine.sign(transaction.hash(chain_id)).unwrap();
-		let signed = SignedTransaction::new(transaction.with_signature(sig, chain_id)).unwrap();
+		Ok(SignedTransaction::new(transaction.with_signature(sig, chain_id)).unwrap())
+	}
+
+	fn transact(
+		&self,
+		action: Action,
+		data: Bytes,
+		gas: Option<U256>,
+		gas_price: Option<U256>,
+		_nonce: Option<U256>,
+	) -> Result<(), transaction::Error>
+	{
+		let signed = self.create_transaction(action, data, gas, gas_price, None)?;
 		self.miner.import_own_transaction(self, signed.into())
 	}
 }

--- a/json/src/spec/authority_round.rs
+++ b/json/src/spec/authority_round.rs
@@ -95,6 +95,9 @@ pub struct AuthorityRoundParams {
 	pub strict_empty_steps_transition: Option<Uint>,
 	/// First block for which a 2/3 quorum (instead of 1/2) is required.
 	pub two_thirds_majority_transition: Option<Uint>,
+	/// The block number at which the consensus engine switches from AuRa to AuRa with POSDAO
+	/// modifications.
+	pub posdao_transition: Option<Uint>,
 }
 
 /// Authority engine deserialization.


### PR DESCRIPTION
This adds a `posdaoTransition` option to modify Aura behavior as required for [POSDAO](https://forum.poa.network/t/posdao-white-paper/2208):
Aura will call `ValidatorSet.emitInitiateChange` whenever the validator set changes, to log an `InitiateChange` event.

This PR shares some code with #10946, and is based on https://github.com/poanetwork/parity-ethereum/commit/10fe386f092455991fc01b51d7f1d9bfbd5a490c and https://github.com/poanetwork/parity-ethereum/commit/abd00f9f34206d05a5eefc71f492a2a807eb239c in POA's `aura-pos` branch.