### PR TITLE
Fix registrar errors early in the chain

### DIFF
--- a/miner/src/service_transaction_checker.rs
+++ b/miner/src/service_transaction_checker.rs
@@ -44,12 +44,12 @@ impl ServiceTransactionChecker {
 		client: &C,
 		tx: &SignedTransaction
 	) -> Result<bool, String> {
-		let sender = tx.sender();
 		// Skip checking the contract if the transaction does not have zero gas price
 		if !tx.gas_price.is_zero() {
 			return Ok(false)
 		}
 
+		let sender = tx.sender();
 		self.check_address(client, sender)
 	}
 

--- a/util/registrar/src/registrar.rs
+++ b/util/registrar/src/registrar.rs
@@ -42,9 +42,10 @@ pub trait RegistrarClient: CallContract + Send + Sync {
 		let id = encode_input(hashed_key, DNS_A_RECORD);
 
 		let address_bytes = self.call_contract(block, registrar_address, id)?;
-
+		if address_bytes.is_empty() {
+			return Ok(None)
+		}
 		let address = decode_output(&address_bytes).map_err(|e| e.to_string())?;
-
 		if address.is_zero() {
 			Ok(None)
 		} else {


### PR DESCRIPTION
In [a previous PR](https://github.com/paritytech/parity-ethereum/pull/11110) the registrar contract was overhauled. After it, syncing from the beginning of the chain spews out a ton of errors like this:

```
2019-11-13 15:23:13  Verifier #9 ERROR client  Error occurred while refreshing service transaction cache: please ensure the contract and method you're calling exist! failed to decode empty bytes. if you're using jsonrpc this is likely due to jsonrpc returning `0x` in case contract or method don't exist
```

It looks a bit nasty but I don't think it's critical. At some point in the chain the problem goes away (not sure exactly were tbh but sometime after ~3M blocks).

The error message comes from `ethabi` and what it really means is we passed in an empty slice of bytes to the [`decode_output()`](https://github.com/paritytech/parity-ethereum/blob/79a17dedd00586126da37d520ec7ff57838fed3b/util/registrar/src/registrar.rs#L46). Further up in the chain we get `0x0000000000000000000000000000000000000000` back and so we hit the [`address.is_zero()` case](https://github.com/paritytech/parity-ethereum/pull/11257/files#diff-5eec7b3aa6bc193722fea0f36b33abbdR49) and all is good (I have a DB synced to ~4.4M where I see this).

So my question in this PR is: is it ok to change the code to interpret `[]` as "a zero address" and return `Ok(None)` [here](https://github.com/paritytech/parity-ethereum/blob/79a17dedd00586126da37d520ec7ff57838fed3b/util/registrar/src/registrar.rs#L44)?