### PR TITLE
ethcore/res: activate agharta on classic 9573000

### DIFF
--- a/ethcore/res/ethereum/classic.json
+++ b/ethcore/res/ethereum/classic.json
@@ -37,7 +37,10 @@
 		"eip140Transition": "0x85d9a0",
 		"eip211Transition": "0x85d9a0",
 		"eip214Transition": "0x85d9a0",
-		"eip658Transition": "0x85d9a0"
+		"eip658Transition": "0x85d9a0",
+		"eip145Transition": "0x921288",
+		"eip1014Transition": "0x921288",
+		"eip1052Transition": "0x921288"
 	},
 	"genesis": {
 		"seal": {


### PR DESCRIPTION
activates ecip-1056 on ethereum classic mainnet block 9573000.

activation is on january 15th, in ~34 days, please consider a patch release with updated specs.

ref https://github.com/ethereumclassic/ECIPs/pull/245