### PR TITLE
dependencies: bump `derive_more v0.99`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.1.0"
 dependencies = [
  "account-db 0.1.0",
  "common-types 0.1.0",
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "journaldb 0.2.0",
@@ -181,7 +181,7 @@ dependencies = [
  "block-reward 0.1.0",
  "client-traits 0.1.0",
  "common-types 0.1.0",
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "engine 0.1.0",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 9.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -645,7 +645,7 @@ dependencies = [
 name = "common-types"
 version = "0.1.0"
 dependencies = [
- "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethbloom 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-io 1.12.0",
  "ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -849,26 +849,12 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.14.0"
+version = "0.99.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1291,7 +1277,7 @@ dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "client-traits 0.1.0",
  "common-types 0.1.0",
- "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "engine 0.1.0",
  "ethcore 1.12.0",
  "ethcore-blockchain 0.1.0",
@@ -1388,7 +1374,7 @@ name = "ethcore-network"
 version = "1.12.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-io 1.12.0",
  "ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1443,7 +1429,7 @@ dependencies = [
  "account-state 0.1.0",
  "client-traits 0.1.0",
  "common-types 0.1.0",
- "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 9.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi-contract 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5642,8 +5628,7 @@ dependencies = [
 "checksum ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
 "checksum ctr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "022cd691704491df67d25d006fe8eca083098253c4d43516c2206479c58c6736"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fbe9f11be34f800b3ecaaed0ec9ec2e015d1d0ba0c8644c1310f73d6e8994615"
-"checksum derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
+"checksum derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2159be042979966de68315bce7034bb000c775f22e3e834e1c52ff78f041cae8"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"

--- a/ethcore/account-state/Cargo.toml
+++ b/ethcore/account-state/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 common-types = { path = "../types"}
-derive_more = "0.15.0"
+derive_more = "0.99"
 ethereum-types = "0.8.0"
 ethtrie = { package = "patricia-trie-ethereum", path = "../../util/patricia-trie-ethereum" }
 trie-vm-factories = { path = "../trie-vm-factories" }

--- a/ethcore/engines/authority-round/Cargo.toml
+++ b/ethcore/engines/authority-round/Cargo.toml
@@ -11,7 +11,7 @@ block-gas-limit = { path = "../../block-gas-limit" }
 block-reward = { path = "../../block-reward" }
 client-traits = { path = "../../client-traits" }
 common-types = { path = "../../types" }
-derive_more = "0.15.0"
+derive_more = "0.99"
 ethabi = "9.0.1"
 ethabi-contract = "9.0.0"
 ethabi-derive = "9.0.1"

--- a/ethcore/light/Cargo.toml
+++ b/ethcore/light/Cargo.toml
@@ -11,7 +11,7 @@ log = "0.4"
 parity-bytes = "0.1"
 client-traits = { path = "../client-traits" }
 common-types = { path = "../types" }
-derive_more = "0.14.0"
+derive_more = "0.99"
 engine = { path = "../engine" }
 ethcore-db = { path = "../db" }
 ethcore-blockchain = { path = "../blockchain" }

--- a/ethcore/private-tx/Cargo.toml
+++ b/ethcore/private-tx/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 account-state = { path = "../account-state" }
 client-traits = { path = "../client-traits" }
 common-types = { path = "../types" }
-derive_more = "0.14.0"
+derive_more = "0.99"
 ethabi = "9.0.1"
 ethabi-contract = "9.0.0"
 ethabi-derive = "9.0.1"

--- a/ethcore/types/Cargo.toml
+++ b/ethcore/types/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
-derive_more = "0.15.0"
+derive_more = "0.99"
 ethbloom = "0.8.0"
 ethcore-io = { path = "../../util/io" }
 ethereum-types = "0.8.0"

--- a/ethcore/types/src/errors/engine_error.rs
+++ b/ethcore/types/src/errors/engine_error.rs
@@ -16,12 +16,11 @@
 
 use std::fmt;
 
-use derive_more::From;
 use ethereum_types::{Address, H64, H256};
 use unexpected::{Mismatch, OutOfBounds};
 
 /// Voting errors.
-#[derive(Debug, From)]
+#[derive(Debug)]
 pub enum EngineError {
 	/// Signature or author field does not belong to an authority.
 	NotAuthorized(Address),
@@ -78,11 +77,11 @@ impl fmt::Display for EngineError {
 		use self::EngineError::*;
 		let msg = match *self {
 			CliqueMissingCheckpoint(ref hash) => format!("Missing checkpoint block: {}", hash),
-			CliqueMissingVanity => format!("Extra data is missing vanity data"),
-			CliqueMissingSignature => format!("Extra data is missing signature"),
+			CliqueMissingVanity => "Extra data is missing vanity data".into(),
+			CliqueMissingSignature => "Extra data is missing signature".into(),
 			CliqueCheckpointInvalidSigners(len) => format!("Checkpoint block list was of length: {} of checkpoint but
 															it needs to be bigger than zero and a divisible by 20", len),
-			CliqueCheckpointNoSigner => format!("Checkpoint block list of signers was empty"),
+			CliqueCheckpointNoSigner => "Checkpoint block list of signers was empty".into(),
 			CliqueInvalidNonce(ref mis) => format!("Unexpected nonce {} expected {} or {}", mis, 0_u64, u64::max_value()),
 			CliqueWrongAuthorCheckpoint(ref oob) => format!("Unexpected checkpoint author: {}", oob),
 			CliqueFaultyRecoveredSigners(ref mis) => format!("Faulty recovered signers {:?}", mis),
@@ -98,9 +97,9 @@ impl fmt::Display for EngineError {
 			SystemCallResultDecoding(ref msg) => format!("Failed to decode the result of a system call: {}", msg),
 			SystemCallResultInvalid(ref msg) => format!("The result of a system call is invalid: {}", msg),
 			MalformedMessage(ref msg) => format!("Received malformed consensus message: {}", msg),
-			RequiresClient => format!("Call requires client but none registered"),
-			RequiresSigner => format!("Call requires signer but none registered"),
-			InvalidEngine => format!("Invalid engine specification or implementation"),
+			RequiresClient => "Call requires client but none registered".into(),
+			RequiresSigner => "Call requires signer but none registered".into(),
+			InvalidEngine => "Invalid engine specification or implementation".into(),
 			MissingParent(ref hash) => format!("Parent Epoch is missing from database: {}", hash),
 		};
 

--- a/util/network/Cargo.toml
+++ b/util/network/Cargo.toml
@@ -7,7 +7,7 @@ version = "1.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
-derive_more = "0.14.0"
+derive_more = "0.99"
 parity-crypto = { version = "0.4.2", features = ["publickey"] }
 ethcore-io = { path = "../io" }
 ethereum-types = "0.8.0"


### PR DESCRIPTION
Depends on #11404 

The primary motivation behind this is to have hard errors on `From` conversions that are ignored by
duplicated `variants` with the same value type. Also, there is `#[from(ignored)]` to enable if for instance we only would want to have a `From<String>` for a specific variant when there are multiple variants that wraps a String.
