### PR TITLE
Don't prune ancient state when instantiating a Client

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -800,13 +800,6 @@ impl Client {
 			config,
 		});
 
-		// prune old states.
-		{
-			let state_db = client.state_db.read().boxed_clone();
-			let chain = client.chain.read();
-			client.prune_ancient(state_db, &chain)?;
-		}
-
 		// ensure genesis epoch proof in the DB.
 		{
 			let chain = client.chain.read();


### PR DESCRIPTION
This is possibly a controversial PR. 
Before this PR, a call to `Client::new()` will delete all state below the `--pruning-history` threshold. This is side-effectey and surprising and I don't think it is necessary; I think it is better if `Client::new()` avoids touching the database. 
For commands like e.g. `parity snapshot`, kicking off a pruning run before starting the snapshot can be problematic as state might be deleted before we even start; for other commands like `import`, `export`, or `reset`, pruning the state before executing the command seems unneccesary and slow.

After this the client will prune ancient state as a side effect of importing new blocks ([in `commit_block()`](https://github.com/paritytech/parity-ethereum/blob/b23c388550d2b636ce48f307f4397495966803d6/ethcore/src/client/client.rs#L587)), which I think is fine.