### PR TITLE
Revert "[Trace] Distinguish between `create` and `create2` (#11311)"

### DIFF
--- a/ethcore/engine/src/engine.rs
+++ b/ethcore/engine/src/engine.rs
@@ -42,7 +42,7 @@ use machine::{
 	Machine,
 	executed_block::ExecutedBlock,
 };
-use vm::{EnvInfo, Schedule, ActionType, ActionValue};
+use vm::{EnvInfo, Schedule, CallType, ActionValue};
 
 use crate::signer::EngineSigner;
 
@@ -82,7 +82,7 @@ pub fn default_system_or_code_call<'a>(machine: &'a Machine, block: &'a mut Exec
 					Some(ActionValue::Apparent(U256::zero())),
 					U256::max_value(),
 					Some(data),
-					Some(ActionType::StaticCall),
+					Some(CallType::StaticCall),
 				)
 			},
 		};

--- a/ethcore/evm/src/interpreter/mod.rs
+++ b/ethcore/evm/src/interpreter/mod.rs
@@ -33,7 +33,7 @@ use ethereum_types::{U256, U512, H256, Address, BigEndianHash};
 
 
 use vm::{
-	self, ActionParams, ParamsType, ActionValue, ActionType, MessageCallResult,
+	self, ActionParams, ParamsType, ActionValue, CallType, MessageCallResult,
 	ContractCreateResult, CreateContractAddress, ReturnData, GasLeft, Schedule,
 	TrapKind, TrapError
 };
@@ -133,8 +133,8 @@ struct InterpreterParams {
 	pub value: ActionValue,
 	/// Input data.
 	pub data: Option<Bytes>,
-	/// Type of action
-	pub action_type: ActionType,
+	/// Type of call
+	pub call_type: CallType,
 	/// Param types encoding
 	pub params_type: ParamsType,
 }
@@ -152,7 +152,7 @@ impl From<ActionParams> for InterpreterParams {
 			gas_price: params.gas_price,
 			value: params.value,
 			data: params.data,
-			action_type: params.action_type,
+			call_type: params.call_type,
 			params_type: params.params_type,
 		}
 	}
@@ -532,9 +532,7 @@ impl<Cost: CostType> Interpreter<Cost> {
 				let init_size = self.stack.pop_back();
 				let address_scheme = match instruction {
 					instructions::CREATE => CreateContractAddress::FromSenderAndNonce,
-					instructions::CREATE2 => CreateContractAddress::FromSenderSaltAndCodeHash(
-						BigEndianHash::from_uint(&self.stack.pop_back())
-					),
+					instructions::CREATE2 => CreateContractAddress::FromSenderSaltAndCodeHash(BigEndianHash::from_uint(&self.stack.pop_back())),
 					_ => unreachable!("instruction can only be CREATE/CREATE2 checked above; qed"),
 				};
 
@@ -555,14 +553,7 @@ impl<Cost: CostType> Interpreter<Cost> {
 
 				let contract_code = self.mem.read_slice(init_off, init_size);
 
-				let create_result = ext.create(
-					&create_gas.as_u256(), 
-					&endowment, 
-					contract_code, 
-					&self.params.code_version, 
-					address_scheme, 
-					true,
-				);
+				let create_result = ext.create(&create_gas.as_u256(), &endowment, contract_code, &self.params.code_version, address_scheme, true);
 				return match create_result {
 					Ok(ContractCreateResult::Created(address, gas_left)) => {
 						self.stack.push(address_to_u256(address));
@@ -616,14 +607,14 @@ impl<Cost: CostType> Interpreter<Cost> {
 							return Err(vm::Error::MutableCallInStaticContext);
 						}
 						let has_balance = ext.balance(&self.params.address)? >= value.expect("value set for all but delegate call; qed");
-						(&self.params.address, &code_address, has_balance, ActionType::Call)
+						(&self.params.address, &code_address, has_balance, CallType::Call)
 					},
 					instructions::CALLCODE => {
 						let has_balance = ext.balance(&self.params.address)? >= value.expect("value set for all but delegate call; qed");
-						(&self.params.address, &self.params.address, has_balance, ActionType::CallCode)
+						(&self.params.address, &self.params.address, has_balance, CallType::CallCode)
 					},
-					instructions::DELEGATECALL => (&self.params.sender, &self.params.address, true, ActionType::DelegateCall),
-					instructions::STATICCALL => (&self.params.address, &code_address, true, ActionType::StaticCall),
+					instructions::DELEGATECALL => (&self.params.sender, &self.params.address, true, CallType::DelegateCall),
+					instructions::STATICCALL => (&self.params.address, &code_address, true, CallType::StaticCall),
 					_ => panic!(format!("Unexpected instruction {:?} in CALL branch.", instruction))
 				};
 

--- a/ethcore/evm/src/lib.rs
+++ b/ethcore/evm/src/lib.rs
@@ -47,7 +47,7 @@ mod instructions;
 mod tests;
 
 pub use vm::{
-    Schedule, CleanDustMode, EnvInfo, ActionType, ActionParams, Ext,
+    Schedule, CleanDustMode, EnvInfo, CallType, ActionParams, Ext,
     ContractCreateResult, MessageCallResult, CreateContractAddress,
     GasLeft, ReturnData
 };

--- a/ethcore/executive-state/src/lib.rs
+++ b/ethcore/executive-state/src/lib.rs
@@ -276,6 +276,7 @@ mod tests {
 		test_helpers::{get_temp_state, get_temp_state_db}
 	};
 	use ethtrie;
+	use evm::CallType;
 	use machine::Machine;
 	use pod::{self, PodAccount, PodState};
 	use rustc_hex::FromHex;
@@ -323,7 +324,6 @@ mod tests {
 				value: 100.into(),
 				gas: 77412.into(),
 				init: vec![96, 16, 128, 96, 12, 96, 0, 57, 96, 0, 243, 0, 96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53, 85],
-				creation_method: Some(trace::CreationMethod::Create),
 			}),
 			result: trace::Res::Create(trace::CreateResult {
 				gas_used: U256::from(3224),
@@ -381,7 +381,6 @@ mod tests {
 				value: 100.into(),
 				gas: 78792.into(),
 				init: vec![91, 96, 0, 86],
-				creation_method: Some(trace::CreationMethod::Create),
 			}),
 			result: trace::Res::FailedCreate(TraceError::OutOfGas),
 			subtraces: 0
@@ -420,7 +419,7 @@ mod tests {
 				value: 100.into(),
 				gas: 79000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(3),
@@ -461,7 +460,7 @@ mod tests {
 				value: 100.into(),
 				gas: 79000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(0),
@@ -502,7 +501,7 @@ mod tests {
 				value: 0.into(),
 				gas: 79_000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(3000),
@@ -544,7 +543,7 @@ mod tests {
 				value: 0.into(),
 				gas: 79000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(3_721), // in post-eip150
@@ -588,7 +587,7 @@ mod tests {
 				value: 0.into(),
 				gas: 79000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: 724.into(), // in post-eip150
@@ -603,7 +602,7 @@ mod tests {
 				value: 0.into(),
 				gas: 4096.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::CallCode),
+				call_type: CallType::CallCode,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: 3.into(),
@@ -647,7 +646,7 @@ mod tests {
 				value: 0.into(),
 				gas: 79000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(736), // in post-eip150
@@ -662,7 +661,7 @@ mod tests {
 				value: 0.into(),
 				gas: 32768.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::DelegateCall),
+				call_type: CallType::DelegateCall,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: 18.into(),
@@ -703,7 +702,7 @@ mod tests {
 				value: 100.into(),
 				gas: 79000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::FailedCall(TraceError::OutOfGas),
 			subtraces: 0,
@@ -745,7 +744,7 @@ mod tests {
 				value: 100.into(),
 				gas: 79000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(69),
@@ -760,7 +759,7 @@ mod tests {
 				value: 0.into(),
 				gas: 78934.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(3),
@@ -802,7 +801,7 @@ mod tests {
 				value: 100.into(),
 				gas: 79000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(31761),
@@ -817,7 +816,7 @@ mod tests {
 				value: 69.into(),
 				gas: 2300.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult::default()),
 		}];
@@ -856,7 +855,7 @@ mod tests {
 				value: 100.into(),
 				gas: 79000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(31761),
@@ -899,7 +898,7 @@ mod tests {
 				value: 100.into(),
 				gas: 79000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(79_000),
@@ -914,7 +913,7 @@ mod tests {
 				value: 0.into(),
 				gas: 78934.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::FailedCall(TraceError::OutOfGas),
 		}];
@@ -955,7 +954,7 @@ mod tests {
 				value: 100.into(),
 				gas: 79000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(135),
@@ -970,7 +969,7 @@ mod tests {
 				value: 0.into(),
 				gas: 78934.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(69),
@@ -985,7 +984,7 @@ mod tests {
 				value: 0.into(),
 				gas: 78868.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(3),
@@ -1030,7 +1029,7 @@ mod tests {
 				value: 100.into(),
 				gas: 79000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(79_000),
@@ -1045,7 +1044,7 @@ mod tests {
 				value: 0.into(),
 				gas: 78934.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::FailedCall(TraceError::OutOfGas),
 		}, FlatTrace {
@@ -1056,7 +1055,7 @@ mod tests {
 				to: Address::from_low_u64_be(0xc),
 				value: 0.into(),
 				gas: 78868.into(),
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 				input: vec![],
 			}),
 			result: trace::Res::Call(trace::CallResult {
@@ -1100,7 +1099,7 @@ mod tests {
 				value: 100.into(),
 				gas: 79000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: 3.into(),

--- a/ethcore/machine/src/executive.rs
+++ b/ethcore/machine/src/executive.rs
@@ -26,7 +26,7 @@ use rlp::RlpStream;
 use log::trace;
 
 use account_state::{Backend as StateBackend, State, CleanupMode};
-use evm::{ActionType, Finalize, FinalizationResult};
+use evm::{CallType, Finalize, FinalizationResult};
 use vm::{
 	self, EnvInfo, CreateContractAddress, ReturnData, CleanDustMode, ActionParams,
 	ActionValue, Schedule, TrapError, ResumeCall, ResumeCreate
@@ -241,7 +241,7 @@ impl<'a> CallCreateExecutive<'a> {
 		trace!("Executive::call(params={:?}) self.env_info={:?}, parent_static={}", params, info, parent_static_flag);
 
 		let gas = params.gas;
-		let static_flag = parent_static_flag || params.action_type == ActionType::StaticCall;
+		let static_flag = parent_static_flag || params.call_type == CallType::StaticCall;
 
 		// if destination is builtin, try to execute it
 		let kind = if let Some(builtin) = machine.builtin(&params.code_address, info.number) {
@@ -298,7 +298,7 @@ impl<'a> CallCreateExecutive<'a> {
 			}
 		} else {
 			if (static_flag &&
-				(params.action_type == ActionType::StaticCall || params.action_type == ActionType::Call)) &&
+				(params.call_type == CallType::StaticCall || params.call_type == CallType::Call)) &&
 				params.value.value() > U256::zero()
 			{
 				return Err(vm::Error::MutableCallInStaticContext);
@@ -909,7 +909,7 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 					code: Some(Arc::new(t.data.clone())),
 					code_version: schedule.latest_version,
 					data: None,
-					action_type: ActionType::Create,
+					call_type: CallType::None,
 					params_type: vm::ParamsType::Embedded,
 				};
 				let res = self.create(params, &mut substate, &mut tracer, &mut vm_tracer);
@@ -932,7 +932,7 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 					code_hash: self.state.code_hash(address)?,
 					code_version: self.state.code_version(address)?,
 					data: Some(t.data.clone()),
-					action_type: ActionType::Call,
+					call_type: CallType::Call,
 					params_type: vm::ParamsType::Separate,
 				};
 				let res = self.call(params, &mut substate, &mut tracer, &mut vm_tracer);
@@ -1236,7 +1236,7 @@ mod tests {
 	use parity_crypto::publickey::{Generator, Random};
 	use evm::{Factory, evm_test, evm_test_ignore};
 	use macros::vec_into;
-	use vm::{ActionParams, ActionValue, EnvInfo, CreateContractAddress};
+	use vm::{ActionParams, ActionValue, CallType, EnvInfo, CreateContractAddress};
 	use ::trace::{
 		trace,
 		FlatTrace, Tracer, NoopTracer, ExecutiveTracer,
@@ -1414,7 +1414,7 @@ mod tests {
 		params.gas = U256::from(100_000);
 		params.code = Some(Arc::new(code));
 		params.value = ActionValue::Transfer(U256::from(100));
-		params.action_type = ActionType::Call;
+		params.call_type = CallType::Call;
 		let mut state = get_temp_state();
 		state.add_balance(&sender, &U256::from(100), CleanupMode::NoEmpty).unwrap();
 		let info = EnvInfo::default();
@@ -1434,7 +1434,7 @@ mod tests {
 				value: 100.into(),
 				gas: 100_000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call)
+				call_type: CallType::Call
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: 33021.into(),
@@ -1449,7 +1449,7 @@ mod tests {
 				value: 1.into(),
 				gas: 66560.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call)
+				call_type: CallType::Call
 			}), result: trace::Res::Call(trace::CallResult {
 				gas_used: 600.into(),
 				output: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 156, 17, 133, 165, 197, 233, 252, 84, 97, 40, 8, 151, 126, 232, 245, 72, 178, 37, 141, 49]
@@ -1498,7 +1498,7 @@ mod tests {
 		params.gas = U256::from(100_000);
 		params.code = Some(Arc::new(code));
 		params.value = ActionValue::Transfer(U256::from(100));
-		params.action_type = ActionType::Call;
+		params.call_type = CallType::Call;
 		let mut state = get_temp_state();
 		state.add_balance(&sender, &U256::from(100), CleanupMode::NoEmpty).unwrap();
 		let info = EnvInfo::default();
@@ -1524,7 +1524,7 @@ mod tests {
 				value: 100.into(),
 				gas: 100000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(55_248),
@@ -1537,8 +1537,7 @@ mod tests {
 				from: Address::from_str("b010143a42d5980c7e5ef0e4a4416dc098a4fed3").unwrap(),
 				value: 23.into(),
 				gas: 67979.into(),
-				init: vec![96, 16, 128, 96, 12, 96, 0, 57, 96, 0, 243, 0, 96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53, 85],
-				creation_method: Some(trace::CreationMethod::Create),
+				init: vec![96, 16, 128, 96, 12, 96, 0, 57, 96, 0, 243, 0, 96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53, 85]
 			}),
 			result: trace::Res::Create(trace::CreateResult {
 				gas_used: U256::from(3224),
@@ -1615,7 +1614,7 @@ mod tests {
 		params.gas = U256::from(100_000);
 		params.code = Some(Arc::new(code));
 		params.value = ActionValue::Transfer(U256::from(100));
-		params.action_type = ActionType::Call;
+		params.call_type = CallType::Call;
 		let mut state = get_temp_state();
 		state.add_balance(&sender, &U256::from(100), CleanupMode::NoEmpty).unwrap();
 		let info = EnvInfo::default();
@@ -1641,7 +1640,7 @@ mod tests {
 				value: 100.into(),
 				gas: 100_000.into(),
 				input: vec![],
-				call_type: Some(trace::CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: trace::Res::Call(trace::CallResult {
 				gas_used: U256::from(37_033),
@@ -1654,8 +1653,7 @@ mod tests {
 				from: Address::from_str("b010143a42d5980c7e5ef0e4a4416dc098a4fed3").unwrap(),
 				value: 23.into(),
 				gas: 66_917.into(),
-				init: vec![0x60, 0x01, 0x60, 0x00, 0xfd],
-				creation_method: Some(trace::CreationMethod::Create),
+				init: vec![0x60, 0x01, 0x60, 0x00, 0xfd]
 			}),
 			result: trace::Res::FailedCreate(vm::Error::Reverted.into()),
 		}];
@@ -1713,7 +1711,6 @@ mod tests {
 				value: 100.into(),
 				gas: params.gas,
 				init: vec![96, 16, 128, 96, 12, 96, 0, 57, 96, 0, 243, 0, 96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53, 85],
-				creation_method: Some(trace::CreationMethod::Create),
 			}),
 			result: trace::Res::Create(trace::CreateResult {
 				gas_used: U256::from(3224),

--- a/ethcore/machine/src/externalities.rs
+++ b/ethcore/machine/src/externalities.rs
@@ -29,7 +29,7 @@ use common_types::{
 };
 use trace::{Tracer, VMTracer};
 use vm::{
-	self, ActionParams, ActionValue, EnvInfo, ActionType, Schedule,
+	self, ActionParams, ActionValue, EnvInfo, CallType, Schedule,
 	Ext, ContractCreateResult, MessageCallResult, CreateContractAddress,
 	ReturnData, TrapKind
 };
@@ -193,7 +193,7 @@ impl<'a, T: 'a, V: 'a, B: 'a> Ext for Externalities<'a, T, V, B>
 				code_hash,
 				code_version,
 				data: Some(data.as_bytes().to_vec()),
-				action_type: ActionType::Call,
+				call_type: CallType::Call,
 				params_type: vm::ParamsType::Separate,
 			};
 
@@ -241,12 +241,6 @@ impl<'a, T: 'a, V: 'a, B: 'a> Ext for Externalities<'a, T, V, B>
 			}
 		};
 
-		let create_type = match address_scheme {
-			CreateContractAddress::FromSenderAndNonce => ActionType::Create,
-			CreateContractAddress::FromSenderSaltAndCodeHash(_) => ActionType::Create2,
-			CreateContractAddress::FromSenderAndCodeHash => ActionType::Create2,
-		};
-
 		// prepare the params
 		let params = ActionParams {
 			code_address: address.clone(),
@@ -260,7 +254,7 @@ impl<'a, T: 'a, V: 'a, B: 'a> Ext for Externalities<'a, T, V, B>
 			code_hash,
 			code_version: *parent_version,
 			data: None,
-			action_type: create_type,
+			call_type: CallType::None,
 			params_type: vm::ParamsType::Embedded,
 		};
 
@@ -291,7 +285,7 @@ impl<'a, T: 'a, V: 'a, B: 'a> Ext for Externalities<'a, T, V, B>
 		value: Option<U256>,
 		data: &[u8],
 		code_address: &Address,
-		call_type: ActionType,
+		call_type: CallType,
 		trap: bool,
 	) -> ::std::result::Result<MessageCallResult, TrapKind> {
 		trace!(target: "externalities", "call");
@@ -317,7 +311,7 @@ impl<'a, T: 'a, V: 'a, B: 'a> Ext for Externalities<'a, T, V, B>
 			code_hash,
 			code_version,
 			data: Some(data.to_vec()),
-			action_type: call_type,
+			call_type,
 			params_type: vm::ParamsType::Separate,
 		};
 
@@ -463,7 +457,7 @@ impl<'a, T: 'a, V: 'a, B: 'a> Ext for Externalities<'a, T, V, B>
 mod tests {
 	use std::str::FromStr;
 	use ethereum_types::{U256, Address};
-	use evm::{EnvInfo, Ext, ActionType};
+	use evm::{EnvInfo, Ext, CallType};
 	use account_state::State;
 	use ethcore::test_helpers::get_temp_state;
 	use trace::{NoopTracer, NoopVMTracer};
@@ -597,7 +591,7 @@ mod tests {
 			Some("0000000000000000000000000000000000000000000000000000000000150000".parse::<U256>().unwrap()),
 			&[],
 			&Address::zero(),
-			ActionType::Call,
+			CallType::Call,
 			false,
 		).ok().unwrap();
 	}

--- a/ethcore/machine/src/machine.rs
+++ b/ethcore/machine/src/machine.rs
@@ -34,7 +34,7 @@ use common_types::{
 	errors::{EngineError, EthcoreError as Error},
 	transaction::{self, SYSTEM_ADDRESS, UNSIGNED_SENDER, UnverifiedTransaction, SignedTransaction},
 };
-use vm::{ActionType, ActionParams, ActionValue, ParamsType};
+use vm::{CallType, ActionParams, ActionValue, ParamsType};
 use vm::{EnvInfo, Schedule};
 
 use account_state::CleanupMode;
@@ -141,7 +141,7 @@ impl Machine {
 		value: Option<ActionValue>,
 		gas: U256,
 		data: Option<Vec<u8>>,
-		action_type: Option<ActionType>,
+		call_type: Option<CallType>,
 	) -> Result<Vec<u8>, Error> {
 		let env_info = {
 			let mut env_info = block.env_info();
@@ -163,7 +163,7 @@ impl Machine {
 			code_hash,
 			code_version: 0.into(),
 			data,
-			action_type: action_type.unwrap_or(ActionType::Call),
+			call_type: call_type.unwrap_or(CallType::Call),
 			params_type: ParamsType::Separate,
 		};
 		let schedule = self.schedule(env_info.number);

--- a/ethcore/spec/src/spec.rs
+++ b/ethcore/spec/src/spec.rs
@@ -52,7 +52,7 @@ use pod::PodState;
 use rlp::{Rlp, RlpStream};
 use trace::{NoopTracer, NoopVMTracer};
 use trie_vm_factories::Factories;
-use vm::{EnvInfo, ActionType, ActionValue, ActionParams, ParamsType};
+use vm::{EnvInfo, CallType, ActionValue, ActionParams, ParamsType};
 
 use crate::{
 	Genesis,
@@ -163,7 +163,7 @@ fn run_constructors<T: Backend>(
 				value: ActionValue::Transfer(Default::default()),
 				code: Some(Arc::new(constructor.clone())),
 				data: None,
-				action_type: ActionType::Create,
+				call_type: CallType::None,
 				params_type: ParamsType::Embedded,
 			};
 

--- a/ethcore/src/json_tests/executive.rs
+++ b/ethcore/src/json_tests/executive.rs
@@ -20,7 +20,7 @@ use super::test_common::*;
 use account_state::{Backend as StateBackend, State};
 use evm::Finalize;
 use vm::{
-	self, ActionParams, ActionType, Schedule, Ext,
+	self, ActionParams, CallType, Schedule, Ext,
 	ContractCreateResult, EnvInfo, MessageCallResult,
 	CreateContractAddress, ReturnData,
 };
@@ -172,7 +172,7 @@ impl<'a, T: 'a, V: 'a, B: 'a> Ext for TestExt<'a, T, V, B>
 		value: Option<U256>,
 		data: &[u8],
 		_code_address: &Address,
-		_call_type: ActionType,
+		_call_type: CallType,
 		_trap: bool
 	) -> Result<MessageCallResult, vm::TrapKind> {
 		self.callcreates.push(CallCreate {

--- a/ethcore/src/tests/evm.rs
+++ b/ethcore/src/tests/evm.rs
@@ -18,7 +18,7 @@
 
 use std::sync::Arc;
 use hash::keccak;
-use vm::{EnvInfo, ActionParams, ActionValue, ActionType, ParamsType};
+use vm::{EnvInfo, ActionParams, ActionValue, CallType, ParamsType};
 use evm::Factory;
 use machine::{
 	executive::Executive,
@@ -62,7 +62,7 @@ fn test_blockhash_eip210(factory: Factory) {
 			code_hash: Some(blockhash_contract_code_hash),
 			code_version: 0.into(),
 			data: Some(H256::from_low_u64_be(i - 1).as_bytes().to_vec()),
-			action_type: ActionType::Call,
+			call_type: CallType::Call,
 			params_type: ParamsType::Separate,
 		};
 		let schedule = machine.schedule(env_info.number);
@@ -86,7 +86,7 @@ fn test_blockhash_eip210(factory: Factory) {
 		code_hash: Some(get_prev_hash_code_hash),
 		code_version: 0.into(),
 		data: None,
-		action_type: ActionType::Call,
+		call_type: CallType::Call,
 		params_type: ParamsType::Separate,
 	};
 	let schedule = machine.schedule(env_info.number);

--- a/ethcore/trace/src/db.rs
+++ b/ethcore/trace/src/db.rs
@@ -374,12 +374,13 @@ mod tests {
 
 	use ethcore::test_helpers::new_db;
 	use ethereum_types::{H256, U256, Address};
+	use evm::CallType;
 	use kvdb::DBTransaction;
 
 	use crate::{
 		BlockNumber, Config, TraceDB, Database as TraceDatabase, ImportRequest, DatabaseExtras,
 		Filter, LocalizedTrace, AddressesFilter, TraceError,
-		trace::{Call, CallType, Action, Res},
+		trace::{Call, Action, Res},
 		flat::{FlatTrace, FlatBlockTraces, FlatTransactionTraces}
 	};
 
@@ -464,7 +465,7 @@ mod tests {
 					value: 3.into(),
 					gas: 4.into(),
 					input: vec![],
-					call_type: Some(CallType::Call),
+					call_type: CallType::Call,
 				}),
 				result: Res::FailedCall(TraceError::OutOfGas),
 			}])]),
@@ -486,7 +487,7 @@ mod tests {
 					value: 3.into(),
 					gas: 4.into(),
 					input: vec![],
-					call_type: Some(CallType::Call),
+					call_type: CallType::Call,
 				}),
 				result: Res::FailedCall(TraceError::OutOfGas),
 			}])]),
@@ -505,7 +506,7 @@ mod tests {
 				value: U256::from(3),
 				gas: U256::from(4),
 				input: vec![],
-				call_type: Some(CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: Res::FailedCall(TraceError::OutOfGas),
 			trace_address: vec![],

--- a/ethcore/trace/src/types/filter.rs
+++ b/ethcore/trace/src/types/filter.rs
@@ -125,9 +125,10 @@ impl Filter {
 #[cfg(test)]
 mod tests {
 	use ethereum_types::{Address, Bloom, BloomInput};
+	use evm::CallType;
 	use crate::{
 		Filter, AddressesFilter, TraceError, RewardType,
-		trace::{Action, Call, CallType, Res, Create, CreationMethod, CreateResult, Suicide, Reward},
+		trace::{Action, Call, Res, Create, CreateResult, Suicide, Reward},
 		flat::FlatTrace,
 	};
 
@@ -272,7 +273,7 @@ mod tests {
 				value: 3.into(),
 				gas: 4.into(),
 				input: vec![0x5],
-				call_type: Some(CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: Res::FailedCall(TraceError::OutOfGas),
 			trace_address: vec![0].into_iter().collect(),
@@ -293,7 +294,6 @@ mod tests {
 				value: 3.into(),
 				gas: 4.into(),
 				init: vec![0x5],
-				creation_method: Some(CreationMethod::Create),
 			}),
 			result: Res::Create(CreateResult {
 				gas_used: 10.into(),
@@ -413,7 +413,6 @@ mod tests {
 				gas: 4.into(),
 				init: vec![0x5],
 				value: 3.into(),
-				creation_method: Some(CreationMethod::Create),
 			}),
 			result: Res::FailedCall(TraceError::BadInstruction),
 			trace_address: vec![].into_iter().collect(),

--- a/ethcore/trace/src/types/flat.rs
+++ b/ethcore/trace/src/types/flat.rs
@@ -123,8 +123,9 @@ mod tests {
 	use rlp::*;
 	use crate::{
 		FlatBlockTraces, FlatTransactionTraces, FlatTrace,
-		trace::{Action, Res, CallResult, Call, CallType, Suicide, Reward, RewardType}
+		trace::{Action, Res, CallResult, Call, Suicide, Reward, RewardType}
 	};
+	use evm::CallType;
 
 	#[test]
 	fn encode_flat_transaction_traces() {
@@ -161,7 +162,7 @@ mod tests {
 				value: "3627e8f712373c0000".parse().unwrap(),
 				gas: 0x03e8.into(),
 				input: vec![],
-				call_type: Some(CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: Res::Call(CallResult {
 				gas_used: 0.into(),
@@ -178,7 +179,7 @@ mod tests {
 				value: 0.into(),
 				gas: 0x010c78.into(),
 				input: vec![0x41, 0xc0, 0xe1, 0xb5],
-				call_type: Some(CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: Res::Call(CallResult {
 				gas_used: 0x0127.into(),

--- a/ethcore/trace/src/types/trace.rs
+++ b/ethcore/trace/src/types/trace.rs
@@ -16,13 +16,12 @@
 
 //! Tracing data types.
 
-use std::convert::TryFrom;
 use ethereum_types::{U256, Address, Bloom, BloomInput};
 use parity_bytes::Bytes;
 use rlp::{Rlp, RlpStream, Encodable, DecoderError, Decodable};
 use rlp_derive::{RlpEncodable, RlpDecodable};
 use vm::ActionParams;
-use evm::ActionType;
+use evm::CallType;
 use super::error::Error;
 
 /// `Call` result.
@@ -32,57 +31,6 @@ pub struct CallResult {
 	pub gas_used: U256,
 	/// Call Output.
 	pub output: Bytes,
-}
-
-/// `Call` type. Distinguish between different types of contract interactions.
-#[derive(Debug, Clone, PartialEq)]
-pub enum CallType {
-	/// Call
-	Call,
-	/// Call code
-	CallCode,
-	/// Delegate call
-	DelegateCall,
-	/// Static call
-	StaticCall,
-}
-
-impl TryFrom<ActionType> for CallType {
-	type Error = &'static str;
-	fn try_from(action_type: ActionType) -> Result<Self, Self::Error> {
-		match action_type {
-			ActionType::Call => Ok(CallType::Call),
-			ActionType::CallCode => Ok(CallType::CallCode),
-			ActionType::DelegateCall => Ok(CallType::DelegateCall),
-			ActionType::StaticCall => Ok(CallType::StaticCall),
-			ActionType::Create => Err("Create cannot be converted to CallType"),
-			ActionType::Create2 => Err("Create2 cannot be converted to CallType"),
-		}
-	}
-}
-
-impl Encodable for CallType {
-	fn rlp_append(&self, s: &mut RlpStream) {
-		let v = match *self {
-			CallType::Call => 0u32,
-			CallType::CallCode => 1,
-			CallType::DelegateCall => 2,
-			CallType::StaticCall => 3,
-		};
-		Encodable::rlp_append(&v, s);
-	}
-}
-
-impl Decodable for CallType {
-	fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-		rlp.as_val().and_then(|v| Ok(match v {
-			0u32 => CallType::Call,
-			1 => CallType::CallCode,
-			2 => CallType::DelegateCall,
-			3 => CallType::StaticCall,
-			_ => return Err(DecoderError::Custom("Invalid value of RewardType item")),
-		}))
-	}
 }
 
 /// `Create` result.
@@ -103,49 +51,6 @@ impl CreateResult {
 	}
 }
 
-/// `Create` method. Distinguish between use of `CREATE` and `CREATE2` opcodes in an action.
-#[derive(Debug, Clone, PartialEq)]
-pub enum CreationMethod {
-	/// Create
-	Create,
-	/// Create2
-	Create2,
-}
-
-impl TryFrom<ActionType> for CreationMethod {
-	type Error = &'static str;
-	fn try_from(action_type: ActionType) -> Result<Self, Self::Error> {
-		match action_type {
-			ActionType::Call => Err("Call cannot be converted to CreationMethod"),
-			ActionType::CallCode => Err("CallCode cannot be converted to CreationMethod"),
-			ActionType::DelegateCall => Err("DelegateCall cannot be converted to CreationMethod"),
-			ActionType::StaticCall => Err("StaticCall cannot be converted to CreationMethod"),
-			ActionType::Create => Ok(CreationMethod::Create),
-			ActionType::Create2 => Ok(CreationMethod::Create2),
-		}
-	}
-}
-
-impl Encodable for CreationMethod {
-	fn rlp_append(&self, s: &mut RlpStream) {
-		let v = match *self {
-			CreationMethod::Create => 0u32,
-			CreationMethod::Create2 => 1,
-		};
-		Encodable::rlp_append(&v, s);
-	}
-}
-
-impl Decodable for CreationMethod {
-	fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-		rlp.as_val().and_then(|v| Ok(match v {
-			0u32 => CreationMethod::Create,
-			1 => CreationMethod::Create2,
-			_ => return Err(DecoderError::Custom("Invalid value of RewardType item")),
-		}))
-	}
-}
-
 /// Description of a _call_ action, either a `CALL` operation or a message transaction.
 #[derive(Debug, Clone, PartialEq, RlpEncodable, RlpDecodable)]
 pub struct Call {
@@ -160,19 +65,19 @@ pub struct Call {
 	/// The input data provided to the call.
 	pub input: Bytes,
 	/// The type of the call.
-	pub call_type: Option<CallType>,
+	pub call_type: CallType,
 }
 
 impl From<ActionParams> for Call {
 	fn from(p: ActionParams) -> Self {
-		match p.action_type {
-			ActionType::DelegateCall | ActionType::CallCode => Call {
+		match p.call_type {
+			CallType::DelegateCall | CallType::CallCode => Call {
 				from: p.address,
 				to: p.code_address,
 				value: p.value.value(),
 				gas: p.gas,
 				input: p.data.unwrap_or_else(Vec::new),
-				call_type: CallType::try_from(p.action_type).ok(),
+				call_type: p.call_type,
 			},
 			_ => Call {
 				from: p.sender,
@@ -180,7 +85,7 @@ impl From<ActionParams> for Call {
 				value: p.value.value(),
 				gas: p.gas,
 				input: p.data.unwrap_or_else(Vec::new),
-				call_type: CallType::try_from(p.action_type).ok(),
+				call_type: p.call_type,
 			},
 		}
 	}
@@ -208,8 +113,6 @@ pub struct Create {
 	pub gas: U256,
 	/// The init code.
 	pub init: Bytes,
-	/// Creation method (CREATE vs CREATE2).
-	pub creation_method: Option<CreationMethod>,
 }
 
 impl From<ActionParams> for Create {
@@ -219,7 +122,6 @@ impl From<ActionParams> for Create {
 			value: p.value.value(),
 			gas: p.gas,
 			init: p.code.map_or_else(Vec::new, |c| (*c).clone()),
-			creation_method: CreationMethod::try_from(p.action_type).ok(),
 		}
 	}
 }

--- a/ethcore/vm/src/action_params.rs
+++ b/ethcore/vm/src/action_params.rs
@@ -20,7 +20,7 @@ use bytes::Bytes;
 use hash::{keccak, KECCAK_EMPTY};
 use ethjson;
 
-use action_type::ActionType;
+use call_type::CallType;
 
 use std::sync::Arc;
 
@@ -88,8 +88,8 @@ pub struct ActionParams {
 	pub code_version: U256,
 	/// Input data.
 	pub data: Option<Bytes>,
-	/// Type of action (e.g. CALL, DELEGATECALL, CREATE, etc.)
-	pub action_type: ActionType,
+	/// Type of call
+	pub call_type: CallType,
 	/// Param types encoding
 	pub params_type: ParamsType,
 }
@@ -109,7 +109,7 @@ impl Default for ActionParams {
 			code: None,
 			code_version: U256::zero(),
 			data: None,
-			action_type: ActionType::Create,
+			call_type: CallType::None,
 			params_type: ParamsType::Separate,
 		}
 	}
@@ -130,7 +130,7 @@ impl From<ethjson::vm::Transaction> for ActionParams {
 			gas: t.gas.into(),
 			gas_price: t.gas_price.into(),
 			value: ActionValue::Transfer(t.value.into()),
-			action_type: ActionType::Call,
+			call_type: match address.is_zero() { true => CallType::None, false => CallType::Call },	// TODO @debris is this correct?
 			params_type: ParamsType::Separate,
 		}
 	}

--- a/ethcore/vm/src/call_type.rs
+++ b/ethcore/vm/src/call_type.rs
@@ -14,51 +14,47 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-//! EVM action types.
+//! EVM call types.
 
 use rlp::{Encodable, Decodable, DecoderError, RlpStream, Rlp};
 
-/// The type of the instruction.
+/// The type of the call-like instruction.
 #[derive(Debug, PartialEq, Clone)]
-pub enum ActionType {
-	/// CREATE.
-	Create,
+pub enum CallType {
+	/// Not a CALL.
+	None,
 	/// CALL.
 	Call,
 	/// CALLCODE.
 	CallCode,
 	/// DELEGATECALL.
 	DelegateCall,
-	/// STATICCALL.
+	/// STATICCALL
 	StaticCall,
-	/// CREATE2.
-	Create2
 }
 
-impl Encodable for ActionType {
+impl Encodable for CallType {
 	fn rlp_append(&self, s: &mut RlpStream) {
 		let v = match *self {
-			ActionType::Create => 0u32,
-			ActionType::Call => 1,
-			ActionType::CallCode => 2,
-			ActionType::DelegateCall => 3,
-			ActionType::StaticCall => 4,
-			ActionType::Create2 => 5,
+			CallType::None => 0u32,
+			CallType::Call => 1,
+			CallType::CallCode => 2,
+			CallType::DelegateCall => 3,
+			CallType::StaticCall => 4,
 		};
 		Encodable::rlp_append(&v, s);
 	}
 }
 
-impl Decodable for ActionType {
+impl Decodable for CallType {
 	fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
 		rlp.as_val().and_then(|v| Ok(match v {
-			0u32 => ActionType::Create,
-			1 => ActionType::Call,
-			2 => ActionType::CallCode,
-			3 => ActionType::DelegateCall,
-			4 => ActionType::StaticCall,
-			5 => ActionType::Create2,
-			_ => return Err(DecoderError::Custom("Invalid value of ActionType item")),
+			0u32 => CallType::None,
+			1 => CallType::Call,
+			2 => CallType::CallCode,
+			3 => CallType::DelegateCall,
+			4 => CallType::StaticCall,
+			_ => return Err(DecoderError::Custom("Invalid value of CallType item")),
 		}))
 	}
 }
@@ -66,11 +62,11 @@ impl Decodable for ActionType {
 #[cfg(test)]
 mod tests {
 	use rlp::*;
-	use super::ActionType;
+	use super::CallType;
 
 	#[test]
 	fn encode_call_type() {
-		let ct = ActionType::Call;
+		let ct = CallType::Call;
 
 		let mut s = RlpStream::new_list(2);
 		s.append(&ct);
@@ -82,9 +78,9 @@ mod tests {
 
 	#[test]
 	fn should_encode_and_decode_call_type() {
-		let original = ActionType::Call;
+		let original = CallType::Call;
 		let encoded = encode(&original);
-		let decoded = decode(&encoded).expect("failure decoding ActionType");
+		let decoded = decode(&encoded).expect("failure decoding CallType");
 		assert_eq!(original, decoded);
 	}
 }

--- a/ethcore/vm/src/ext.rs
+++ b/ethcore/vm/src/ext.rs
@@ -19,7 +19,7 @@
 use std::sync::Arc;
 use ethereum_types::{U256, H256, Address};
 use bytes::Bytes;
-use action_type::ActionType;
+use call_type::CallType;
 use env_info::EnvInfo;
 use schedule::Schedule;
 use return_data::ReturnData;
@@ -115,7 +115,7 @@ pub trait Ext {
 		value: Option<U256>,
 		data: &[u8],
 		code_address: &Address,
-		call_type: ActionType,
+		call_type: CallType,
 		trap: bool
 	) -> ::std::result::Result<MessageCallResult, TrapKind>;
 

--- a/ethcore/vm/src/lib.rs
+++ b/ethcore/vm/src/lib.rs
@@ -24,7 +24,7 @@ extern crate keccak_hash as hash;
 extern crate patricia_trie_ethereum as ethtrie;
 
 mod action_params;
-mod action_type;
+mod call_type;
 mod env_info;
 mod schedule;
 mod ext;
@@ -34,7 +34,7 @@ mod error;
 pub mod tests;
 
 pub use action_params::{ActionParams, ActionValue, ParamsType};
-pub use action_type::ActionType;
+pub use call_type::CallType;
 pub use env_info::{EnvInfo, LastHashes};
 pub use schedule::{Schedule, VersionedSchedule, CleanDustMode, WasmCosts};
 pub use ext::{Ext, MessageCallResult, ContractCreateResult, CreateContractAddress};

--- a/ethcore/vm/src/tests.rs
+++ b/ethcore/vm/src/tests.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, HashSet};
 use ethereum_types::{U256, H256, Address};
 use bytes::Bytes;
 use {
-	ActionType, Schedule, EnvInfo,
+	CallType, Schedule, EnvInfo,
 	ReturnData, Ext, ContractCreateResult, MessageCallResult,
 	CreateContractAddress, Result, GasLeft,
 };
@@ -185,7 +185,7 @@ impl Ext for FakeExt {
 		value: Option<U256>,
 		data: &[u8],
 		code_address: &Address,
-		_call_type: ActionType,
+		_call_type: CallType,
 		_trap: bool,
 	) -> ::std::result::Result<MessageCallResult, TrapKind> {
 		self.calls.insert(FakeCall {

--- a/ethcore/wasm/src/runtime.rs
+++ b/ethcore/wasm/src/runtime.rs
@@ -16,7 +16,7 @@
 
 use std::cmp;
 use ethereum_types::{BigEndianHash, U256, H256, Address};
-use vm::{self, ActionType};
+use vm::{self, CallType};
 use wasmi::{self, MemoryRef, RuntimeArgs, RuntimeValue, Error as InterpreterError, Trap, TrapKind};
 use super::panic_payload;
 
@@ -384,7 +384,7 @@ impl<'a> Runtime<'a> {
 	fn do_call(
 		&mut self,
 		use_val: bool,
-		call_type: ActionType,
+		call_type: CallType,
 		args: RuntimeArgs,
 	)
 		-> Result<RuntimeValue>
@@ -445,8 +445,8 @@ impl<'a> Runtime<'a> {
 
 		let call_result = self.ext.call(
 			&gas.into(),
-			match call_type { ActionType::DelegateCall => &self.context.sender, _ => &self.context.address },
-			match call_type { ActionType::Call | ActionType::StaticCall => &address, _ => &self.context.address },
+			match call_type { CallType::DelegateCall => &self.context.sender, _ => &self.context.address },
+			match call_type { CallType::Call | CallType::StaticCall => &address, _ => &self.context.address },
 			val,
 			&payload,
 			&address,
@@ -487,17 +487,17 @@ impl<'a> Runtime<'a> {
 
 	/// Message call
 	fn ccall(&mut self, args: RuntimeArgs) -> Result<RuntimeValue> {
-		self.do_call(true, ActionType::Call, args)
+		self.do_call(true, CallType::Call, args)
 	}
 
 	/// Delegate call
 	fn dcall(&mut self, args: RuntimeArgs) -> Result<RuntimeValue> {
-		self.do_call(false, ActionType::DelegateCall, args)
+		self.do_call(false, CallType::DelegateCall, args)
 	}
 
 	/// Static call
 	fn scall(&mut self, args: RuntimeArgs) -> Result<RuntimeValue> {
-		self.do_call(false, ActionType::StaticCall, args)
+		self.do_call(false, CallType::StaticCall, args)
 	}
 
 	fn return_address_ptr(&mut self, ptr: u32, val: Address) -> Result<()>

--- a/evmbin/src/main.rs
+++ b/evmbin/src/main.rs
@@ -45,7 +45,7 @@ use ethereum_types::{U256, Address};
 use ethcore::{json_tests, test_helpers::TrieSpec};
 use spec;
 use serde::Deserialize;
-use vm::{ActionParams, ActionType};
+use vm::{ActionParams, CallType};
 
 mod info;
 mod display;
@@ -314,7 +314,7 @@ fn run_call<T: Informant>(args: Args, informant: T) {
 	}
 
 	let mut params = ActionParams::default();
-	params.action_type = if code.is_none() { ActionType::Call } else { ActionType::Create };
+	params.call_type = if code.is_none() { CallType::Call } else { CallType::None };
 	params.code = code.map(Arc::new);
 	params.code_address = to;
 	params.address = to;

--- a/rpc/src/v1/tests/mocked/traces.rs
+++ b/rpc/src/v1/tests/mocked/traces.rs
@@ -23,7 +23,7 @@ use ethcore::test_helpers::TestBlockChainClient;
 use ethereum_types::{Address, H256};
 
 use types::transaction::CallError;
-use trace::trace::CallType;
+use vm::CallType;
 
 use jsonrpc_core::IoHandler;
 use v1::tests::helpers::{TestMinerService};
@@ -44,7 +44,7 @@ fn io() -> Tester {
 			value: 0x1.into(),
 			gas: 0x100.into(),
 			input: vec![1, 2, 3],
-			call_type: Some(CallType::Call),
+			call_type: CallType::Call,
 		}),
 		result: Res::None,
 		subtraces: 0,

--- a/rpc/src/v1/types/trace.rs
+++ b/rpc/src/v1/types/trace.rs
@@ -24,6 +24,7 @@ use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 use types::account_diff;
 use types::state_diff;
+use vm;
 
 use v1::types::Bytes;
 
@@ -213,7 +214,6 @@ impl From<state_diff::StateDiff> for StateDiff {
 
 /// Create response
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct Create {
 	/// Sender
 	from: H160,
@@ -223,9 +223,6 @@ pub struct Create {
 	gas: U256,
 	/// Initialization code
 	init: Bytes,
-	// Create Type
-	#[serde(skip_serializing_if="Option::is_none")]
-	creation_method: Option<CreationMethod>,
 }
 
 impl From<trace::Create> for Create {
@@ -235,7 +232,6 @@ impl From<trace::Create> for Create {
 			value: c.value,
 			gas: c.gas,
 			init: Bytes::new(c.init),
-			creation_method: c.creation_method.map(|c| c.into()),
 		}
 	}
 }
@@ -244,6 +240,8 @@ impl From<trace::Create> for Create {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum CallType {
+	/// None
+	None,
 	/// Call
 	Call,
 	/// Call code
@@ -254,32 +252,14 @@ pub enum CallType {
 	StaticCall,
 }
 
-impl From<trace::CallType> for CallType {
-	fn from(c: trace::CallType) -> Self {
+impl From<vm::CallType> for CallType {
+	fn from(c: vm::CallType) -> Self {
 		match c {
-			trace::CallType::Call => CallType::Call,
-			trace::CallType::CallCode => CallType::CallCode,
-			trace::CallType::DelegateCall => CallType::DelegateCall,
-			trace::CallType::StaticCall => CallType::StaticCall,
-		}
-	}
-}
-
-/// Create type.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum CreationMethod {
-	/// Create
-	Create,
-	/// Create2
-	Create2,
-}
-
-impl From<trace::CreationMethod> for CreationMethod {
-	fn from(c: trace::CreationMethod) -> Self {
-		match c {
-			trace::CreationMethod::Create => CreationMethod::Create,
-			trace::CreationMethod::Create2 => CreationMethod::Create2,
+			vm::CallType::None => CallType::None,
+			vm::CallType::Call => CallType::Call,
+			vm::CallType::CallCode => CallType::CallCode,
+			vm::CallType::DelegateCall => CallType::DelegateCall,
+			vm::CallType::StaticCall => CallType::StaticCall,
 		}
 	}
 }
@@ -299,7 +279,7 @@ pub struct Call {
 	/// Input data
 	input: Bytes,
 	/// The type of the call.
-	call_type: Option<CallType>,
+	call_type: CallType,
 }
 
 impl From<trace::Call> for Call {
@@ -310,7 +290,7 @@ impl From<trace::Call> for Call {
 			value: c.value,
 			gas: c.gas,
 			input: c.input.into(),
-			call_type: c.call_type.map(|c| c.into()),
+			call_type: c.call_type.into(),
 		}
 	}
 }
@@ -701,7 +681,7 @@ mod tests {
 				value: 6.into(),
 				gas: 7.into(),
 				input: Bytes::new(vec![0x12, 0x34]),
-				call_type: Some(CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: Res::Call(CallResult {
 				gas_used: 8.into(),
@@ -727,7 +707,7 @@ mod tests {
 				value: 6.into(),
 				gas: 7.into(),
 				input: Bytes::new(vec![0x12, 0x34]),
-				call_type: Some(CallType::Call),
+				call_type: CallType::Call,
 			}),
 			result: Res::FailedCall(TraceError::OutOfGas),
 			trace_address: vec![10],
@@ -749,7 +729,6 @@ mod tests {
 				value: 6.into(),
 				gas: 7.into(),
 				init: Bytes::new(vec![0x12, 0x34]),
-				creation_method: Some(CreationMethod::Create),
 			}),
 			result: Res::Create(CreateResult {
 				gas_used: 8.into(),
@@ -764,7 +743,7 @@ mod tests {
 			block_hash: H256::from_low_u64_be(14),
 		};
 		let serialized = serde_json::to_string(&t).unwrap();
-		assert_eq!(serialized, r#"{"type":"create","action":{"from":"0x0000000000000000000000000000000000000004","value":"0x6","gas":"0x7","init":"0x1234","creationMethod":"create"},"result":{"gasUsed":"0x8","code":"0x5678","address":"0x00000000000000000000000000000000000000ff"},"traceAddress":[10],"subtraces":1,"transactionPosition":11,"transactionHash":"0x000000000000000000000000000000000000000000000000000000000000000c","blockNumber":13,"blockHash":"0x000000000000000000000000000000000000000000000000000000000000000e"}"#);
+		assert_eq!(serialized, r#"{"type":"create","action":{"from":"0x0000000000000000000000000000000000000004","value":"0x6","gas":"0x7","init":"0x1234"},"result":{"gasUsed":"0x8","code":"0x5678","address":"0x00000000000000000000000000000000000000ff"},"traceAddress":[10],"subtraces":1,"transactionPosition":11,"transactionHash":"0x000000000000000000000000000000000000000000000000000000000000000c","blockNumber":13,"blockHash":"0x000000000000000000000000000000000000000000000000000000000000000e"}"#);
 	}
 
 	#[test]
@@ -775,7 +754,6 @@ mod tests {
 				value: 6.into(),
 				gas: 7.into(),
 				init: Bytes::new(vec![0x12, 0x34]),
-				creation_method: Some(CreationMethod::Create),
 			}),
 			result: Res::FailedCreate(TraceError::OutOfGas),
 			trace_address: vec![10],
@@ -786,7 +764,7 @@ mod tests {
 			block_hash: H256::from_low_u64_be(14),
 		};
 		let serialized = serde_json::to_string(&t).unwrap();
-		assert_eq!(serialized, r#"{"type":"create","action":{"from":"0x0000000000000000000000000000000000000004","value":"0x6","gas":"0x7","init":"0x1234","creationMethod":"create"},"error":"Out of gas","traceAddress":[10],"subtraces":1,"transactionPosition":11,"transactionHash":"0x000000000000000000000000000000000000000000000000000000000000000c","blockNumber":13,"blockHash":"0x000000000000000000000000000000000000000000000000000000000000000e"}"#);
+		assert_eq!(serialized, r#"{"type":"create","action":{"from":"0x0000000000000000000000000000000000000004","value":"0x6","gas":"0x7","init":"0x1234"},"error":"Out of gas","traceAddress":[10],"subtraces":1,"transactionPosition":11,"transactionHash":"0x000000000000000000000000000000000000000000000000000000000000000c","blockNumber":13,"blockHash":"0x000000000000000000000000000000000000000000000000000000000000000e"}"#);
 	}
 
 	#[test]


### PR DESCRIPTION
This reverts commit 87e108058125098ec404951393a054f08aebef7a.

Fixes https://github.com/paritytech/parity-ethereum/issues/11422, https://github.com/paritytech/parity-ethereum/issues/11424, https://github.com/paritytech/parity-ethereum/issues/11421