### PR TITLE
Simplify a number of Option / Result / Iterator patterns

### DIFF
--- a/accounts/ethstore/src/import.rs
+++ b/accounts/ethstore/src/import.rs
@@ -70,8 +70,7 @@ pub fn import_geth_accounts(dst: &dyn KeyDirectory, desired: HashSet<Address>, t
 	let existing_accounts = dst.load()?.into_iter().map(|a| a.address).collect::<HashSet<_>>();
 
 	accounts.into_iter()
-		.filter(|a| !existing_accounts.contains(&a.address))
-		.filter(|a| desired.contains(&a.address))
+		.filter(|a| !existing_accounts.contains(&a.address) && desired.contains(&a.address))
 		.map(|a| {
 			let address = a.address.clone();
 			dst.insert(a)?;

--- a/accounts/ethstore/src/json/key_file.rs
+++ b/accounts/ethstore/src/json/key_file.rs
@@ -143,20 +143,11 @@ impl<'a> Visitor<'a> for KeyFileVisitor {
 			}
 		}
 
-		let id = match id {
-			Some(id) => id,
-			None => return Err(V::Error::missing_field("id")),
-		};
+		let id = id.ok_or_else(|| V::Error::missing_field("id"))?;
 
-		let version = match version {
-			Some(version) => version,
-			None => return Err(V::Error::missing_field("version")),
-		};
+		let version = version.ok_or_else(|| V::Error::missing_field("version"))?;
 
-		let crypto = match crypto {
-			Some(crypto) => crypto,
-			None => return Err(V::Error::missing_field("crypto")),
-		};
+		let crypto = crypto.ok_or_else(|| V::Error::missing_field("crypto"))?;
 
 		let result = KeyFile {
 			id: id,

--- a/cli-signer/src/lib.rs
+++ b/cli-signer/src/lib.rs
@@ -174,10 +174,7 @@ pub fn signer_sign(
 			}
 		}
 		None => {
-			password = match rpassword::prompt_password_stdout("Password: ") {
-				Ok(p) => p,
-				Err(e) => return Err(format!("{}", e)),
-			}
+			password = rpassword::prompt_password_stdout("Password: ").map_err(|e| format!("{}", e))?
 		}
 	}
 

--- a/ethcore/account-state/src/account.rs
+++ b/ethcore/account-state/src/account.rs
@@ -294,11 +294,7 @@ impl Account {
 	pub fn cached_original_storage_at(&self, key: &H256) -> Option<H256> {
 		match &self.original_storage_cache {
 			Some((_, ref original_storage_cache)) => {
-				if let Some(value) = original_storage_cache.borrow_mut().get_mut(key) {
-					Some(value.clone())
-				} else {
-					None
-				}
+				original_storage_cache.borrow_mut().get_mut(key).cloned()
 			},
 			None => {
 				self.cached_moved_original_storage_at(key)
@@ -314,11 +310,7 @@ impl Account {
 			return Some(H256::zero());
 		}
 
-		if let Some(value) = self.storage_cache.borrow_mut().get_mut(key) {
-			Some(value.clone())
-		} else {
-			None
-		}
+		self.storage_cache.borrow_mut().get_mut(key).cloned()
 	}
 
 	/// return the balance associated with this account.

--- a/ethcore/light/src/cht.rs
+++ b/ethcore/light/src/cht.rs
@@ -110,10 +110,7 @@ pub fn build<F>(cht_num: u64, mut fetcher: F)
 	{
 		let mut t = TrieDBMut::new(&mut db, &mut root);
 		for blk_num in (0..SIZE).map(|n| last_num - n) {
-			let info = match fetcher(id) {
-				Some(info) => info,
-				None => return None,
-			};
+			let info = fetcher(id)?;
 
 			id = BlockId::Hash(info.parent_hash);
 			t.insert(&key!(blk_num), &val!(info.hash, info.total_difficulty))

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -393,10 +393,7 @@ impl<T: ChainDataFetcher> Client<T> {
 
 	/// Get environment info for a given block.
 	pub fn env_info(&self, id: BlockId) -> Option<EnvInfo> {
-		let header = match self.block_header(id) {
-			Some(hdr) => hdr,
-			None => return None,
-		};
+		let header = self.block_header(id)?;
 
 		Some(EnvInfo {
 			number: header.number(),

--- a/ethcore/light/src/net/request_set.rs
+++ b/ethcore/light/src/net/request_set.rs
@@ -74,10 +74,7 @@ impl RequestSet {
 
 	/// Remove a set of requests from the stack.
 	pub fn remove(&mut self, req_id: ReqId, now: Instant) -> Option<Requests> {
-		let id = match self.ids.remove(&req_id) {
-			Some(id) => id,
-			None => return None,
-		};
+		let id = self.ids.remove(&req_id)?;
 
 		let Entry(req, cost) = self.reqs.remove(&id).expect("entry in `ids` implies entry in `reqs`; qed");
 

--- a/ethcore/light/src/on_demand/request.rs
+++ b/ethcore/light/src/on_demand/request.rs
@@ -461,10 +461,7 @@ impl CheckedRequest {
 				let block_hash = req.hash.as_ref()
 					.cloned()
 					.or_else(|| check.0.as_ref().ok().map(|hdr| hdr.hash()));
-				let block_hash = match block_hash {
-					Some(hash) => hash,
-					None => return None,
-				};
+				let block_hash = block_hash?;
 
 				let mut cache = cache.lock();
 				let cached_header;

--- a/ethcore/light/src/provider.rs
+++ b/ethcore/light/src/provider.rs
@@ -248,10 +248,7 @@ impl<T: ProvingBlockChainClient + ?Sized> Provider for T {
 				}
 			};
 
-			match cht::build(cht_number, block_info) {
-				Some(cht) => cht,
-				None => return None, // incomplete CHT.
-			}
+			cht::build(cht_number, block_info)? // None => incomplete CHT
 		};
 
 		let (needed_hdr, needed_td) = needed.expect("`needed` always set in loop, number checked before; qed");
@@ -275,10 +272,7 @@ impl<T: ProvingBlockChainClient + ?Sized> Provider for T {
 		use common_types::transaction::Transaction;
 
 		let id = BlockId::Hash(req.block_hash);
-		let nonce = match self.nonce(&req.from, id) {
-			Some(nonce) => nonce,
-			None => return None,
-		};
+		let nonce = self.nonce(&req.from, id)?;
 		let transaction = Transaction {
 			nonce,
 			gas: req.gas,

--- a/ethcore/machine/src/executive.rs
+++ b/ethcore/machine/src/executive.rs
@@ -471,10 +471,7 @@ impl<'a> CallCreateExecutive<'a> {
 				let out = match exec {
 					Some(exec) => {
 						let mut ext = Self::as_externalities(state, self.info, self.machine, self.schedule, self.depth, self.stack_depth, self.static_flag, &origin_info, &mut unconfirmed_substate, OutputPolicy::Return, tracer, vm_tracer);
-						match exec.exec(&mut ext) {
-							Ok(val) => Ok(val.finalize(ext)),
-							Err(err) => Err(err),
-						}
+						exec.exec(&mut ext).map(|val| { val.finalize(ext) })
 					},
 					None => Ok(Err(vm::Error::OutOfGas)),
 				};
@@ -522,10 +519,7 @@ impl<'a> CallCreateExecutive<'a> {
 				let out = match exec {
 					Some(exec) => {
 						let mut ext = Self::as_externalities(state, self.info, self.machine, self.schedule, self.depth, self.stack_depth, self.static_flag, &origin_info, &mut unconfirmed_substate, OutputPolicy::InitContract, tracer, vm_tracer);
-						match exec.exec(&mut ext) {
-							Ok(val) => Ok(val.finalize(ext)),
-							Err(err) => Err(err),
-						}
+						exec.exec(&mut ext).map(|val| { val.finalize(ext) })
 					},
 					None => Ok(Err(vm::Error::OutOfGas)),
 				};
@@ -559,10 +553,7 @@ impl<'a> CallCreateExecutive<'a> {
 					let exec = resume.resume_call(result);
 
 					let mut ext = Self::as_externalities(state, self.info, self.machine, self.schedule, self.depth, self.stack_depth, self.static_flag, &origin_info, &mut unconfirmed_substate, if self.is_create { OutputPolicy::InitContract } else { OutputPolicy::Return }, tracer, vm_tracer);
-					match exec.exec(&mut ext) {
-						Ok(val) => Ok(val.finalize(ext)),
-						Err(err) => Err(err),
-					}
+					exec.exec(&mut ext).map(|val| { val.finalize(ext) })
 				};
 
 				let res = match out {
@@ -598,10 +589,7 @@ impl<'a> CallCreateExecutive<'a> {
 					let exec = resume.resume_create(result);
 
 					let mut ext = Self::as_externalities(state, self.info, self.machine, self.schedule, self.depth, self.stack_depth, self.static_flag, &origin_info, &mut unconfirmed_substate, if self.is_create { OutputPolicy::InitContract } else { OutputPolicy::Return }, tracer, vm_tracer);
-					match exec.exec(&mut ext) {
-						Ok(val) => Ok(val.finalize(ext)),
-						Err(err) => Err(err),
-					}
+					exec.exec(&mut ext).map(|val| { val.finalize(ext) })
 				};
 
 				let res = match out {

--- a/ethcore/machine/src/executive.rs
+++ b/ethcore/machine/src/executive.rs
@@ -471,7 +471,7 @@ impl<'a> CallCreateExecutive<'a> {
 				let out = match exec {
 					Some(exec) => {
 						let mut ext = Self::as_externalities(state, self.info, self.machine, self.schedule, self.depth, self.stack_depth, self.static_flag, &origin_info, &mut unconfirmed_substate, OutputPolicy::Return, tracer, vm_tracer);
-						exec.exec(&mut ext).map(|val| { val.finalize(ext) })
+						exec.exec(&mut ext).map(|val| val.finalize(ext))
 					},
 					None => Ok(Err(vm::Error::OutOfGas)),
 				};
@@ -519,7 +519,7 @@ impl<'a> CallCreateExecutive<'a> {
 				let out = match exec {
 					Some(exec) => {
 						let mut ext = Self::as_externalities(state, self.info, self.machine, self.schedule, self.depth, self.stack_depth, self.static_flag, &origin_info, &mut unconfirmed_substate, OutputPolicy::InitContract, tracer, vm_tracer);
-						exec.exec(&mut ext).map(|val| { val.finalize(ext) })
+						exec.exec(&mut ext).map(|val| val.finalize(ext))
 					},
 					None => Ok(Err(vm::Error::OutOfGas)),
 				};
@@ -553,7 +553,7 @@ impl<'a> CallCreateExecutive<'a> {
 					let exec = resume.resume_call(result);
 
 					let mut ext = Self::as_externalities(state, self.info, self.machine, self.schedule, self.depth, self.stack_depth, self.static_flag, &origin_info, &mut unconfirmed_substate, if self.is_create { OutputPolicy::InitContract } else { OutputPolicy::Return }, tracer, vm_tracer);
-					exec.exec(&mut ext).map(|val| { val.finalize(ext) })
+					exec.exec(&mut ext).map(|val| val.finalize(ext))
 				};
 
 				let res = match out {
@@ -589,7 +589,7 @@ impl<'a> CallCreateExecutive<'a> {
 					let exec = resume.resume_create(result);
 
 					let mut ext = Self::as_externalities(state, self.info, self.machine, self.schedule, self.depth, self.stack_depth, self.static_flag, &origin_info, &mut unconfirmed_substate, if self.is_create { OutputPolicy::InitContract } else { OutputPolicy::Return }, tracer, vm_tracer);
-					exec.exec(&mut ext).map(|val| { val.finalize(ext) })
+					exec.exec(&mut ext).map(|val| val.finalize(ext))
 				};
 
 				let res = match out {

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -421,10 +421,7 @@ impl SyncProvider for EthSync {
 
 			let peer_info = self.eth_handler.sync.peer_info(&peer_ids);
 			peer_ids.into_iter().zip(peer_info).filter_map(|(peer_id, peer_info)| {
-				let session_info = match ctx.session_info(peer_id) {
-					None => return None,
-					Some(info) => info,
-				};
+				let session_info = ctx.session_info(peer_id)?;
 
 				Some(PeerInfo {
 					id: session_info.id.map(|id| format!("{:x}", id)),
@@ -1041,10 +1038,7 @@ impl LightSyncProvider for LightSync {
 			let peer_ids = self.network.connected_peers();
 
 			peer_ids.into_iter().filter_map(|peer_id| {
-				let session_info = match ctx.session_info(peer_id) {
-					None => return None,
-					Some(info) => info,
-				};
+				let session_info = ctx.session_info(peer_id)?;
 
 				Some(PeerInfo {
 					id: session_info.id.map(|id| format!("{:x}", id)),

--- a/miner/stratum/src/lib.rs
+++ b/miner/stratum/src/lib.rs
@@ -143,13 +143,10 @@ impl StratumImpl {
 		trace!(target: "stratum", "Subscription request from {:?}", meta.addr());
 
 		Ok(match self.dispatcher.initial() {
-			Some(initial) => match jsonrpc_core::Value::from_str(&initial) {
-				Ok(val) => Ok(val),
-				Err(e) => {
+			Some(initial) => jsonrpc_core::Value::from_str(&initial).or_else(|e| { {
 					warn!(target: "stratum", "Invalid payload: '{}' ({:?})", &initial, e);
 					to_value(&[0u8; 0])
-				},
-			},
+				} }),
 			None => to_value(&[0u8; 0]),
 		}.expect("Empty slices are serializable; qed"))
 	}

--- a/parity/secretstore/blockchain.rs
+++ b/parity/secretstore/blockchain.rs
@@ -192,10 +192,7 @@ impl SecretStoreChain for TrustedClient {
 	}
 
 	fn retrieve_last_logs(&self, filter: Filter) -> Option<Vec<RawLog>> {
-		let confirmed_block = match self.get_confirmed_block_hash() {
-			Some(confirmed_block) => confirmed_block,
-			None => return None, // no block with enough confirmations
-		};
+		let confirmed_block = self.get_confirmed_block_hash()?; // no block with enough confirmations
 
 		let from_block = self.block_hash(filter.from_block).unwrap_or_else(|| confirmed_block);
 		let first_block = match self.tree_route(&from_block, &confirmed_block) {

--- a/parity/user_defaults.rs
+++ b/parity/user_defaults.rs
@@ -156,13 +156,10 @@ impl Default for UserDefaults {
 impl UserDefaults {
 	pub fn load<P>(path: P) -> Result<Self, String> where P: AsRef<Path> {
 		match File::open(path) {
-			Ok(file) => match from_reader(file) {
-				Ok(defaults) => Ok(defaults),
-				Err(e) => {
+			Ok(file) => from_reader(file).or_else(|e| { {
 					warn!("Error loading user defaults file: {:?}", e);
 					Ok(UserDefaults::default())
-				},
-			},
+				} }),
 			_ => Ok(UserDefaults::default()),
 		}
 	}

--- a/rpc/src/v1/helpers/engine_signer.rs
+++ b/rpc/src/v1/helpers/engine_signer.rs
@@ -36,10 +36,7 @@ impl EngineSigner {
 
 impl engine::signer::EngineSigner for EngineSigner {
 	fn sign(&self, message: Message) -> Result<Signature, Error> {
-		match self.accounts.sign(self.address, Some(self.password.clone()), message) {
-			Ok(ok) => Ok(ok),
-			Err(_) => Err(Error::InvalidSecretKey),
-		}
+		self.accounts.sign(self.address, Some(self.password.clone()), message).map_err(|_| { Error::InvalidSecretKey })
 	}
 
 	fn decrypt(&self, auth_data: &[u8], cipher: &[u8]) -> Result<Vec<u8>, Error> {

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -620,10 +620,7 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 		let num = num.unwrap_or_default();
 
 		try_bf!(check_known(&*self.client, num.clone()));
-		let res = match self.client.balance(&address, self.get_state(num)) {
-			Some(balance) => Ok(balance),
-			None => Err(errors::state_pruned()),
-		};
+		let res = self.client.balance(&address, self.get_state(num)).ok_or_else(|| { errors::state_pruned() });
 
 		Box::new(future::done(res))
 	}
@@ -706,10 +703,7 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 			},
 			number => {
 				try_bf!(check_known(&*self.client, number.clone()));
-				match self.client.nonce(&address, block_number_to_id(number)) {
-					Some(nonce) => Ok(nonce),
-					None => Err(errors::state_pruned()),
-				}
+				self.client.nonce(&address, block_number_to_id(number)).ok_or_else(|| { errors::state_pruned() })
 			}
 		};
 

--- a/rpc/src/v1/impls/light/eth.rs
+++ b/rpc/src/v1/impls/light/eth.rs
@@ -573,10 +573,7 @@ where
 }
 
 fn extract_uncle_at_index<T: LightChainClient>(block: encoded::Block, index: Index, client: Arc<T>) -> Option<RichBlock> {
-		let uncle = match block.uncles().into_iter().nth(index.value()) {
-			Some(u) => u,
-			None => return None,
-		};
+		let uncle = block.uncles().into_iter().nth(index.value())?;
 
 		let extra_info = client.engine().extra_info(&uncle);
 		Some(RichBlock {

--- a/rpc/src/v1/impls/parity_set.rs
+++ b/rpc/src/v1/impls/parity_set.rs
@@ -120,10 +120,7 @@ impl<C, M, U, F> ParitySet for ParitySetClient<C, M, U, F> where
 {
 
 	fn set_min_gas_price(&self, gas_price: U256) -> Result<bool> {
-		match self.miner.set_minimal_gas_price(gas_price) {
-			Ok(success) => Ok(success),
-			Err(e) => Err(errors::unsupported(e, None)),
-		}
+		self.miner.set_minimal_gas_price(gas_price).map_err(|e| { errors::unsupported(e, None) })
 	}
 
 	fn set_transactions_limit(&self, _limit: usize) -> Result<bool> {

--- a/secret-store/src/key_server_cluster/client_sessions/signing_session_ecdsa.rs
+++ b/secret-store/src/key_server_cluster/client_sessions/signing_session_ecdsa.rs
@@ -667,10 +667,7 @@ impl SessionImpl {
 		debug_assert!(self.core.access_key == *message.sub_session);
 		debug_assert!(sender != &self.core.meta.self_node_id);
 
-		let key_share = match self.core.key_share.as_ref() {
-			None => return Err(Error::InvalidMessage),
-			Some(key_share) => key_share,
-		};
+		let key_share = self.core.key_share.as_ref().ok_or_else(|| Error::InvalidMessage)?;
 
 		let mut data = self.data.lock();
 
@@ -999,10 +996,7 @@ impl SessionCore {
 	}
 
 	pub fn disseminate_jobs(&self, consensus_session: &mut SigningConsensusSession, version: &H256, nonce_public: Public, inv_nonce_share: Secret, inversed_nonce_coeff: Secret, message_hash: H256) -> Result<(), Error> {
-		let key_share = match self.key_share.as_ref() {
-			None => return Err(Error::InvalidMessage),
-			Some(key_share) => key_share,
-		};
+		let key_share = self.key_share.as_ref().ok_or_else(|| Error::InvalidMessage)?;
 
 		let key_version = key_share.version(version)?.hash.clone();
 		let signing_job = EcdsaSigningJob::new_on_master(key_share.clone(), key_version, nonce_public, inv_nonce_share, inversed_nonce_coeff, message_hash)?;

--- a/secret-store/src/key_server_cluster/client_sessions/signing_session_schnorr.rs
+++ b/secret-store/src/key_server_cluster/client_sessions/signing_session_schnorr.rs
@@ -395,10 +395,7 @@ impl SessionImpl {
 		let mut other_consensus_group_nodes = consensus_group.clone();
 		other_consensus_group_nodes.remove(&self.core.meta.self_node_id);
 
-		let key_share = match self.core.key_share.as_ref() {
-			None => return Err(Error::InvalidMessage),
-			Some(key_share) => key_share,
-		};
+		let key_share = self.core.key_share.as_ref().ok_or_else(|| Error::InvalidMessage)?;
 
 		let generation_session = GenerationSession::new(GenerationSessionParams {
 			id: self.core.meta.id.clone(),
@@ -488,10 +485,7 @@ impl SessionImpl {
 		debug_assert!(self.core.access_key == *message.sub_session);
 		debug_assert!(sender != &self.core.meta.self_node_id);
 
-		let key_share = match self.core.key_share.as_ref() {
-			None => return Err(Error::InvalidMessage),
-			Some(key_share) => key_share,
-		};
+		let key_share = self.core.key_share.as_ref().ok_or_else(|| Error::InvalidMessage)?;
 
 		let mut data = self.data.lock();
 
@@ -745,10 +739,7 @@ impl SessionCore {
 	}
 
 	pub fn disseminate_jobs(&self, consensus_session: &mut SigningConsensusSession, version: &H256, session_public: Public, session_secret_share: Secret, message_hash: H256) -> Result<(), Error> {
-		let key_share = match self.key_share.as_ref() {
-			None => return Err(Error::InvalidMessage),
-			Some(key_share) => key_share,
-		};
+		let key_share = self.key_share.as_ref().ok_or_else(|| Error::InvalidMessage)?;
 
 		let key_version = key_share.version(version)?.hash.clone();
 		let signing_job = SchnorrSigningJob::new_on_master(self.meta.self_node_id.clone(), key_share.clone(), key_version,

--- a/secret-store/src/key_server_cluster/cluster_connections_net.rs
+++ b/secret-store/src/key_server_cluster/cluster_connections_net.rs
@@ -182,10 +182,7 @@ impl ConnectionProvider for RwLock<NetConnectionsContainer> {
 	}
 
 	fn connection(&self, node: &NodeId) -> Option<Arc<dyn Connection>> {
-		match self.read().connections.get(node).cloned() {
-			Some(connection) => Some(connection),
-			None => None,
-		}
+		self.read().connections.get(node).cloned()
 	}
 }
 

--- a/secret-store/src/key_server_cluster/cluster_sessions.rs
+++ b/secret-store/src/key_server_cluster/cluster_sessions.rs
@@ -99,9 +99,7 @@ pub trait ClusterSession {
 		result_reader: F
 	) -> Option<Result<T, Error>> {
 		let mut locked_data = session_data.lock();
-		match result_reader(&locked_data) {
-			Some(result) => Some(result),
-			None => {
+		result_reader(&locked_data).or_else(|| { {
 				let completion_condvar = completion.completion_condvar.as_ref().expect("created in test mode");
 				match timeout {
 					None => completion_condvar.wait(&mut locked_data),
@@ -111,8 +109,7 @@ pub trait ClusterSession {
 				}
 
 				result_reader(&locked_data)
-			},
-		}
+			} })
 	}
 }
 

--- a/secret-store/src/key_server_cluster/connection_trigger_with_migration.rs
+++ b/secret-store/src/key_server_cluster/connection_trigger_with_migration.rs
@@ -437,8 +437,7 @@ fn select_master_node(snapshot: &KeyServerSetSnapshot) -> &NodeId {
 	match snapshot.migration.as_ref() {
 		Some(migration) => &migration.master,
 		None => snapshot.current_set.keys()
-			.filter(|n| snapshot.new_set.contains_key(n))
-			.nth(0)
+			.find(|n| snapshot.new_set.contains_key(n))
 			.or_else(|| snapshot.new_set.keys().nth(0))
 			.unwrap_or_else(|| snapshot.current_set.keys().nth(0)
 				.expect("select_master_node is only called when migration is Required or Started;\

--- a/secret-store/src/key_server_cluster/jobs/decryption_job.rs
+++ b/secret-store/src/key_server_cluster/jobs/decryption_job.rs
@@ -148,10 +148,7 @@ impl JobExecutor for DecryptionJob {
 		Ok(JobPartialRequestAction::Respond(PartialDecryptionResponse {
 			request_id: partial_request.id,
 			shadow_point: shadow_point,
-			decrypt_shadow: match decrypt_shadow.clone() {
-				None => None,
-				Some(decrypt_shadow) => Some(encrypt(&self.requester, &DEFAULT_MAC, decrypt_shadow.as_bytes())?),
-			},
+			decrypt_shadow: decrypt_shadow.clone().map(|decrypt_shadow| { encrypt(&self.requester, &DEFAULT_MAC, decrypt_shadow.as_bytes())? }),
 		}))
 	}
 

--- a/util/network-devp2p/src/ip_utils.rs
+++ b/util/network-devp2p/src/ip_utils.rs
@@ -427,10 +427,7 @@ fn search_natpmp(local: &NodeEndpoint) -> Option<NodeEndpoint> {
 pub fn map_external_address(local: &NodeEndpoint, nat_type: &NatType) -> Option<NodeEndpoint> {
 	match *nat_type {
 		NatType::Any => {
-			match search_natpmp(local) {
-				Some(end_point) => Some(end_point),
-				None => search_upnp(local),
-			}
+			search_natpmp(local).or_else(|| { search_upnp(local) })
 		},
 		NatType::NatPMP => search_natpmp(local),
 		NatType::UPnP => search_upnp(local),


### PR DESCRIPTION
This makes a number of pattern matches easier to read, and speeds up
one `filter` + select into a `find`. Opinions on these refactorings
loosely held, happy to accomodate review.