### PR TITLE
Add check for deserialising hex values over U256 limit

### DIFF
--- a/json/src/spec/account.rs
+++ b/json/src/spec/account.rs
@@ -103,7 +103,7 @@ mod tests {
 	#[should_panic]
 	fn account_balance_panics_over_u256_limit() {
 		let s = r#"{
-			"nonce": "0x10000000000000000000000000000000000000000000000000000000000000000"
+			"balance": "0x10000000000000000000000000000000000000000000000000000000000000000"
 		}"#;
 		let _: Account = serde_json::from_str(s).unwrap();
 	}

--- a/json/src/spec/account.rs
+++ b/json/src/spec/account.rs
@@ -100,6 +100,15 @@ mod tests {
 	}
 
 	#[test]
+	#[should_panic]
+	fn account_balance_panics_over_u256_limit() {
+		let s = r#"{
+			"nonce": "0x10000000000000000000000000000000000000000000000000000000000000000"
+		}"#;
+		let _: Account = serde_json::from_str(s).unwrap();
+	}
+
+	#[test]
 	fn account_empty() {
 		let s = r#"{
 			"builtin": {

--- a/json/src/spec/account.rs
+++ b/json/src/spec/account.rs
@@ -100,15 +100,6 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic]
-	fn account_balance_panics_over_u256_limit() {
-		let s = r#"{
-			"balance": "0x10000000000000000000000000000000000000000000000000000000000000000"
-		}"#;
-		let _: Account = serde_json::from_str(s).unwrap();
-	}
-
-	#[test]
 	fn account_empty() {
 		let s = r#"{
 			"builtin": {

--- a/json/src/uint.rs
+++ b/json/src/uint.rs
@@ -125,6 +125,7 @@ pub fn validate_optional_non_zero<'de, D>(d: D) -> Result<Option<Uint>, D::Error
 mod test {
 	use super::Uint;
 	use ethereum_types::U256;
+	use serde_json::error::Category;
 
 	#[test]
 	fn uint_deserialization() {
@@ -137,6 +138,18 @@ mod test {
 				   Uint(U256::from(0)),
 				   Uint(U256::from(0))
 		]);
+	}
+
+	#[test]
+	fn uint_deserialization_error_for_hex_too_large() {
+		let hex = format!("0x{}", "1".repeat(65));
+		let result: Result<Uint, _> = serde_json::from_str(&format!(r#""{}""#, hex));
+		let err = result.unwrap_err();
+		assert_eq!(err.classify(), Category::Data);
+		assert_eq!(
+			format!("{}", err),
+			format!("Invalid hex value {}: value too big at line 1 column 69", hex)
+		);
 	}
 
 	#[test]

--- a/json/src/uint.rs
+++ b/json/src/uint.rs
@@ -78,7 +78,7 @@ impl<'a> Visitor<'a> for UintVisitor {
 			2 if value.starts_with("0x") => U256::from(0),
 			_ if value.starts_with("0x") => {
 				if value.len() > 66 {
-					return Err(Error::custom(format!("Invalid hex value {}", value).as_str()));
+					return Err(Error::custom(format!("Invalid hex value {}: value too big", value).as_str()));
 				}
 				U256::from_str(&value[2..]).map_err(|e| {
 					Error::custom(format!("Invalid hex value {}: {}", value, e).as_str())

--- a/json/src/uint.rs
+++ b/json/src/uint.rs
@@ -76,9 +76,14 @@ impl<'a> Visitor<'a> for UintVisitor {
 		let value = match value.len() {
 			0 => U256::from(0),
 			2 if value.starts_with("0x") => U256::from(0),
-			_ if value.starts_with("0x") => U256::from_str(&value[2..]).map_err(|e| {
-				Error::custom(format!("Invalid hex value {}: {}", value, e).as_str())
-			})?,
+			_ if value.starts_with("0x") => {
+				if value.len() > 66 {
+					return Err(Error::custom(format!("Invalid hex value {}", value).as_str()));
+				}
+				U256::from_str(&value[2..]).map_err(|e| {
+					Error::custom(format!("Invalid hex value {}: {}", value, e).as_str())
+				})?
+			},
 			_ => U256::from_dec_str(value).map_err(|e| {
 				Error::custom(format!("Invalid decimal value {}: {:?}", value, e).as_str())
 			})?


### PR DESCRIPTION
Add a length check to return appropriate error when attempting to deserialise hex values over the U256 limit.

Fixes #11268