### PR TITLE
json-tests: Fix compile error

### DIFF
--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -116,7 +116,7 @@ evm-debug-tests = ["evm-debug", "evm/evm-debug-tests"]
 # EVM debug traces are printed.
 slow-blocks = []
 # Run JSON consensus tests.
-json-tests = ["env_logger", "test-helpers", "lazy_static", "machine/test-helpers"]
+json-tests = ["env_logger", "test-helpers", "lazy_static", "machine/test-helpers", "common-types/test-helpers"]
 # Run memory/cpu heavy tests.
 test-heavy = []
 # Compile test helpers


### PR DESCRIPTION
I got the compile error when I run the tests:

```sh
$ pwd
/Users/akihito1/src/github.com/ackintosh/parity-ethereum/ethcore

$ cargo test --features=json-tests
   Compiling ethcore v1.12.0 (/Users/akihito1/src/github.com/ackintosh/parity-ethereum/ethcore)
error[E0277]: the trait bound `types::transaction::SignedTransaction: std::convert::From<ethjson::transaction::Transaction>` is not satisfied
  --> ethcore/src/json_tests/state.rs:78:83
   |
78 |                     let transaction: SignedTransaction = multitransaction.select(&state.indexes).into();
   |                                                                                                  ^^^^ the trait `std::convert::From<ethjson::transaction::Transaction>` is not implemented for `types::transaction::SignedTransaction`
   |
   = note: required because of the requirements on the impl of `std::convert::Into<types::transaction::SignedTransaction>` for `ethjson::transaction::Transaction`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: could not compile `ethcore`.
warning: build failed, waiting for other jobs to finish...
error[E0277]: the trait bound `types::transaction::SignedTransaction: std::convert::From<ethjson::transaction::Transaction>` is not satisfied
  --> ethcore/src/json_tests/state.rs:78:83
   |
78 |                     let transaction: SignedTransaction = multitransaction.select(&state.indexes).into();
   |                                                                                                  ^^^^ the trait `std::convert::From<ethjson::transaction::Transaction>` is not implemented for `types::transaction::SignedTransaction`
   |
   = note: required because of the requirements on the impl of `std::convert::Into<types::transaction::SignedTransaction>` for `ethjson::transaction::Transaction`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: could not compile `ethcore`.

To learn more, run the command again with --verbose.
```

The error is due to the PR that [adding `cfg` to the From trait](https://github.com/paritytech/parity-ethereum/pull/11335/files#diff-ffdd27c0e6928e872d31ecdc8f8e09eaR141).
https://github.com/paritytech/parity-ethereum/pull/11335