### PR TITLE
Fix esoteric test config variable

### DIFF
--- a/ethcore/res/ethereum/transition_test.json
+++ b/ethcore/res/ethereum/transition_test.json
@@ -28,6 +28,7 @@
 		"maxCodeSize": 24576,
 		"maxCodeSizeTransition": "0",
 		"eip150Transition": "0",
+		"eip155Transition": "0",
 		"eip160Transition": "0",
 		"eip161abcTransition": "0",
 		"eip161dTransition": "0",
@@ -35,7 +36,6 @@
 		"eip140Transition": "5",
 		"eip211Transition": "5",
 		"eip214Transition": "5",
-		"eip155Transition": "5",
 		"eip658Transition": "5"
 	},
 	"genesis": {

--- a/ethcore/res/ethereum/transition_test.json
+++ b/ethcore/res/ethereum/transition_test.json
@@ -57,6 +57,7 @@
 		"0000000000000000000000000000000000000002": { "balance": "1", "builtin": { "name": "sha256", "pricing": { "linear": { "base": 60, "word": 12 } } } },
 		"0000000000000000000000000000000000000003": { "balance": "1", "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
 		"0000000000000000000000000000000000000004": { "balance": "1", "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } },
+		"0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "activate_at": "0x5", "pricing": { "modexp": { "divisor": 20 } } } },
 		"0000000000000000000000000000000000000006": {
 			"builtin": {
 				"name": "alt_bn128_add",


### PR DESCRIPTION
EIP155 canonically (on Ethereum mainnet, for which these test were developed)
happens simultaneously with EIP158/161 and other "Spurious Dragon" upgrades.

This test is intended to test the transition from the EIP158/161 era (Spurious Dragon)
to the Byzantium era, with Byzantium changes happening at 5.
