### PR TITLE
Enable EIP-2384 for ice age hard fork

### DIFF
--- a/ethcore/res/ethereum/foundation.json
+++ b/ethcore/res/ethereum/foundation.json
@@ -137,7 +137,7 @@
 				"difficultyBombDelays": {
 					"0x42ae50": "0x2dc6c0",
 					"0x6f1580": "0x1e8480",
-					"0x8a61c8": "0x3d0900"
+					"0x8c6180": "0x3d0900"
 				}
 			}
 		}

--- a/ethcore/res/ethereum/foundation.json
+++ b/ethcore/res/ethereum/foundation.json
@@ -136,7 +136,8 @@
 				"eip100bTransition": "0x42ae50",
 				"difficultyBombDelays": {
 					"0x42ae50": "0x2dc6c0",
-					"0x6f1580": "0x1e8480"
+					"0x6f1580": "0x1e8480",
+					"0x8a61c8": "0x3d0900"
 				}
 			}
 		}

--- a/ethcore/res/ethereum/ropsten.json
+++ b/ethcore/res/ethereum/ropsten.json
@@ -16,7 +16,8 @@
 				"eip100bTransition": "0x19f0a0",
 				"difficultyBombDelays": {
 					"0x19f0a0": "0x2dc6c0",
-					"0x408b70": "0x1e8480"
+					"0x408b70": "0x1e8480",
+					"0x6c993d": "0x3d0900"
 				}
 			}
 		}


### PR DESCRIPTION
There is a discussion in AllCoreDevs to include a difficulty bomb delay in Istanbul, or potentially conduct another hard fork one month after Istanbul. The proposal EIP-2384 further delays the bomb for another 4 million blocks.

Note that this is not mergable until a decision is reached.