### PR TITLE
[WIP] Implements EIP-2364

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_const"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byte-slice-cast"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +648,14 @@ dependencies = [
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unexpected 0.1.0",
  "vm 0.1.0",
+]
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1362,10 +1375,13 @@ dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "common-types 0.1.0",
+ "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-io 1.12.0",
  "ethcore-network 1.12.0",
  "ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "igd 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3195,6 +3211,7 @@ dependencies = [
  "ethcore-logger 1.12.0",
  "ethcore-miner 1.12.0",
  "ethcore-network 1.12.0",
+ "ethcore-network-devp2p 1.12.0",
  "ethcore-private-tx 1.0.0",
  "ethcore-sync 1.12.0",
  "ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5450,6 +5467,7 @@ dependencies = [
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum bn 0.4.4 (git+https://github.com/paritytech/bn)" = "<none>"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
+"checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byte-slice-cast 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7cbcbf18128ec71d8d4a0d054461ec59fff5b75b7d10a4c9b7c7cb1a379c3e77"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
@@ -5468,6 +5486,7 @@ dependencies = [
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "6ec65ee4f9c9d16f335091d23693457ed4928657ba4982289d7fafee03bc614a"
 "checksum combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+"checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "938703e165481c8d612ea3479ac8342e5615185db37765162e762ec3523e2fc6"
 "checksum criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccdc6ce8bbe352ca89025bee672aa6d24f4eb8c53e3a8b5d1bc58011da072a2"
 "checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -28,8 +28,8 @@ use crate::light_sync::{self, SyncInfo};
 use crate::private_tx::PrivateTxHandler;
 use crate::chain::{
 	sync_packet::SyncPacket::{PrivateTransactionPacket, SignedPrivateTransactionPacket},
-	ChainSyncApi, SyncState, SyncStatus as EthSyncStatus, ETH_PROTOCOL_VERSION_62,
-	ETH_PROTOCOL_VERSION_63, PAR_PROTOCOL_VERSION_1, PAR_PROTOCOL_VERSION_2,
+	ChainSyncApi, SyncState, SyncStatus as EthSyncStatus, ETH_PROTOCOL_VERSION_63,
+	ETH_PROTOCOL_VERSION_64, PAR_PROTOCOL_VERSION_1, PAR_PROTOCOL_VERSION_2,
 	PAR_PROTOCOL_VERSION_3, PAR_PROTOCOL_VERSION_4,
 };
 
@@ -606,7 +606,7 @@ impl ChainNotify for EthSync {
 			_ => {},
 		}
 
-		self.network.register_protocol(self.eth_handler.clone(), self.subprotocol_name, &[ETH_PROTOCOL_VERSION_62, ETH_PROTOCOL_VERSION_63])
+		self.network.register_protocol(self.eth_handler.clone(), self.subprotocol_name, &[ETH_PROTOCOL_VERSION_63, ETH_PROTOCOL_VERSION_64])
 			.unwrap_or_else(|e| warn!("Error registering ethereum protocol: {:?}", e));
 		// register the warp sync subprotocol
 		self.network.register_protocol(self.eth_handler.clone(), WARP_SYNC_PROTOCOL_ID, &[PAR_PROTOCOL_VERSION_1, PAR_PROTOCOL_VERSION_2, PAR_PROTOCOL_VERSION_3, PAR_PROTOCOL_VERSION_4])

--- a/ethcore/sync/src/chain/handler.rs
+++ b/ethcore/sync/src/chain/handler.rs
@@ -32,7 +32,7 @@ use crate::{
 			}
 		},
 		BlockSet, ChainSync, ForkConfirmation, PacketDecodeError, PeerAsking, PeerInfo, SyncRequester,
-		SyncState, ETH_PROTOCOL_VERSION_62, ETH_PROTOCOL_VERSION_63, MAX_NEW_BLOCK_AGE, MAX_NEW_HASHES,
+		SyncState, ETH_PROTOCOL_VERSION_63, ETH_PROTOCOL_VERSION_64, MAX_NEW_BLOCK_AGE, MAX_NEW_HASHES,
 		PAR_PROTOCOL_VERSION_1, PAR_PROTOCOL_VERSION_3, PAR_PROTOCOL_VERSION_4,
 	}
 };
@@ -630,7 +630,7 @@ impl SyncHandler {
 
 		if false
 			|| (warp_protocol && (peer.protocol_version < PAR_PROTOCOL_VERSION_1.0 || peer.protocol_version > PAR_PROTOCOL_VERSION_4.0))
-			|| (!warp_protocol && (peer.protocol_version < ETH_PROTOCOL_VERSION_62.0 || peer.protocol_version > ETH_PROTOCOL_VERSION_63.0))
+			|| (!warp_protocol && (peer.protocol_version < ETH_PROTOCOL_VERSION_63.0 || peer.protocol_version > ETH_PROTOCOL_VERSION_64.0))
 		{
 			trace!(target: "sync", "Peer {} unsupported eth protocol ({})", peer_id, peer.protocol_version);
 			return Err(DownloaderImportError::Invalid);

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -147,6 +147,8 @@ malloc_size_of_is_0!(PeerInfo);
 
 pub type PacketDecodeError = DecoderError;
 
+/// 64 version of Ethereum protocol.
+pub const ETH_PROTOCOL_VERSION_64: (u8, u8) = (64, 0x11);
 /// 63 version of Ethereum protocol.
 pub const ETH_PROTOCOL_VERSION_63: (u8, u8) = (63, 0x11);
 /// 62 version of Ethereum protocol.
@@ -718,7 +720,7 @@ impl ChainSync {
 		let last_imported_number = self.new_blocks.last_imported_block_number();
 		SyncStatus {
 			state: self.state.clone(),
-			protocol_version: ETH_PROTOCOL_VERSION_63.0,
+			protocol_version: ETH_PROTOCOL_VERSION_64.0,
 			network_id: self.network_id,
 			start_block_number: self.starting_block,
 			last_imported_block_number: Some(last_imported_number),
@@ -1238,7 +1240,7 @@ impl ChainSync {
 		let warp_protocol_version = io.protocol_version(&WARP_SYNC_PROTOCOL_ID, peer);
 		let warp_protocol = warp_protocol_version != 0;
 		let private_tx_protocol = warp_protocol_version >= PAR_PROTOCOL_VERSION_3.0;
-		let protocol = if warp_protocol { warp_protocol_version } else { ETH_PROTOCOL_VERSION_63.0 };
+		let protocol = if warp_protocol { warp_protocol_version } else { ETH_PROTOCOL_VERSION_64.0 };
 		trace!(target: "sync", "Sending status to {}, protocol version {}", peer, protocol);
 		let mut packet = RlpStream::new();
 		packet.begin_unbounded_list();

--- a/ethcore/sync/src/tests/helpers.rs
+++ b/ethcore/sync/src/tests/helpers.rs
@@ -24,7 +24,7 @@ use crate::{
 			PacketInfo,
 			SyncPacket::{self, PrivateTransactionPacket, SignedPrivateTransactionPacket}
 		},
-		ChainSync, SyncSupplier, ETH_PROTOCOL_VERSION_63, PAR_PROTOCOL_VERSION_4
+		ChainSync, SyncSupplier, ETH_PROTOCOL_VERSION_64, PAR_PROTOCOL_VERSION_4
 	},
 	private_tx::SimplePrivateTxHandler,
 	sync_io::SyncIo,
@@ -156,7 +156,7 @@ impl<'p, C> SyncIo for TestIo<'p, C> where C: FlushingBlockChainClient, C: 'p {
 	}
 
 	fn eth_protocol_version(&self, _peer: PeerId) -> u8 {
-		ETH_PROTOCOL_VERSION_63.0
+		ETH_PROTOCOL_VERSION_64.0
 	}
 
 	fn protocol_version(&self, protocol: &ProtocolId, peer_id: PeerId) -> u8 {

--- a/parity/rpc_apis.rs
+++ b/parity/rpc_apis.rs
@@ -329,6 +329,9 @@ impl FullDependencies {
 							EthPubSubClient::new(self.client.clone(), self.executor.clone(), pool_receiver);
 						let weak_client = Arc::downgrade(&self.client);
 
+						// Start subscribing new block heads.
+						parity_rpc::v1::subscribe_header(&client);
+
 						client.add_sync_notifier(self.sync.sync_notification(), move |state| {
 							let client = weak_client.upgrade()?;
 							let queue_info = client.queue_info();
@@ -566,6 +569,9 @@ impl<C: LightChainClient + 'static> LightDependencies<C> {
 						self.gas_price_percentile,
 						receiver
 					);
+
+					// Start subscribing new block heads.
+					parity_rpc::v1::subscribe_header(&client);
 
 					let weak_client = Arc::downgrade(&self.client);
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -45,6 +45,7 @@ ethcore-light = { path = "../ethcore/light" }
 ethcore-logger = { path = "../parity/logger" }
 ethcore-miner = { path = "../miner" }
 ethcore-network = { path = "../util/network" }
+ethcore-network-devp2p = { path = "../util/network-devp2p" }
 ethcore-private-tx = { path = "../ethcore/private-tx" }
 ethcore-sync = { path = "../ethcore/sync" }
 ethereum-types = "0.8.0"

--- a/rpc/src/v1/helpers/fork_id.rs
+++ b/rpc/src/v1/helpers/fork_id.rs
@@ -1,0 +1,36 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity Ethereum.
+
+// Parity Ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
+
+/// Implements EIP-2364 for using `fork_id` to check if the peer is compatible.
+
+use v1::{EthPubSub, EthPubSubClient, Metadata};
+use v1::types::pubsub::Kind;
+use jsonrpc_pubsub::typed::Subscriber;
+use futures::sync::mpsc;
+use jsonrpc_pubsub::SubscriptionId;
+
+/// Start subscribing new header.
+pub fn subscribe_header<C: Send + Sync + 'static>(client: &EthPubSubClient<C>)
+    -> (jsonrpc_pubsub::oneshot::Receiver<Result<SubscriptionId,
+        jsonrpc_core::Error>>, mpsc::Receiver<String>) {
+    let meta_data = Metadata::default();
+
+    let (subscriber, id, subscription) = Subscriber::new_test("eip_2364");
+
+    EthPubSubClient::subscribe(client, meta_data, subscriber, Kind::NewHeads, None);
+
+    (id, subscription)
+}

--- a/rpc/src/v1/helpers/mod.rs
+++ b/rpc/src/v1/helpers/mod.rs
@@ -40,6 +40,7 @@ mod subscribers;
 mod subscription_manager;
 mod work;
 mod signature;
+mod fork_id;
 
 pub use self::dispatch::{Dispatcher, FullDispatcher, LightDispatcher};
 pub use self::signature::verify_signature;
@@ -52,6 +53,7 @@ pub use self::requests::{
 pub use self::subscribers::Subscribers;
 pub use self::subscription_manager::GenericPollManager;
 pub use self::work::submit_work_detail;
+pub use self::fork_id::subscribe_header;
 
 pub fn to_url(address: &Option<::Host>) -> Option<String> {
 	address.as_ref().map(|host| (**host).to_owned())

--- a/rpc/src/v1/mod.rs
+++ b/rpc/src/v1/mod.rs
@@ -43,7 +43,7 @@ pub mod traits;
 
 pub use self::traits::{Debug, Eth, EthFilter, EthPubSub, EthSigning, Net, Parity, ParityAccountsInfo, ParityAccounts, ParitySet, ParitySetAccounts, ParitySigning, Personal, PubSub, Private, Rpc, SecretStore, Signer, Traces, Web3};
 pub use self::impls::*;
-pub use self::helpers::{NetworkSettings, block_import, dispatch};
+pub use self::helpers::{NetworkSettings, block_import, dispatch, subscribe_header};
 pub use self::metadata::Metadata;
 pub use self::types::Origin;
 pub use self::types::pubsub::PubSubSyncStatus;

--- a/util/network-devp2p/Cargo.toml
+++ b/util/network-devp2p/Cargo.toml
@@ -17,6 +17,7 @@ slab = "0.2"
 igd = "0.9"
 libc = "0.2.7"
 parking_lot = "0.9"
+futures = "0.1.6"
 ansi_term = "0.11"
 rustc-hex = "1.0"
 ethcore-io = { path = "../io", features = ["mio"] }
@@ -32,6 +33,8 @@ parity-snappy = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 lru-cache = "0.1"
+crc = "1.8"
+common-types = { path = "../../ethcore/types" }
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/util/network-devp2p/src/eth_entry.rs
+++ b/util/network-devp2p/src/eth_entry.rs
@@ -1,0 +1,35 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity Ethereum.
+
+// Parity Ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::fork_id::ID;
+use blockchain::BlockChain;
+
+/// EthEntry is the "eth" db entry for advertising eth protocol on the discovery network.
+pub struct EthEntry {
+    fork_id: ID,    // Fork identifier defined in EIP-2124
+    rest: String    // For forward compatibility ignore additional fields
+}
+
+impl EthEntry {
+    /// Get current ENR entry object.
+    pub fn get_current(chain: &BlockChain) -> EthEntry {
+        let fork_id = ID::new(chain);
+        EthEntry {
+            fork_id,
+            rest: r#"rlp:"tail""#.to_owned()
+        }
+    }
+}

--- a/util/network-devp2p/src/fork_id.rs
+++ b/util/network-devp2p/src/fork_id.rs
@@ -1,0 +1,212 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity Ethereum.
+
+// Parity Ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::io::{Error, ErrorKind};
+
+use common_types::{
+    BlockNumber,
+    engines::params::CommonParams
+};
+use log::{error, Metadata};
+use crc::crc32;
+use ethereum_types::H256;
+
+/// A fork identifier as defined by EIP-2124.
+#[derive(Debug)]
+pub struct ID {
+    hash: u32,          // CRC32 checksum of the all fork blocks from genesis.
+    next: BlockNumber   // Next upcoming fork block number, 0 if not yet known.
+}
+
+impl ID {
+    /// Calculates the Ethereum fork ID from the chain_info.
+    pub fn new(params: &CommonParams, genesis_hash: &H256, best_block: BlockNumber) -> Self {
+        ID::new_inner(
+            params,
+            genesis_hash,
+            best_block
+        )
+    }
+
+    // Use *_inner to allow testing the IDs without
+    // having to simulate an entire blockchain.
+    fn new_inner(params: &CommonParams, genesis: &H256, head: BlockNumber) -> Self {
+        let mut hash = crc32::checksum_ieee(&genesis[..]);
+        let mut next= 0;
+        let forks = Filter::get_forks_history(params);
+        let _: Vec<_> = forks.into_iter()
+            .filter(|fork| *fork <= head)
+            .map(|fork| {
+                hash = Filter::update_checksum(hash, &fork);
+                next = fork;
+            })
+            .collect();
+
+        ID {
+            hash,
+            next
+        }
+    }
+}
+
+/// A filter that returns if a fork ID should be rejected or not
+/// based on the local chain's status.
+pub struct Filter {
+    check_sums: Vec<u32>,
+    forks: Vec<BlockNumber>,
+    head: BlockNumber,
+}
+
+impl Filter {
+    /// Make new Filter for checking if a fork ID should be rejected to connect or not.
+    pub fn new(params: &CommonParams, genesis_hash: H256) -> Self {
+        Filter::new_inner(
+            0,
+            params,
+            genesis_hash
+        )
+    }
+
+    /// Calling inner function is to allow testing it without having to simulate an entire blockchain.
+    pub fn new_inner(head: BlockNumber, params: &CommonParams, genesis: H256) -> Self {
+        let mut check_sums = Vec::new();
+        let forks = Filter::get_forks_history(params);
+        let mut hash = crc32::checksum_ieee(&genesis[..]);
+        check_sums.push(hash);
+        check_sums.extend(forks.iter()
+            .map(|fork| {
+                hash = Filter::update_checksum(hash, fork);
+                hash
+            })
+        );
+
+        Filter {
+            check_sums,
+            forks,
+            head
+        }
+    }
+
+    /// Check if a fork block ID should be accepted or rejected to connect.
+    pub fn is_valid(&self, id: ID) -> Result<(), Error> {
+        // The fork checksum validation ruleset is:
+        //   1. If local and remote fork checksum matches, compare local head to FORK_NEXT.
+        //        The two nodes are in the same fork state currently.
+        //        They might know different future forks, but that's not matter until
+        //          the fork actually will happen.
+        //      1-1. A remote node announced but remote node does not passed a block and
+        //          the block is already passed at local node,
+        //          this is invalid because the chains are incompatible.
+        //      1-2. Remote node does not announce fork,
+        //          Or the fork does not yet passed at local node, then it is valid.
+        //   2. If the remote FORK_CSUM is a subset of the local forks set and the
+        //      remote FORK_NEXT matches with a fork block number of local forks set,
+        //      it is valid.
+        //        Remote node is currently syncing. It may diverge in the future,
+        //        but at this point we don't have enough information.
+        //   3. If the remote FORK_CSUM is a superset of the local forks set and can
+        //      be completed with future forks of local set, it is valid.
+        //        Local node is currently syncing. It may diverge from in the future,
+        //        but at this point we don't have enough information.
+        //   4. Reject in all other cases.
+
+        let _ = self.forks.iter().enumerate()
+            .filter(|(_i, fork)| &self.head <= fork)
+            .map(|(i, _fork)| {
+                // First unpassed fork block is found, check if our current state matches
+                // the remote checksum (rule #1).
+                if self.check_sums[i] == id.hash {
+                    // Checksum matches, check if remote future fork block already passed (rule #1-1)
+                    if id.next > 0 && self.head >= id.next {
+                        return Err(Error::new(ErrorKind::Other, ""))
+                    }
+                    // Local node does not yet passed a remote fork, valid (rule #1-2)
+                    return Ok(())
+                }
+
+                // The local and remote nodes are in different forks currently, check if the
+                // remote checksum is a subset of our local forks (rule #2).
+                let mut j = 0;
+                while j < i {
+                    j += 1;
+                    if self.check_sums[j] == id.hash {
+                        // Remote checksum is a subset, validate based on the announced next fork
+                        if self.forks[j] != id.next {
+                            return Err(Error::new(ErrorKind::Other, ""))
+                        }
+                        return Ok(())
+                    }
+                }
+                // Remote chain is not a subset of our local one, check if it's a superset by
+                // any chance, signalling that we're simply out of sync (rule #3).
+                let mut j = i;
+                while j < self.check_sums.len() {
+                    j += 1;
+                    if self.check_sums[j] == id.hash {
+                        // Yay, remote checksum is a superset, ignore upcoming forks
+                        return Ok(())
+                    }
+                }
+                // No exact, subset or superset match. We are on differing chains, reject.
+                return Err(Error::new(ErrorKind::Other, ""))
+            }).collect::<Vec<_>>();
+
+        error!(target: "network", "Impossible fork ID validation error: id = {:?}.", id);
+        Ok(()) // Something is wrong, accept rather than reject.
+    }
+
+    // Calculates the next IEEE CRC32 checksum based on the formula of CRC32(original-blob || fork).
+    fn update_checksum(hash: u32, fork: &BlockNumber) -> u32 {
+        let blob = fork.to_be_bytes();
+        crc32::update(hash, &crc32::IEEE_TABLE, &blob)
+    }
+
+    // Get forks history data
+    fn get_forks_history(params: &CommonParams) -> Vec<BlockNumber> {
+        let mut fork_history = Vec::new();
+
+        fork_history.push(params.eip150_transition);
+        fork_history.push(params.eip160_transition);
+        fork_history.push(params.eip161abc_transition);
+        fork_history.push(params.eip161d_transition);
+        fork_history.push(params.eip98_transition);
+        fork_history.push(params.eip658_transition);
+        fork_history.push(params.eip155_transition);
+        fork_history.push(params.eip140_transition);
+        fork_history.push(params.eip210_transition);
+        fork_history.push(params.eip211_transition);
+        fork_history.push(params.eip214_transition);
+        fork_history.push(params.eip145_transition);
+        fork_history.push(params.eip1052_transition);
+        fork_history.push(params.eip1283_transition);
+        fork_history.push(params.eip1014_transition);
+        fork_history.push(params.eip1706_transition);
+        fork_history.push(params.eip1344_transition);
+        fork_history.push(params.eip1884_transition);
+        fork_history.push(params.eip2028_transition);
+        fork_history.push(params.dust_protection_transition);
+        fork_history.push(params.wasm_activation_transition);
+        fork_history.push(params.kip4_transition);
+        fork_history.push(params.kip6_transition);
+        fork_history.push(params.max_code_size_transition);
+        fork_history.push(params.transaction_permission_contract_transition);
+
+        fork_history.sort();
+
+        fork_history
+    }
+}
+

--- a/util/network-devp2p/src/lib.rs
+++ b/util/network-devp2p/src/lib.rs
@@ -73,5 +73,7 @@ mod discovery;
 mod service;
 mod node_table;
 mod ip_utils;
+mod fork_id;
+//mod eth_entry;
 
 const PROTOCOL_VERSION: u32 = 5;


### PR DESCRIPTION
Implemets EIP-2364.
EIP-2364 includes EIP-2124 which use `fork_id` to check if remote node is compatible or not.
Only compatible nodes would be connected.
This saves unnecessary packets to connect to incompatible nodes.
*** Currently it is not yet done. ***