### PR TITLE
[chain specs]: activate `Istanbul` on mainnet

### DIFF
--- a/ethcore/res/ethereum/foundation.json
+++ b/ethcore/res/ethereum/foundation.json
@@ -164,9 +164,7 @@
 		"eip145Transition": "0x6f1580",
 		"eip1014Transition": "0x6f1580",
 		"eip1052Transition": "0x6f1580",
-		"eip1283Transition": "0x0",
-		"eip1283DisableTransition": "0x0",
-		"eip1283ReenableTransition": "0x8a61c8",
+		"eip1283Transition": "0x8a61c8",
 		"eip1706Transition": "0x8a61c8",
 		"eip1884Transition": "0x8a61c8",
 		"eip2028Transition": "0x8a61c8"

--- a/ethcore/res/ethereum/foundation.json
+++ b/ethcore/res/ethereum/foundation.json
@@ -4450,8 +4450,8 @@
 					"0x42ae50": {
 						"price": { "alt_bn128_const_operations": { "price": 500 }}
 					},
-					"0x7fffffffffffff": {
-						"info": "EIP 1108 transition",
+					"0x8a61c8": {
+						"info": "EIP 1108 transition at block 9_069_000 (0x8a61c8)",
 						"price": { "alt_bn128_const_operations": { "price": 150 }}
 					}
 				}
@@ -4464,8 +4464,8 @@
 					"0x42ae50": {
 						"price": { "alt_bn128_const_operations": { "price": 40000 }}
 					},
-					"0x7fffffffffffff": {
-						"info": "EIP 1108 transition",
+					"0x8a61c8": {
+						"info": "EIP 1108 transition at block 9_069_000 (0x8a61c8)",
 						"price": { "alt_bn128_const_operations": { "price": 6000 }}
 					}
 				}
@@ -4478,9 +4478,20 @@
 					"0x42ae50": {
 						"price": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 }}
 					},
-					"0x7fffffffffffff": {
-						"info": "EIP 1108 transition",
+					"0x8a61c8": {
+						"info": "EIP 1108 transition at block 9_069_000 (0x8a61c8)",
 						"price": { "alt_bn128_pairing": { "base": 45000, "pair": 34000 }}
+					}
+				}
+			}
+		},
+		"0x0000000000000000000000000000000000000009": {
+			"builtin": {
+				"name": "blake2_f",
+				"activate_at": "0x8a61c8",
+				"pricing": {
+					"blake2_f": {
+						"gas_per_round": 1
 					}
 				}
 			}

--- a/ethcore/res/ethereum/foundation.json
+++ b/ethcore/res/ethereum/foundation.json
@@ -163,7 +163,13 @@
 		"eip658Transition": "0x42ae50",
 		"eip145Transition": "0x6f1580",
 		"eip1014Transition": "0x6f1580",
-		"eip1052Transition": "0x6f1580"
+		"eip1052Transition": "0x6f1580",
+		"eip1283Transition": "0x0",
+		"eip1283DisableTransition": "0x0",
+		"eip1283ReenableTransition": "0x8a61c8",
+		"eip1706Transition": "0x8a61c8",
+		"eip1884Transition": "0x8a61c8",
+		"eip2028Transition": "0x8a61c8"
 	},
 	"genesis": {
 		"seal": {

--- a/ethcore/res/ethereum/goerli.json
+++ b/ethcore/res/ethereum/goerli.json
@@ -135,7 +135,7 @@
 						"price": { "alt_bn128_const_operations": { "price": 500 }}
 					},
 					"0x17d433": {
-						"info": "EIP 1108 transition",
+						"info": "EIP 1108 transition at block 1_561_651 (0x17d433)",
 						"price": { "alt_bn128_const_operations": { "price": 150 }}
 					}
 				}
@@ -150,7 +150,7 @@
 						"price": { "alt_bn128_const_operations": { "price": 40000 }}
 					},
 					"0x17d433": {
-						"info": "EIP 1108 transition",
+						"info": "EIP 1108 transition at block 1_561_651 (0x17d433)",
 						"price": { "alt_bn128_const_operations": { "price": 6000 }}
 					}
 				}
@@ -165,7 +165,7 @@
 						"price": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 }}
 					},
 					"0x17d433": {
-						"info": "EIP 1108 transition",
+						"info": "EIP 1108 transition at block 1_561_651 (0x17d433)",
 						"price": { "alt_bn128_pairing": { "base": 45000, "pair": 34000 }}
 					}
 				}

--- a/ethcore/res/ethereum/kovan.json
+++ b/ethcore/res/ethereum/kovan.json
@@ -6731,7 +6731,7 @@
 						"price": { "alt_bn128_const_operations": { "price": 500 }}
 					},
 					"0xd751a5": {
-						"info": "EIP 1108 transition",
+						"info": "EIP 1108 transition at block 14_111_141 (0xd751a5)",
 						"price": { "alt_bn128_const_operations": { "price": 150 }}
 					}
 				}
@@ -6745,7 +6745,7 @@
 						"price": { "alt_bn128_const_operations": { "price": 40000 }}
 					},
 					"0xd751a5": {
-						"info": "EIP 1108 transition",
+						"info": "EIP 1108 transition at block 14_111_141 (0xd751a5)",
 						"price": { "alt_bn128_const_operations": { "price": 6000 }}
 					}
 				}
@@ -6759,7 +6759,7 @@
 						"price": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 }}
 					},
 					"0xd751a5": {
-						"info": "EIP 1108 transition",
+						"info": "EIP 1108 transition at block 14_111_141 (0xd751a5)",
 						"price": { "alt_bn128_pairing": { "base": 45000, "pair": 34000 }}
 					}
 				}

--- a/ethcore/res/ethereum/rinkeby.json
+++ b/ethcore/res/ethereum/rinkeby.json
@@ -130,7 +130,7 @@
 						"price": { "alt_bn128_const_operations": { "price": 500 }}
 					},
 					"0x52efd1": {
-						"info": "EIP 1108 transition",
+						"info": "EIP 1108 transition at block 5_435_345 (0x52efd1)",
 						"price": { "alt_bn128_const_operations": { "price": 150 }}
 					}
 				}
@@ -145,7 +145,7 @@
 						"price": { "alt_bn128_const_operations": { "price": 40000 }}
 					},
 					"0x52efd1": {
-						"info": "EIP 1108 transition",
+						"info": "EIP 1108 transition at block 5_435_345 (0x52efd1)",
 						"price": { "alt_bn128_const_operations": { "price": 6000 }}
 					}
 				}
@@ -160,7 +160,7 @@
 						"price": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 }}
 					},
 					"0x52efd1": {
-						"info": "EIP 1108 transition",
+						"info": "EIP 1108 transition at block 5_435_345 (0x52efd1)",
 						"price": { "alt_bn128_pairing": { "base": 45000, "pair": 34000 }}
 					}
 				}

--- a/ethcore/res/ethereum/ropsten.json
+++ b/ethcore/res/ethereum/ropsten.json
@@ -2744,7 +2744,7 @@
 						"price": { "alt_bn128_const_operations": { "price": 500 }}
 					},
 					"0x62f756": {
-						"info": "EIP 1108 transition",
+						"info": "EIP 1108 transition at block 6_485_846 (0x62f756)",
 						"price": { "alt_bn128_const_operations": { "price": 150 }}
 					}
 				}
@@ -2760,7 +2760,7 @@
 						"price": { "alt_bn128_const_operations": { "price": 40000 }}
 					},
 					"0x62f756": {
-						"info": "EIP 1108 transition",
+						"info": "EIP 1108 transition at block 6_485_846 (0x62f756)",
 						"price": { "alt_bn128_const_operations": { "price": 6000 }}
 					}
 				}
@@ -2776,7 +2776,7 @@
 						"price": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 }}
 					},
 					"0x62f756": {
-						"info": "EIP 1108 transition",
+						"info": "EIP 1108 transition at block 6_485_846 (0x62f756)",
 						"price": { "alt_bn128_pairing": { "base": 45000, "pair": 34000 }}
 					}
 				}


### PR DESCRIPTION
This PR enables  `Istanbul` for mainnet at block 9_069_000

See https://github.com/ethereum/EIPs/pull/2332/files for further information.