### PR TITLE
Fix atomicity violation in network-devp2p

### DIFF
--- a/util/network-devp2p/src/connection.rs
+++ b/util/network-devp2p/src/connection.rs
@@ -220,14 +220,13 @@ impl Connection {
 
 	/// Register this connection with the IO event loop.
 	pub fn register_socket<Host: Handler>(&self, reg: Token, event_loop: &mut EventLoop<Host>) -> io::Result<()> {
-		if self.registered.load(AtomicOrdering::SeqCst) {
+		if self.registered.compare_and_swap(false, true, AtomicOrdering::SeqCst) {
 			return Ok(());
         }
 		trace!(target: "network", "connection register; token={:?}", reg);
 		if let Err(e) = event_loop.register(&self.socket, reg, self.interest, PollOpt::edge() /* | PollOpt::oneshot() */) { // TODO: oneshot is broken on windows
 			trace!(target: "network", "Failed to register {:?}, {:?}", reg, e);
 		}
-		self.registered.store(true, AtomicOrdering::SeqCst);
 		Ok(())
 	}
 


### PR DESCRIPTION
It is to fix an atomicity violation in network-devp2p.

https://github.com/paritytech/parity-ethereum/blob/ee016127686f6cc63815b15d7df5aa22f4edc22c/util/network-devp2p/src/connection.rs#L222-L232

Following the same bug pattern of #5910
In function register_socket:
1. atomic variable registered is loaded and checked
2. if it is true, directly returns
3. otherwise, execute some code and set the atomic variable to true.

It seems that the atomic variable is used to guarantee that the inner code will only be executed once in multiple calls.
The function takes &self (instead of &mut self) and I think it may be called in different threads simultaneously.
If that is the case, the following execution path may happen:

1. Thread1 calls load and check, gets false
2. Thread2 calls load and check, also gets false
3. Thread2 calls the inner code and sets the variable to true
4. Thread1 calls the inner code again.

The atomicity violation happens because the read and write of one atomic variable are interleaved by another write.

The fix is to use one compare_and_swap to replace the separate load and store, as shown in the fix.
✄ -----------------------------------------------------------------------------
