### PR TITLE
interruptible test and build jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ image:                             ${REGISTRY}/parity-ci-linux:latest
 variables:
   GIT_STRATEGY:                    fetch
   GIT_SUBMODULE_STRATEGY:          recursive
+  GIT_DEPTH:                       3
   CI_SERVER_NAME:                  "GitLab CI"
   CARGO_HOME:                      "/ci-cache/${CI_PROJECT_NAME}/cargo/${CI_JOB_NAME}"
   CARGO_TARGET:                    x86_64-unknown-linux-gnu
@@ -31,9 +32,8 @@ variables:
       - tools/
 
 .docker-cache-status:              &docker-cache-status
-  variables:
-    CARGO_HOME:                    "/ci-cache/parity-ethereum/cargo/${CI_JOB_NAME}"
   dependencies:                    []
+  interruptible:                   true
   before_script:
     - rustup show
     - cargo --version


### PR DESCRIPTION
- `interruptible`: if more than one pipeline is launched for the branch, the previous pipeline's `interruptible` jobs will be auto-canceled on the fly. And jobs from the next stages won't be executed if previous stage was canceled. I didn't set it for publishing and deploying since it is dangerous to interrupt them.
- `GIT_DEPTH` sets amount of last commits pulled for the job
- `dependencies` is only needed in one job: `check_warnings:` copies artifacts from `test-linux-stable`