### PR TITLE
Treat blocks, that already downloaded, as synced

### DIFF
--- a/ethcore/sync/src/block_sync.rs
+++ b/ethcore/sync/src/block_sync.rs
@@ -571,6 +571,8 @@ impl BlockDownloader {
 				},
 				Err(EthcoreError::Import(ImportError::AlreadyQueued)) => {
 					trace_sync!(self, "Block already queued {:?}", h);
+					// Treat blocks in queue as imported in order not to start retraction too early
+					imported.insert(h.clone());
 					self.block_imported(&h, number, &parent);
 				},
 				Ok(_) => {


### PR DESCRIPTION
Important: it's recreated #10864 I've decided to re-create it from the scratch, because it had a lot of not relevant commits, that were made during its testing. Now the fix is verified (in duet with #10895) and ready for review.

(Copypasted description)

This PR aims to fix the following scenario in the block sync:

1. Node downloads the next block number N and starts importing it. Due to block's complexity or some configuration issues block's import takes more time (I've seen this issue, when import took 5-10 seconds).
2. Meanwhile the next sync round has begun and Parity tries to sync block N once more time, obviously import of this block has no success with error AlreadyQueued. As a result the sync round has completed with 0 blocks synced
3. As no new blocks were synced during sync round Parity starts descending in block number, treating this situation as error during blocks download: https://github.com/paritytech/parity-ethereum/blob/master/ethcore/sync/src/block_sync.rs#L429 and repeats sync for (already downloaded) blocks
4. Attempt to sync block number N-1 returns the same error and causes attempt to download block N-2 and so on

See the sequence diagram:
![image](https://user-images.githubusercontent.com/5435439/69050822-16af7a80-0a03-11ea-8246-ed6bab709f02.png)

This downfall only finishes, when (if) block number N is imported and Parity catches up the current best block
As a result huge DDOS of GetBlock requests outcomes from the node. This also can affect current block's verification and exacerbates the issue.
Suggested solution:
Treat downloaded blocks on step 2 (marked * in the diagram) and further, that exist already in the chain or in the queue, as actually synced on this round and (as result) do not start error handling procedure with blocks descending.

Comments:

Relates to #10724.
Also such DDOS can cause the hanging of other node (see #10821 ), that replies to these massive GetBlocks requests.
This issue has similarities to the described in #9531 but has different scenario and root causes are not connected.