### PR TITLE
ethcore/res: fix ethereum classic chainspec blake2_f activation block…

### DIFF
--- a/ethcore/res/ethereum/classic.json
+++ b/ethcore/res/ethereum/classic.json
@@ -4466,7 +4466,7 @@
 			"balance": "0x1",
 			"builtin": {
 				"name": "blake2_f",
-				"activate_at": "0x1f67cf",
+				"activate_at": "0xa03ae7",
 				"pricing": {
 					"blake2_f": {
 						"gas_per_round": 1


### PR DESCRIPTION
Accidentally introduced in #11347

Block number was copy-pasted from the Kotti chainspec. /cc @sorpaas 

Correct block numbers can be compared against: https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1061.md#abstract

This needs a timely chain-spec release if possible.

- [x] You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points reviewers should know?
  - Is there something left for follow-up PRs?
- [ ] You labeled the PR with appropriate labels if you have permissions to do so.
- [x] You mentioned a related issue if this PR related to it, e.g. `Fixes #228` or `Related #1337`.
- [x] You asked any particular reviewers to review. If you aren't sure, start with GH suggestions.
- [x] Your PR adheres [the style guide](https://wiki.parity.io/Coding-guide)
  - In particular, mind the maximal line length.
  - There is no commented code checked in unless necessary.
  - Any panickers have a proof or removed.
- [ ] You updated any rustdocs which may have changed
