### PR TITLE
upgrade vergen to 3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,11 +292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -3335,7 +3330,7 @@ dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "vergen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5115,11 +5110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vergen"
-version = "0.1.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5382,7 +5378,6 @@ dependencies = [
 "checksum bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9f04a5e50dc80b3d5d35320889053637d15011aed5e66b66b37ae798c65da6f7"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
-"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum bitvec 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9633b74910e1870f50f5af189b08487195cdb83c0e27a71d6f64d5e09dd0538b"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
@@ -5739,7 +5734,7 @@ dependencies = [
 "checksum validator 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "236a5eda3df2c877872e98dbc55d497d943792e6405d8fc65bd4f8a5e3b53c99"
 "checksum validator_derive 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d360d6f5754972c0c1da14fb3d5580daa31aee566e1e45e2f8d3bf5950ecd3e9"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum vergen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c3365f36c57e5df714a34be40902b27a992eeddb9996eca52d0584611cf885d"
+"checksum vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6aba5e34f93dc7051dfad05b98a18e9156f27e7b431fe1d2398cb6061c0a1dba"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -27,7 +27,7 @@ rlp = "0.4.0"
 target_info = "0.1"
 
 [build-dependencies]
-vergen = "0.1"
+vergen = "3.0.4"
 rustc_version = "0.2"
 toml = "0.4"
 

--- a/util/version/build.rs
+++ b/util/version/build.rs
@@ -30,6 +30,7 @@ fn main() {
 	let vergen_flags = ConstantsFlags::COMMIT_DATE |
 		ConstantsFlags::SHA |
 		ConstantsFlags::SHA_SHORT |
+		ConstantsFlags::TARGET_TRIPLE |
 		ConstantsFlags::REBUILD_ON_HEAD_CHANGE;
 	generate_cargo_keys(vergen_flags).expect(ERROR_MSG);
 

--- a/util/version/build.rs
+++ b/util/version/build.rs
@@ -22,12 +22,16 @@ use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
-use vergen::{vergen, OutputFns};
+use vergen::{ConstantsFlags, generate_cargo_keys};
 
 const ERROR_MSG: &'static str = "Failed to generate metadata files";
 
 fn main() {
-	vergen(OutputFns::all()).expect(ERROR_MSG);
+	let vergen_flags = ConstantsFlags::COMMIT_DATE |
+		ConstantsFlags::SHA |
+		ConstantsFlags::SHA_SHORT |
+		ConstantsFlags::REBUILD_ON_HEAD_CHANGE;
+	generate_cargo_keys(vergen_flags).expect(ERROR_MSG);
 
 	let version = rustc_version::version().expect(ERROR_MSG);
 

--- a/util/version/src/lib.rs
+++ b/util/version/src/lib.rs
@@ -38,9 +38,7 @@ const THIS_TRACK: &'static str = "unstable";
 
 /// Get the platform identifier.
 pub fn platform() -> String {
-	let env = Target::env();
-	let env_dash = if env.is_empty() { "" } else { "-" };
-	format!("{}-{}{}{}", Target::arch(), Target::os(), env_dash, env)
+	format!("{}", env!("VERGEN_TARGET_TRIPLE"))
 }
 
 /// Get the standard version string for this software.

--- a/util/version/src/lib.rs
+++ b/util/version/src/lib.rs
@@ -24,11 +24,6 @@ use target_info::Target;
 use bytes::Bytes;
 use rlp::RlpStream;
 
-mod vergen {
-	#![allow(unused)]
-	include!(concat!(env!("OUT_DIR"), "/version.rs"));
-}
-
 mod generated {
 	include!(concat!(env!("OUT_DIR"), "/meta.rs"));
 }
@@ -50,11 +45,16 @@ pub fn platform() -> String {
 
 /// Get the standard version string for this software.
 pub fn version() -> String {
-	let sha3 = vergen::short_sha();
-	let sha3_dash = if sha3.is_empty() { "" } else { "-" };
-	let commit_date = vergen::commit_date().replace("-", "");
-	let date_dash = if commit_date.is_empty() { "" } else { "-" };
-	format!("Parity-Ethereum/v{}-{}{}{}{}{}/{}/rustc{}", env!("CARGO_PKG_VERSION"), THIS_TRACK, sha3_dash, sha3, date_dash, commit_date, platform(), generated::rustc_version())
+	let commit_date = format!("{}", env!("VERGEN_COMMIT_DATE")).replace("-", "");
+	format!(
+		"Parity-Ethereum/v{}-{}-{}-{}/{}/rustc{}",
+		env!("CARGO_PKG_VERSION"),
+		THIS_TRACK,
+		env!("VERGEN_SHA_SHORT"),
+		commit_date,
+		platform(),
+		generated::rustc_version(),
+	)
 }
 
 /// Get the standard version data for this software.
@@ -73,5 +73,5 @@ pub fn version_data() -> Bytes {
 
 /// Provide raw information on the package.
 pub fn raw_package_info() -> (&'static str, &'static str, &'static str) {
-	(THIS_TRACK, env!["CARGO_PKG_VERSION"], vergen::sha())
+	(THIS_TRACK, env!["CARGO_PKG_VERSION"], env!["VERGEN_SHA"])
 }


### PR DESCRIPTION
I've noticed the version output was not always updated when switching between commit, added
`ConstantsFlags::REBUILD_ON_HEAD_CHANGE` to fix that.
The output has slightly changed (target triple)
before
```
version Parity-Ethereum/v2.7.0-unstable-cf2cb58e1-20191126/x86_64-linux-gnu/rustc1.39.0
```
after
```
version Parity-Ethereum/v2.7.0-unstable-dfa75c607-20191202/x86_64-unknown-linux-gnu/rustc1.39.0
```