### PR TITLE
remove client mode

### DIFF
--- a/ethcore/client-traits/src/lib.rs
+++ b/ethcore/client-traits/src/lib.rs
@@ -31,7 +31,6 @@ use common_types::{
 	BlockNumber,
 	call_analytics::CallAnalytics,
 	chain_notify::{NewBlocks, ChainMessageType},
-	client_types::Mode,
 	encoded,
 	engines::{epoch::Transition as EpochTransition, machine::Executed},
 	errors::{EthcoreError, EthcoreResult},
@@ -369,12 +368,6 @@ pub trait BlockChainClient:
 
 	/// Get the preferred chain ID to sign on
 	fn signing_chain_id(&self) -> Option<u64>;
-
-	/// Get the mode.
-	fn mode(&self) -> Mode;
-
-	/// Set the mode.
-	fn set_mode(&self, mode: Mode);
 
 	/// Get the chain spec name.
 	fn spec_name(&self) -> String;

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1572,7 +1572,6 @@ impl BlockChainClient for Client {
 	}
 
 	fn disable(&self) {
-		//self.set_mode(Mode::Off);
 		self.enabled.store(false, AtomicOrdering::Relaxed);
 		self.clear_queue();
 	}
@@ -2161,7 +2160,7 @@ impl IoClient for Client {
 impl Tick for Client {
 	/// Tick the client.
 	// TODO: manage by real events.
-	fn tick(&self, prevent_sleep: bool) {
+	fn tick(&self, _prevent_sleep: bool) {
 		self.check_garbage();
 	}
 }

--- a/ethcore/src/client/config.rs
+++ b/ethcore/src/client/config.rs
@@ -20,7 +20,6 @@ use blockchain::Config as BlockChainConfig;
 use journaldb;
 use snapshot::SnapshotConfiguration;
 use trace::Config as TraceConfig;
-use types::client_types::Mode;
 use verification::{VerifierType, QueueConfig};
 
 pub use evm::VMType;
@@ -76,8 +75,6 @@ pub struct ClientConfig {
 	pub db_cache_size: Option<usize>,
 	/// State db compaction profile
 	pub db_compaction: DatabaseCompactionProfile,
-	/// Operating mode
-	pub mode: Mode,
 	/// The chain spec name
 	pub spec_name: String,
 	/// Type of block verifier used by client.
@@ -113,7 +110,6 @@ impl Default for ClientConfig {
 			name: "default".into(),
 			db_cache_size: None,
 			db_compaction: Default::default(),
-			mode: Mode::Active,
 			spec_name: "".into(),
 			verifier_type: VerifierType::Canon,
 			state_cache_size: 1 * mb,

--- a/ethcore/src/test_helpers/test_client.rs
+++ b/ethcore/src/test_helpers/test_client.rs
@@ -55,7 +55,7 @@ use types::{
 	view,
 	views::BlockView,
 	verification::Unverified,
-	client_types::{Mode, StateResult},
+	client_types::StateResult,
 	blockchain_info::BlockChainInfo,
 	block_status::BlockStatus,
 	verification::VerificationQueueInfo as BlockQueueInfo,
@@ -893,10 +893,6 @@ impl BlockChainClient for TestBlockChainClient {
 	}
 
 	fn signing_chain_id(&self) -> Option<u64> { None }
-
-	fn mode(&self) -> Mode { Mode::Active }
-
-	fn set_mode(&self, _: Mode) { unimplemented!(); }
 
 	fn spec_name(&self) -> String { "foundation".into() }
 

--- a/ethcore/types/src/client_types.rs
+++ b/ethcore/types/src/client_types.rs
@@ -16,41 +16,10 @@
 
 //! Client related types.
 
-use std::{
-	cmp,
-	fmt::{Display, Formatter, Error as FmtError},
-	ops,
-	time::Duration,
-};
+use std::{cmp, ops};
 
 use ethereum_types::U256;
 use crate::header::Header;
-
-/// Operating mode for the client.
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub enum Mode {
-	/// Always on.
-	Active,
-	/// Goes offline after client is inactive for some (given) time, but
-	/// comes back online after a while of inactivity.
-	Passive(Duration, Duration),
-	/// Goes offline after client is inactive for some (given) time and
-	/// stays inactive.
-	Dark(Duration),
-	/// Always off.
-	Off,
-}
-
-impl Display for Mode {
-	fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
-		match *self {
-			Mode::Active => write!(f, "active"),
-			Mode::Passive(..) => write!(f, "passive"),
-			Mode::Dark(..) => write!(f, "dark"),
-			Mode::Off => write!(f, "offline"),
-		}
-	}
-}
 
 /// Report on the status of a client.
 #[derive(Default, Clone, Debug, Eq, PartialEq)]

--- a/parity/blockchain.rs
+++ b/parity/blockchain.rs
@@ -44,7 +44,7 @@ use ansi_term::Colour;
 use types::{
 	ids::BlockId,
 	errors::{ImportError, EthcoreError},
-	client_types::{Mode, StateResult},
+	client_types::StateResult,
 };
 use types::data_format::DataFormat;
 use verification::queue::VerifierSettings;
@@ -347,7 +347,6 @@ fn execute_import(cmd: ImportBlockchain) -> Result<(), String> {
 	let mut client_config = to_client_config(
 		&cmd.cache_config,
 		spec.name.to_lowercase(),
-		Mode::Active,
 		tracing,
 		fat_db,
 		cmd.compaction,
@@ -484,7 +483,6 @@ fn start_client(
 	let client_config = to_client_config(
 		&cache_config,
 		spec.name.to_lowercase(),
-		Mode::Active,
 		tracing,
 		fat_db,
 		compaction,

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -1454,7 +1454,6 @@ mod tests {
 				max_delay: 100,
 				frequency: 20,
 			},
-			mode: Default::default(),
 			tracing: Default::default(),
 			compaction: Default::default(),
 			vm_type: Default::default(),

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -38,7 +38,7 @@ use verification::queue::VerifierSettings;
 use rpc::{IpcConfiguration, HttpConfiguration, WsConfiguration};
 use parity_rpc::NetworkSettings;
 use cache::CacheConfig;
-use helpers::{to_duration, to_mode, to_block_id, to_u256, to_pending_set, to_price, geth_ipc_path, parity_ipc_path, to_bootnodes, to_addresses, to_address, to_queue_strategy, to_queue_penalization};
+use helpers::{to_duration, to_block_id, to_u256, to_pending_set, to_price, geth_ipc_path, parity_ipc_path, to_bootnodes, to_addresses, to_address, to_queue_strategy, to_queue_penalization};
 use dir::helpers::{replace_home, replace_home_and_local};
 use params::{ResealPolicy, AccountsConfig, GasPricerConfig, MinerExtras, SpecType};
 use ethcore_logger::Config as LogConfig;
@@ -122,10 +122,6 @@ impl Configuration {
 		let pruning_history = self.args.arg_pruning_history;
 		let vm_type = self.vm_type()?;
 		let spec = self.chain()?;
-		let mode = match self.args.arg_mode.as_ref() {
-			"last" => None,
-			mode => Some(to_mode(&mode, self.args.arg_mode_timeout, self.args.arg_mode_alarm)?),
-		};
 		let update_policy = self.update_policy()?;
 		let logger_config = self.logger_config();
 		let ws_conf = self.ws_config()?;
@@ -390,7 +386,6 @@ impl Configuration {
 				stratum: self.stratum_options()?,
 				update_policy: update_policy,
 				allow_missing_blocks: self.args.flag_jsonrpc_allow_missing_blocks,
-				mode: mode,
 				tracing: tracing,
 				fat_db: fat_db,
 				compaction: compaction,

--- a/parity/params.rs
+++ b/parity/params.rs
@@ -27,7 +27,6 @@ use miner::gas_pricer::GasPricer;
 use miner::gas_price_calibrator::{GasPriceCalibratorOptions, GasPriceCalibrator};
 use parity_version::version_data;
 use user_defaults::UserDefaults;
-use types::client_types::Mode;
 
 use crate::configuration;
 
@@ -359,10 +358,6 @@ pub fn fatdb_switch_to_bool(switch: Switch, user_defaults: &UserDefaults, _algor
 		(_, Switch::Auto, def) => Ok(def),
 	};
 	result
-}
-
-pub fn mode_switch_to_bool(switch: Option<Mode>, user_defaults: &UserDefaults) -> Result<Mode, String> {
-	Ok(switch.unwrap_or(user_defaults.mode().clone()))
 }
 
 #[cfg(test)]

--- a/parity/rpc.rs
+++ b/parity/rpc.rs
@@ -155,7 +155,7 @@ pub fn new_ws<D: rpc_apis::Dependencies>(
 	let handler = {
 		let mut handler = MetaIoHandler::with_middleware((
 			rpc::WsDispatcher::new(full_handler),
-			Middleware::new(deps.stats.clone(), deps.apis.activity_notifier())
+			Middleware::new(deps.stats.clone())
 		));
 		let apis = conf.apis.list_apis();
 		deps.apis.extend_with_set(&mut handler, &apis);
@@ -288,11 +288,11 @@ fn with_domain(items: Option<Vec<String>>, domain: &str, dapps_address: &Option<
 	})
 }
 
-pub fn setup_apis<D>(apis: ApiSet, deps: &Dependencies<D>) -> MetaIoHandler<Metadata, Middleware<D::Notifier>>
+pub fn setup_apis<D>(apis: ApiSet, deps: &Dependencies<D>) -> MetaIoHandler<Metadata, Middleware>
 	where D: rpc_apis::Dependencies
 {
 	let mut handler = MetaIoHandler::with_middleware(
-		Middleware::new(deps.stats.clone(), deps.apis.activity_notifier())
+		Middleware::new(deps.stats.clone())
 	);
 	let apis = apis.list_apis();
 	deps.apis.extend_with_set(&mut handler, &apis);

--- a/parity/rpc_apis.rs
+++ b/parity/rpc_apis.rs
@@ -36,7 +36,6 @@ use light::client::LightChainClient;
 use light::{Cache as LightDataCache, TransactionQueue as LightTransactionQueue};
 use miner::external::ExternalMiner;
 use parity_rpc::dispatch::{FullDispatcher, LightDispatcher};
-use parity_rpc::informant::{ActivityNotifier, ClientNotifier};
 use parity_rpc::{Host, Metadata, NetworkSettings};
 use parity_rpc::v1::traits::TransactionsPool;
 use parity_runtime::Executor;
@@ -220,11 +219,6 @@ macro_rules! add_signing_methods {
 
 /// RPC dependencies can be used to initialize RPC endpoints from APIs.
 pub trait Dependencies {
-	type Notifier: ActivityNotifier;
-
-	/// Create the activity notifier.
-	fn activity_notifier(&self) -> Self::Notifier;
-
 	/// Extend the given I/O handler with endpoints for each API.
 	fn extend_with_set<S>(&self, handler: &mut MetaIoHandler<Metadata, S>, apis: &HashSet<Api>)
 	where
@@ -457,27 +451,12 @@ impl FullDependencies {
 }
 
 impl Dependencies for FullDependencies {
-	type Notifier = ClientNotifier;
-
-	fn activity_notifier(&self) -> ClientNotifier {
-		ClientNotifier {
-			client: self.client.clone(),
-		}
-	}
-
 	fn extend_with_set<S>(&self, handler: &mut MetaIoHandler<Metadata, S>, apis: &HashSet<Api>)
 	where
 		S: core::Middleware<Metadata>,
 	{
 		self.extend_api(handler, apis, false)
 	}
-}
-
-/// Light client notifier. Doesn't do anything yet, but might in the future.
-pub struct LightClientNotifier;
-
-impl ActivityNotifier for LightClientNotifier {
-	fn active(&self) {}
 }
 
 /// RPC dependencies for a light client.
@@ -678,12 +657,6 @@ impl<C: LightChainClient + 'static> LightDependencies<C> {
 }
 
 impl<T: LightChainClient + 'static> Dependencies for LightDependencies<T> {
-	type Notifier = LightClientNotifier;
-
-	fn activity_notifier(&self) -> Self::Notifier {
-		LightClientNotifier
-	}
-
 	fn extend_with_set<S>(&self, handler: &mut MetaIoHandler<Metadata, S>, apis: &HashSet<Api>)
 	where
 		S: core::Middleware<Metadata>,

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -388,8 +388,6 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 	// check if fatdb is on
 	let fat_db = fatdb_switch_to_bool(cmd.fat_db, &user_defaults, algorithm)?;
 
-	// get the mode
-	// TODO: check if this is ok
 	let network_enabled = true;
 
 	// get the update policy

--- a/parity/snapshot_cmd.rs
+++ b/parity/snapshot_cmd.rs
@@ -31,7 +31,6 @@ use parking_lot::RwLock;
 use types::{
 	ids::BlockId,
 	snapshot::Progress,
-	client_types::Mode,
 	snapshot::RestorationStatus,
 };
 
@@ -176,7 +175,6 @@ impl SnapshotCommand {
 		let mut client_config = to_client_config(
 			&self.cache_config,
 			spec.name.to_lowercase(),
-			Mode::Active,
 			tracing,
 			fat_db,
 			self.compaction,

--- a/rpc/src/v1/impls/light/parity.rs
+++ b/rpc/src/v1/impls/light/parity.rs
@@ -289,10 +289,6 @@ where
 		Box::new(self.light_dispatch.next_nonce(address))
 	}
 
-	fn mode(&self) -> Result<String> {
-		Err(errors::light_unimplemented(None))
-	}
-
 	fn chain(&self) -> Result<String> {
 		Ok(self.settings.chain.clone())
 	}

--- a/rpc/src/v1/impls/parity.rs
+++ b/rpc/src/v1/impls/parity.rs
@@ -303,10 +303,6 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 		Box::new(future::ok(self.miner.next_nonce(&*self.client, &address)))
 	}
 
-	fn mode(&self) -> Result<String> {
-		Ok(self.client.mode().to_string())
-	}
-
 	fn enode(&self) -> Result<String> {
 		self.sync.enode().ok_or_else(errors::network_disabled)
 	}

--- a/rpc/src/v1/impls/parity_set.rs
+++ b/rpc/src/v1/impls/parity_set.rs
@@ -17,10 +17,8 @@
 /// Parity-specific rpc interface for operations altering the settings.
 use std::io;
 use std::sync::Arc;
-use std::time::Duration;
 
 use client_traits::BlockChainClient;
-use types::client_types::Mode;
 use ethcore::miner::{self, MinerService};
 use ethereum_types::{H160, H256, U256};
 use crypto::publickey::KeyPair;
@@ -205,14 +203,7 @@ impl<C, M, U, F> ParitySet for ParitySetClient<C, M, U, F> where
 		Ok(true)
 	}
 
-	fn set_mode(&self, mode: String) -> Result<bool> {
-		self.client.set_mode(match mode.as_str() {
-			"offline" => Mode::Off,
-			"dark" => Mode::Dark(Duration::from_secs(300)),
-			"passive" => Mode::Passive(Duration::from_secs(300), Duration::from_secs(3600)),
-			"active" => Mode::Active,
-			e => { return Err(errors::invalid_params("mode", e.to_owned())); },
-		});
+	fn set_mode(&self, _mode: String) -> Result<bool> {
 		Ok(true)
 	}
 

--- a/rpc/src/v1/traits/parity.rs
+++ b/rpc/src/v1/traits/parity.rs
@@ -164,10 +164,6 @@ pub trait Parity {
 	#[rpc(name = "parity_nextNonce")]
 	fn next_nonce(&self, _: H160) -> BoxFuture<U256>;
 
-	/// Get the mode. Returns one of: "active", "passive", "dark", "offline".
-	#[rpc(name = "parity_mode")]
-	fn mode(&self) -> Result<String>;
-
 	/// Get the chain name. Returns one of the pre-configured chain names or a filename.
 	#[rpc(name = "parity_chain")]
 	fn chain(&self) -> Result<String>;

--- a/rpc/src/v1/traits/parity_set.rs
+++ b/rpc/src/v1/traits/parity_set.rs
@@ -87,17 +87,19 @@ pub trait ParitySet {
 
 	/// Start the network.
 	///
-	/// @deprecated - Use `set_mode("active")` instead.
+	/// @deprecated - Inactive
 	#[rpc(name = "parity_startNetwork")]
 	fn start_network(&self) -> Result<bool>;
 
 	/// Stop the network.
 	///
-	/// @deprecated - Use `set_mode("offline")` instead.
+	/// @deprecated - Inactive
 	#[rpc(name = "parity_stopNetwork")]
 	fn stop_network(&self) -> Result<bool>;
 
 	/// Set the mode. Argument must be one of: "active", "passive", "dark", "offline".
+	///
+	/// @deprecated - Inactive
 	#[rpc(name = "parity_setMode")]
 	fn set_mode(&self, _: String) -> Result<bool>;
 


### PR DESCRIPTION
This is quite opinionated pr as it removes one of the parity features. Since 2016 parity allows users to set an operation mode of the node, that is: `online`, `passive`, `dark` or `off`. I believe that our users (who are mostly power users), never use any other option that `online`. Therefore I believe it is feasible to remove this feature, especially that it's implementation is not very clear, nor idiomatic