### PR TITLE
Insert explicit warning into the panic hook

### DIFF
--- a/parity/main.rs
+++ b/parity/main.rs
@@ -285,6 +285,7 @@ fn main_direct(force_can_restart: bool) -> i32 {
 					let e = exit.clone();
 					let exiting = exiting.clone();
 					move |panic_msg| {
+						warn!("Panic occured, see stderr for details");
 						eprintln!("{}", panic_msg);
 						if !exiting.swap(true, Ordering::SeqCst) {
 							*e.0.lock() = ExitStatus {


### PR DESCRIPTION
This additional warning should help to debug the use case, when stderr is setup to put output somewhere else (not in Parity log).
In particular, I had this issue, when Parity was running as daemon and one of its threads panicked. The log looked very innocent, no panic was shown and it was not easy to understand the reason, why Parity quits. 