### PR TITLE
update master/nightly version: v2.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "parity-ethereum"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3104,7 +3104,7 @@ dependencies = [
  "parity-runtime 0.1.0",
  "parity-updater 1.12.0",
  "parity-util-mem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-version 2.7.0",
+ "parity-version 2.8.0",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3237,7 +3237,7 @@ dependencies = [
  "parity-crypto 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-runtime 0.1.0",
  "parity-updater 1.12.0",
- "parity-version 2.7.0",
+ "parity-version 2.8.0",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3364,7 +3364,7 @@ dependencies = [
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-hash-fetch 1.12.0",
  "parity-path 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-version 2.7.0",
+ "parity-version 2.8.0",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Parity Ethereum client"
 name = "parity-ethereum"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "2.7.0"
+version = "2.8.0"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for Parity Ethereum version string (via env CARGO_PKG_VERSION)
-version = "2.7.0"
+version = "2.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 


### PR DESCRIPTION
Since `stable` is now at v2.7.0, need to bump master to v2.8.0