### PR TITLE
accounts: clippy and style fixes

### DIFF
--- a/accounts/ethkey/src/brain.rs
+++ b/accounts/ethkey/src/brain.rs
@@ -23,8 +23,8 @@ use parity_wordlist;
 pub struct Brain(String);
 
 impl Brain {
-	pub fn new(s: String) -> Self {
-		Brain(s)
+	pub const fn new(s: String) -> Self {
+		Self(s)
 	}
 
 	pub fn validate_phrase(phrase: &str, expected_words: usize) -> Result<(), ::WordlistError> {
@@ -43,18 +43,15 @@ impl Generator for Brain {
 		loop {
 			secret = secret.keccak256();
 
-			match i > 16384 {
-				false => i += 1,
-				true => {
-					if let Ok(pair) = Secret::import_key(&secret)
-						.and_then(KeyPair::from_secret)
-					{
-						if pair.address()[0] == 0 {
-							trace!("Testing: {}, got: {:?}", self.0, pair.address());
-							return Ok(pair)
-						}
-					}
-				},
+			if i <= 16384 {
+				i += 1
+			} else if let Ok(pair) = Secret::import_key(&secret)
+					.and_then(KeyPair::from_secret)
+				{
+					if pair.address()[0] == 0 {
+						trace!("Testing: {}, got: {:?}", self.0, pair.address());
+						return Ok(pair)
+				}
 			}
 		}
 	}
@@ -69,7 +66,7 @@ mod tests {
 	fn test_brain() {
 		let words = "this is sparta!".to_owned();
 		let first_keypair = Brain::new(words.clone()).generate().unwrap();
-		let second_keypair = Brain::new(words.clone()).generate().unwrap();
+		let second_keypair = Brain::new(words).generate().unwrap();
 		assert_eq!(first_keypair.secret(), second_keypair.secret());
 	}
 }

--- a/accounts/ethkey/src/brain_prefix.rs
+++ b/accounts/ethkey/src/brain_prefix.rs
@@ -27,8 +27,8 @@ pub struct BrainPrefix {
 }
 
 impl BrainPrefix {
-	pub fn new(prefix: Vec<u8>, iterations: usize, no_of_words: usize) -> Self {
-		BrainPrefix {
+	pub const fn new(prefix: Vec<u8>, iterations: usize, no_of_words: usize) -> Self {
+		Self {
 			prefix,
 			iterations,
 			no_of_words,
@@ -65,7 +65,7 @@ mod tests {
 
 	#[test]
 	fn prefix_generator() {
-		let prefix = vec![0x00u8];
+		let prefix = vec![0x00_u8];
 		let keypair = BrainPrefix::new(prefix.clone(), usize::max_value(), 12).generate().unwrap();
 		assert!(keypair.address().as_bytes().starts_with(&prefix));
 	}

--- a/accounts/ethkey/src/brain_recover.rs
+++ b/accounts/ethkey/src/brain_recover.rs
@@ -82,20 +82,20 @@ impl PhrasesIterator {
 			let to_add = expected_words - words.len();
 			info!("Number of words is insuficcient adding {} more.", to_add);
 			for _ in 0..to_add {
-				words.push(parity_wordlist::WORDS.iter().cloned().collect());
+				words.push(parity_wordlist::WORDS.to_vec());
 			}
 		}
 
 		// start searching
-		PhrasesIterator::new(words)
+		Self::new(words)
 	}
 
 	pub fn new(words: Vec<Vec<&'static str>>) -> Self {
-		let combinations = words.iter().fold(1u64, |acc, x| acc * x.len() as u64);
+		let combinations = words.iter().fold(1_u64, |acc, x| acc * x.len() as u64);
 		let indexes = words.iter().map(|_| 0).collect();
 		info!("Starting to test {} possible combinations.", combinations);
 
-		PhrasesIterator {
+		Self {
 			words,
 			combinations,
 			indexes,
@@ -103,7 +103,7 @@ impl PhrasesIterator {
 		}
 	}
 
-	pub fn combinations(&self) -> u64 {
+	pub const fn combinations(&self) -> u64 {
 		self.combinations
 	}
 

--- a/accounts/ethkey/src/lib.rs
+++ b/accounts/ethkey/src/lib.rs
@@ -14,7 +14,53 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-// #![warn(missing_docs)]
+#![warn(
+	clippy::all,
+	clippy::pedantic,
+	clippy::nursery,
+)]
+#![allow(
+	clippy::blacklisted_name,
+	clippy::cast_lossless,
+	clippy::cast_possible_truncation,
+	clippy::cast_possible_wrap,
+	clippy::cast_precision_loss,
+	clippy::cast_ptr_alignment,
+	clippy::cast_sign_loss,
+	clippy::cognitive_complexity,
+	clippy::default_trait_access,
+	clippy::enum_glob_use,
+	clippy::eval_order_dependence,
+	clippy::fallible_impl_from,
+	clippy::float_cmp,
+	clippy::identity_op,
+	clippy::if_not_else,
+	clippy::indexing_slicing,
+	clippy::inline_always,
+	clippy::items_after_statements,
+	clippy::large_enum_variant,
+	clippy::many_single_char_names,
+	clippy::match_same_arms,
+	clippy::missing_errors_doc,
+	clippy::missing_safety_doc,
+	clippy::module_inception,
+	clippy::module_name_repetitions,
+	clippy::must_use_candidate,
+	clippy::needless_pass_by_value,
+	clippy::needless_update,
+	clippy::non_ascii_literal,
+	clippy::option_option,
+	clippy::pub_enum_variant_names,
+	clippy::same_functions_in_if_condition,
+	clippy::shadow_unrelated,
+	clippy::similar_names,
+	clippy::single_component_path_imports,
+	clippy::too_many_arguments,
+	clippy::too_many_lines,
+	clippy::type_complexity,
+	clippy::unused_self,
+	clippy::used_underscore_binding,
+)]
 
 extern crate edit_distance;
 extern crate parity_crypto;

--- a/accounts/ethkey/src/password.rs
+++ b/accounts/ethkey/src/password.rs
@@ -47,13 +47,13 @@ impl Drop for Password {
 }
 
 impl From<String> for Password {
-	fn from(s: String) -> Password {
-		Password(s)
+	fn from(s: String) -> Self {
+		Self(s)
 	}
 }
 
 impl<'a> From<&'a str> for Password {
-	fn from(s: &'a str) -> Password {
-		Password::from(String::from(s))
+	fn from(s: &'a str) -> Self {
+		Self::from(String::from(s))
 	}
 }

--- a/accounts/ethkey/src/prefix.rs
+++ b/accounts/ethkey/src/prefix.rs
@@ -23,10 +23,10 @@ pub struct Prefix {
 }
 
 impl Prefix {
-	pub fn new(prefix: Vec<u8>, iterations: usize) -> Self {
-		Prefix {
-			prefix: prefix,
-			iterations: iterations,
+	pub const fn new(prefix: Vec<u8>, iterations: usize) -> Self {
+		Self {
+			prefix,
+			iterations,
 		}
 	}
 }
@@ -53,7 +53,7 @@ mod tests {
 
 	#[test]
 	fn prefix_generator() {
-		let prefix = vec![0xffu8];
+		let prefix = vec![0xff_u8];
 		let keypair = Prefix::new(prefix.clone(), usize::max_value()).generate().unwrap();
 		assert!(keypair.address().as_bytes().starts_with(&prefix));
 	}

--- a/accounts/ethstore/src/account/cipher.rs
+++ b/accounts/ethstore/src/account/cipher.rs
@@ -28,7 +28,7 @@ pub enum Cipher {
 
 impl From<json::Aes128Ctr> for Aes128Ctr {
 	fn from(json: json::Aes128Ctr) -> Self {
-		Aes128Ctr {
+		Self {
 			iv: json.iv.into()
 		}
 	}
@@ -45,7 +45,7 @@ impl Into<json::Aes128Ctr> for Aes128Ctr {
 impl From<json::Cipher> for Cipher {
 	fn from(json: json::Cipher) -> Self {
 		match json {
-			json::Cipher::Aes128Ctr(params) => Cipher::Aes128Ctr(From::from(params)),
+			json::Cipher::Aes128Ctr(params) => Self::Aes128Ctr(From::from(params)),
 		}
 	}
 }
@@ -53,7 +53,7 @@ impl From<json::Cipher> for Cipher {
 impl Into<json::Cipher> for Cipher {
 	fn into(self) -> json::Cipher {
 		match self {
-			Cipher::Aes128Ctr(params) => json::Cipher::Aes128Ctr(params.into()),
+			Self::Aes128Ctr(params) => json::Cipher::Aes128Ctr(params.into()),
 		}
 	}
 }

--- a/accounts/ethstore/src/account/kdf.rs
+++ b/accounts/ethstore/src/account/kdf.rs
@@ -47,7 +47,7 @@ pub enum Kdf {
 impl From<json::Prf> for Prf {
 	fn from(json: json::Prf) -> Self {
 		match json {
-			json::Prf::HmacSha256 => Prf::HmacSha256,
+			json::Prf::HmacSha256 => Self::HmacSha256,
 		}
 	}
 }
@@ -55,14 +55,14 @@ impl From<json::Prf> for Prf {
 impl Into<json::Prf> for Prf {
 	fn into(self) -> json::Prf {
 		match self {
-			Prf::HmacSha256 => json::Prf::HmacSha256,
+			Self::HmacSha256 => json::Prf::HmacSha256,
 		}
 	}
 }
 
 impl From<json::Pbkdf2> for Pbkdf2 {
 	fn from(json: json::Pbkdf2) -> Self {
-		Pbkdf2 {
+		Self {
 			c: json.c,
 			dklen: json.dklen,
 			prf: From::from(json.prf),
@@ -84,7 +84,7 @@ impl Into<json::Pbkdf2> for Pbkdf2 {
 
 impl From<json::Scrypt> for Scrypt {
 	fn from(json: json::Scrypt) -> Self {
-		Scrypt {
+		Self {
 			dklen: json.dklen,
 			p: json.p,
 			n: json.n,
@@ -109,8 +109,8 @@ impl Into<json::Scrypt> for Scrypt {
 impl From<json::Kdf> for Kdf {
 	fn from(json: json::Kdf) -> Self {
 		match json {
-			json::Kdf::Pbkdf2(params) => Kdf::Pbkdf2(From::from(params)),
-			json::Kdf::Scrypt(params) => Kdf::Scrypt(From::from(params)),
+			json::Kdf::Pbkdf2(params) => Self::Pbkdf2(From::from(params)),
+			json::Kdf::Scrypt(params) => Self::Scrypt(From::from(params)),
 		}
 	}
 }
@@ -118,8 +118,8 @@ impl From<json::Kdf> for Kdf {
 impl Into<json::Kdf> for Kdf {
 	fn into(self) -> json::Kdf {
 		match self {
-			Kdf::Pbkdf2(params) => json::Kdf::Pbkdf2(params.into()),
-			Kdf::Scrypt(params) => json::Kdf::Scrypt(params.into()),
+			Self::Pbkdf2(params) => json::Kdf::Pbkdf2(params.into()),
+			Self::Scrypt(params) => json::Kdf::Scrypt(params.into()),
 		}
 	}
 }

--- a/accounts/ethstore/src/account/version.rs
+++ b/accounts/ethstore/src/account/version.rs
@@ -24,7 +24,7 @@ pub enum Version {
 impl From<json::Version> for Version {
 	fn from(json: json::Version) -> Self {
 		match json {
-			json::Version::V3 => Version::V3,
+			json::Version::V3 => Self::V3,
 		}
 	}
 }
@@ -32,7 +32,7 @@ impl From<json::Version> for Version {
 impl Into<json::Version> for Version {
 	fn into(self) -> json::Version {
 		match self {
-			Version::V3 => json::Version::V3,
+			Self::V3 => json::Version::V3,
 		}
 	}
 }

--- a/accounts/ethstore/src/accounts_dir/disk.rs
+++ b/accounts/ethstore/src/accounts_dir/disk.rs
@@ -25,7 +25,7 @@ use super::{KeyDirectory, VaultKeyDirectory, VaultKeyDirectoryProvider, VaultKey
 use super::vault::{VAULT_FILE_NAME, VaultDiskDirectory};
 use ethkey::Password;
 
-const IGNORED_FILES: &'static [&'static str] = &[
+const IGNORED_FILES: &[&str] = &[
 	"thumbs.db",
 	"address_book.json",
 	"dapps_policy.json",
@@ -141,28 +141,32 @@ impl RootDiskDirectory {
 impl<T> DiskDirectory<T> where T: KeyFileManager {
 	/// Create new disk directory instance
 	pub fn new<P>(path: P, key_manager: T) -> Self where P: AsRef<Path> {
-		DiskDirectory {
+		Self {
 			path: path.as_ref().to_path_buf(),
-			key_manager: key_manager,
+			key_manager,
 		}
 	}
 
 	fn files(&self) -> Result<Vec<PathBuf>, Error>  {
 		Ok(fs::read_dir(&self.path)?
-			.flat_map(Result::ok)
-			.filter(|entry| {
-				let metadata = entry.metadata().ok();
-				let file_name = entry.file_name();
-				let name = file_name.to_string_lossy();
-				// filter directories
-				metadata.map_or(false, |m| !m.is_dir()) &&
-					// hidden files
-					!name.starts_with(".") &&
-					// other ignored files
-					!IGNORED_FILES.contains(&&*name)
+			.filter_map(|entry| {
+				if let Ok(entry) = entry {
+					let metadata = entry.metadata().ok();
+					let file_name = entry.file_name();
+					let name = file_name.to_string_lossy();
+					// filter directories
+					if metadata.map_or(false, |m| !m.is_dir()) &&
+						// hidden files
+						!name.starts_with('.') &&
+						// other ignored files
+						!IGNORED_FILES.contains(&&*name) {
+							return Some(entry.path());
+						}
+				}
+
+				None
 			})
-			.map(|entry| entry.path())
-			.collect::<Vec<PathBuf>>()
+			.collect()
 		)
 	}
 
@@ -180,8 +184,8 @@ impl<T> DiskDirectory<T> where T: KeyFileManager {
 	}
 
 	fn last_modification_date(&self) -> Result<u64, Error> {
-		use std::time::{Duration, UNIX_EPOCH};
-		let duration = fs::metadata(&self.path)?.modified()?.duration_since(UNIX_EPOCH).unwrap_or(Duration::default());
+		use std::time::UNIX_EPOCH;
+		let duration = fs::metadata(&self.path)?.modified()?.duration_since(UNIX_EPOCH).unwrap_or_default();
 		let timestamp = duration.as_secs() ^ (duration.subsec_nanos() as u64);
 		Ok(timestamp)
 	}
@@ -194,7 +198,7 @@ impl<T> DiskDirectory<T> where T: KeyFileManager {
 		Ok(paths
 			.into_iter()
 			.filter_map(|path| {
-				let filename = Some(path.file_name().and_then(|n| n.to_str()).expect("Keys have valid UTF8 names only.").to_owned());
+				let filename = Some(path.file_name().and_then(std::ffi::OsStr::to_str).expect("Keys have valid UTF8 names only.").to_owned());
 				fs::File::open(path.clone())
 					.map_err(Into::into)
 					.and_then(|file| self.key_manager.read(filename, file))
@@ -273,7 +277,7 @@ impl<T> KeyDirectory for DiskDirectory<T> where T: KeyFileManager {
 		// and find entry with given address
 		let to_remove = self.files_content()?
 			.into_iter()
-			.find(|&(_, ref acc)| acc.id == account.id && acc.address == account.address);
+			.find(|(_, acc)| acc.id == account.id && acc.address == account.address);
 
 		// remove it
 		match to_remove {
@@ -311,7 +315,7 @@ impl<T> VaultKeyDirectoryProvider for DiskDirectory<T> where T: KeyFileManager {
 				let mut vault_file_path = path.clone();
 				vault_file_path.push(VAULT_FILE_NAME);
 				if vault_file_path.is_file() {
-					path.file_name().and_then(|f| f.to_str()).map(|f| f.to_owned())
+					path.file_name().and_then(std::ffi::OsStr::to_str).map(std::borrow::ToOwned::to_owned)
 				} else {
 					None
 				}
@@ -369,7 +373,7 @@ mod test {
 		let directory = RootDiskDirectory::create(dir.clone()).unwrap();
 
 		// when
-		let account = SafeAccount::create(&keypair, [0u8; 16], &password, 1024, "Test".to_owned(), "{}".to_owned());
+		let account = SafeAccount::create(&keypair, [0_u8; 16], &password, 1024, "Test".to_owned(), "{}".to_owned());
 		let res = directory.insert(account.unwrap());
 
 		// then
@@ -390,14 +394,14 @@ mod test {
 		let directory = RootDiskDirectory::create(dir.clone()).unwrap();
 
 		// when
-		let account = SafeAccount::create(&keypair, [0u8; 16], &password, 1024, "Test".to_owned(), "{}".to_owned()).unwrap();
+		let account = SafeAccount::create(&keypair, [0_u8; 16], &password, 1024, "Test".to_owned(), "{}".to_owned()).unwrap();
 		let filename = "test".to_string();
 		let dedup = true;
 
 		directory.insert_with_filename(account.clone(), "foo".to_string(), dedup).unwrap();
 		let file1 = directory.insert_with_filename(account.clone(), filename.clone(), dedup).unwrap().filename.unwrap();
 		let file2 = directory.insert_with_filename(account.clone(), filename.clone(), dedup).unwrap().filename.unwrap();
-		let file3 = directory.insert_with_filename(account.clone(), filename.clone(), dedup).unwrap().filename.unwrap();
+		let file3 = directory.insert_with_filename(account, filename.clone(), dedup).unwrap().filename.unwrap();
 
 		// then
 		// the first file should have the original names
@@ -469,12 +473,12 @@ mod test {
 		let hash = directory.files_hash().expect("Files hash should be calculated ok");
 		assert_eq!(
 			hash,
-			15130871412783076140
+			15_130_871_412_783_076_140
 		);
 
 		let keypair = Random.generate().unwrap();
 		let password = "test pass".into();
-		let account = SafeAccount::create(&keypair, [0u8; 16], &password, 1024, "Test".to_owned(), "{}".to_owned());
+		let account = SafeAccount::create(&keypair, [0_u8; 16], &password, 1024, "Test".to_owned(), "{}".to_owned());
 		directory.insert(account.unwrap()).expect("Account should be inserted ok");
 
 		let new_hash = directory.files_hash().expect("New files hash should be calculated ok");

--- a/accounts/ethstore/src/accounts_dir/memory.rs
+++ b/accounts/ethstore/src/accounts_dir/memory.rs
@@ -66,9 +66,9 @@ impl KeyDirectory for MemoryDirectory {
 	}
 
 	fn unique_repr(&self) -> Result<u64, Error> {
-		let mut val = 0u64;
+		let mut val = 0_u64;
 		let accounts = self.accounts.read();
-		for acc in accounts.keys() { val = val ^ acc.to_low_u64_be() }
+		for acc in accounts.keys() { val ^= acc.to_low_u64_be() }
 		Ok(val)
 	}
 }

--- a/accounts/ethstore/src/accounts_dir/mod.rs
+++ b/accounts/ethstore/src/accounts_dir/mod.rs
@@ -97,9 +97,9 @@ pub use self::vault::VaultDiskDirectory;
 impl VaultKey {
 	/// Create new vault key
 	pub fn new(password: &Password, iterations: u32) -> Self {
-		VaultKey {
+		Self {
 			password: password.clone(),
-			iterations: iterations,
+			iterations,
 		}
 	}
 }

--- a/accounts/ethstore/src/error.rs
+++ b/accounts/ethstore/src/error.rs
@@ -58,23 +58,23 @@ pub enum Error {
 
 impl fmt::Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-		let s = match *self {
-			Error::Io(ref err) => err.to_string(),
-			Error::InvalidPassword => "Invalid password".into(),
-			Error::InvalidSecret => "Invalid secret".into(),
-			Error::InvalidCryptoMeta => "Invalid crypted metadata".into(),
-			Error::InvalidAccount => "Invalid account".into(),
-			Error::InvalidMessage => "Invalid message".into(),
-			Error::InvalidKeyFile(ref reason) => format!("Invalid key file: {}", reason),
-			Error::VaultsAreNotSupported => "Vaults are not supported".into(),
-			Error::UnsupportedVault => "Vault is not supported for this operation".into(),
-			Error::InvalidVaultName => "Invalid vault name".into(),
-			Error::VaultNotFound => "Vault not found".into(),
-			Error::CreationFailed => "Account creation failed".into(),
-			Error::EthCrypto(ref err) => err.to_string(),
-			Error::EthPublicKeyCrypto(ref err) => err.to_string(),
-			Error::Derivation(ref err) => format!("Derivation error: {:?}", err),
-			Error::Custom(ref s) => s.clone(),
+		let s = match self {
+			Self::Io(err) => err.to_string(),
+			Self::InvalidPassword => "Invalid password".into(),
+			Self::InvalidSecret => "Invalid secret".into(),
+			Self::InvalidCryptoMeta => "Invalid crypted metadata".into(),
+			Self::InvalidAccount => "Invalid account".into(),
+			Self::InvalidMessage => "Invalid message".into(),
+			Self::InvalidKeyFile(reason) => format!("Invalid key file: {}", reason),
+			Self::VaultsAreNotSupported => "Vaults are not supported".into(),
+			Self::UnsupportedVault => "Vault is not supported for this operation".into(),
+			Self::InvalidVaultName => "Invalid vault name".into(),
+			Self::VaultNotFound => "Vault not found".into(),
+			Self::CreationFailed => "Account creation failed".into(),
+			Self::EthCrypto(err) => err.to_string(),
+			Self::EthPublicKeyCrypto(err) => err.to_string(),
+			Self::Derivation(err) => format!("Derivation error: {:?}", err),
+			Self::Custom(s) => s.clone(),
 		};
 
 		write!(f, "{}", s)
@@ -83,36 +83,36 @@ impl fmt::Display for Error {
 
 impl From<IoError> for Error {
 	fn from(err: IoError) -> Self {
-		Error::Io(err)
+		Self::Io(err)
 	}
 }
 
 impl From<EthPublicKeyCryptoError> for Error {
 	fn from(err: EthPublicKeyCryptoError) -> Self {
-		Error::EthPublicKeyCrypto(err)
+		Self::EthPublicKeyCrypto(err)
 	}
 }
 
 impl From<EthCryptoError> for Error {
 	fn from(err: EthCryptoError) -> Self {
-		Error::EthCrypto(err)
+		Self::EthCrypto(err)
 	}
 }
 
 impl From<crypto::error::ScryptError> for Error {
 	fn from(err: crypto::error::ScryptError) -> Self {
-		Error::EthCrypto(err.into())
+		Self::EthCrypto(err.into())
 	}
 }
 
 impl From<crypto::error::SymmError> for Error {
 	fn from(err: crypto::error::SymmError) -> Self {
-		Error::EthCrypto(err.into())
+		Self::EthCrypto(err.into())
 	}
 }
 
 impl From<DerivationError> for Error {
 	fn from(err: DerivationError) -> Self {
-		Error::Derivation(err)
+		Self::Derivation(err)
 	}
 }

--- a/accounts/ethstore/src/json/bytes.rs
+++ b/accounts/ethstore/src/json/bytes.rs
@@ -36,7 +36,7 @@ impl<'a> Deserialize<'a> for Bytes {
 	{
 		let s = String::deserialize(deserializer)?;
 		let data = s.from_hex().map_err(|e| Error::custom(format!("Invalid hex value {}", e)))?;
-		Ok(Bytes(data))
+		Ok(Self(data))
 	}
 }
 
@@ -51,19 +51,19 @@ impl str::FromStr for Bytes {
 	type Err = FromHexError;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		s.from_hex().map(Bytes)
+		s.from_hex().map(Self)
 	}
 }
 
 impl From<&'static str> for Bytes {
 	fn from(s: &'static str) -> Self {
-		s.parse().expect(&format!("invalid string literal for {}: '{}'", stringify!(Self), s))
+		s.parse().unwrap_or_else(|e| panic!("invalid string literal for {}: '{}': {}", stringify!(Self), s, e))
 	}
 }
 
 impl From<Vec<u8>> for Bytes {
 	fn from(v: Vec<u8>) -> Self {
-		Bytes(v)
+		Self(v)
 	}
 }
 

--- a/accounts/ethstore/src/json/cipher.rs
+++ b/accounts/ethstore/src/json/cipher.rs
@@ -27,8 +27,8 @@ pub enum CipherSer {
 impl Serialize for CipherSer {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where S: Serializer {
-		match *self {
-			CipherSer::Aes128Ctr => serializer.serialize_str("aes-128-ctr"),
+		match self {
+			Self::Aes128Ctr => serializer.serialize_str("aes-128-ctr"),
 		}
 	}
 }
@@ -74,8 +74,8 @@ pub enum CipherSerParams {
 impl Serialize for CipherSerParams {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where S: Serializer {
-		match *self {
-			CipherSerParams::Aes128Ctr(ref params) => params.serialize(serializer),
+		match self {
+			Self::Aes128Ctr(params) => params.serialize(serializer),
 		}
 	}
 }
@@ -84,7 +84,7 @@ impl<'a> Deserialize<'a> for CipherSerParams {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where D: Deserializer<'a> {
 		Aes128Ctr::deserialize(deserializer)
-			.map(CipherSerParams::Aes128Ctr)
+			.map(Self::Aes128Ctr)
 			.map_err(|_| Error::InvalidCipherParams)
 			.map_err(SerdeError::custom)
 	}

--- a/accounts/ethstore/src/json/crypto.rs
+++ b/accounts/ethstore/src/json/crypto.rs
@@ -56,7 +56,7 @@ enum CryptoField {
 }
 
 impl<'a> Deserialize<'a> for CryptoField {
-	fn deserialize<D>(deserializer: D) -> Result<CryptoField, D::Error>
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 		where D: Deserializer<'a>
 	{
 		deserializer.deserialize_any(CryptoFieldVisitor)
@@ -89,10 +89,10 @@ impl<'a> Visitor<'a> for CryptoFieldVisitor {
 }
 
 impl<'a> Deserialize<'a> for Crypto {
-	fn deserialize<D>(deserializer: D) -> Result<Crypto, D::Error>
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 		where D: Deserializer<'a>
 	{
-		static FIELDS: &'static [&'static str] = &["id", "version", "crypto", "Crypto", "address"];
+		static FIELDS: &[&str] = &["id", "version", "crypto", "Crypto", "address"];
 		deserializer.deserialize_struct("Crypto", FIELDS, CryptoVisitor)
 	}
 }
@@ -155,10 +155,10 @@ impl<'a> Visitor<'a> for CryptoVisitor {
 		};
 
 		let result = Crypto {
-			cipher: cipher,
-			ciphertext: ciphertext,
-			kdf: kdf,
-			mac: mac,
+			cipher,
+			ciphertext,
+			kdf,
+			mac,
 		};
 
 		Ok(result)
@@ -170,19 +170,19 @@ impl Serialize for Crypto {
 		where S: Serializer
 	{
 		let mut crypto = serializer.serialize_struct("Crypto", 6)?;
-		match self.cipher {
-			Cipher::Aes128Ctr(ref params) => {
+		match &self.cipher {
+			Cipher::Aes128Ctr(params) => {
 				crypto.serialize_field("cipher", &CipherSer::Aes128Ctr)?;
 				crypto.serialize_field("cipherparams", params)?;
 			},
 		}
 		crypto.serialize_field("ciphertext", &self.ciphertext)?;
-		match self.kdf {
-			Kdf::Pbkdf2(ref params) => {
+		match &self.kdf {
+			Kdf::Pbkdf2(params) => {
 				crypto.serialize_field("kdf", &KdfSer::Pbkdf2)?;
 				crypto.serialize_field("kdfparams", params)?;
 			},
-			Kdf::Scrypt(ref params) => {
+			Kdf::Scrypt(params) => {
 				crypto.serialize_field("kdf", &KdfSer::Scrypt)?;
 				crypto.serialize_field("kdfparams", params)?;
 			},

--- a/accounts/ethstore/src/json/error.rs
+++ b/accounts/ethstore/src/json/error.rs
@@ -30,15 +30,15 @@ pub enum Error {
 
 impl fmt::Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-		match *self {
-			Error::InvalidUuid => write!(f, "Invalid Uuid"),
-			Error::UnsupportedVersion => write!(f, "Unsupported version"),
-			Error::UnsupportedKdf => write!(f, "Unsupported kdf"),
-			Error::InvalidCiphertext => write!(f, "Invalid ciphertext"),
-			Error::UnsupportedCipher => write!(f, "Unsupported cipher"),
-			Error::InvalidCipherParams => write!(f, "Invalid cipher params"),
-			Error::InvalidH256 => write!(f, "Invalid hash"),
-			Error::InvalidPrf => write!(f, "Invalid prf"),
+		match self {
+			Self::InvalidUuid => write!(f, "Invalid Uuid"),
+			Self::UnsupportedVersion => write!(f, "Unsupported version"),
+			Self::UnsupportedKdf => write!(f, "Unsupported kdf"),
+			Self::InvalidCiphertext => write!(f, "Invalid ciphertext"),
+			Self::UnsupportedCipher => write!(f, "Unsupported cipher"),
+			Self::InvalidCipherParams => write!(f, "Invalid cipher params"),
+			Self::InvalidH256 => write!(f, "Invalid hash"),
+			Self::InvalidPrf => write!(f, "Invalid prf"),
 		}
 	}
 }

--- a/accounts/ethstore/src/json/hash.rs
+++ b/accounts/ethstore/src/json/hash.rs
@@ -83,14 +83,15 @@ macro_rules! impl_hash {
 			type Err = Error;
 
 			fn from_str(value: &str) -> Result<Self, Self::Err> {
-				match value.from_hex() {
-					Ok(ref hex) if hex.len() == $size => {
-						let mut hash = [0u8; $size];
-						hash.clone_from_slice(hex);
-						Ok($name(hash))
+				if let Ok(hex) = value.from_hex() {
+					if hex.len() == $size {
+						let mut hash = [0_u8; $size];
+						hash.copy_from_slice(&hex);
+						return Ok($name(hash));
 					}
-					_ => Err(Error::InvalidH256),
 				}
+
+				Err(Error::InvalidH256)
 			}
 		}
 

--- a/accounts/ethstore/src/json/id.rs
+++ b/accounts/ethstore/src/json/id.rs
@@ -27,7 +27,7 @@ pub struct Uuid([u8; 16]);
 
 impl From<[u8; 16]> for Uuid {
 	fn from(uuid: [u8; 16]) -> Self {
-		Uuid(uuid)
+		Self(uuid)
 	}
 }
 
@@ -56,7 +56,7 @@ impl Into<[u8; 16]> for Uuid {
 
 impl fmt::Display for Uuid {
 	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-		let s: String = (self as &Uuid).into();
+		let s: String = (self as &Self).into();
 		write!(f, "{}", s)
 	}
 }
@@ -76,13 +76,13 @@ impl str::FromStr for Uuid {
 	type Err = Error;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		let parts: Vec<&str> = s.split("-").collect();
+		let parts: Vec<&str> = s.split('-').collect();
 
 		if parts.len() != 5 {
 			return Err(Error::InvalidUuid);
 		}
 
-		let mut uuid = [0u8; 16];
+		let mut uuid = [0_u8; 16];
 
 		copy_into(parts[0], &mut uuid[0..4])?;
 		copy_into(parts[1], &mut uuid[4..6])?;
@@ -90,13 +90,13 @@ impl str::FromStr for Uuid {
 		copy_into(parts[3], &mut uuid[8..10])?;
 		copy_into(parts[4], &mut uuid[10..16])?;
 
-		Ok(Uuid(uuid))
+		Ok(Self(uuid))
 	}
 }
 
 impl From<&'static str> for Uuid {
 	fn from(s: &'static str) -> Self {
-		s.parse().expect(&format!("invalid string literal for {}: '{}'", stringify!(Self), s))
+		s.parse().unwrap_or_else(|e| panic!("invalid string literal for {}: '{}': {}", stringify!(Self), s, e))
 	}
 }
 

--- a/accounts/ethstore/src/json/kdf.rs
+++ b/accounts/ethstore/src/json/kdf.rs
@@ -28,9 +28,9 @@ pub enum KdfSer {
 impl Serialize for KdfSer {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where S: Serializer {
-		match *self {
-			KdfSer::Pbkdf2 => serializer.serialize_str("pbkdf2"),
-			KdfSer::Scrypt => serializer.serialize_str("scrypt"),
+		match self {
+			Self::Pbkdf2 => serializer.serialize_str("pbkdf2"),
+			Self::Scrypt => serializer.serialize_str("scrypt"),
 		}
 	}
 }
@@ -72,8 +72,8 @@ pub enum Prf {
 impl Serialize for Prf {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where S: Serializer {
-		match *self {
-			Prf::HmacSha256 => serializer.serialize_str("hmac-sha256"),
+		match self {
+			Self::HmacSha256 => serializer.serialize_str("hmac-sha256"),
 		}
 	}
 }
@@ -132,9 +132,9 @@ pub enum KdfSerParams {
 impl Serialize for KdfSerParams {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where S: Serializer {
-		match *self {
-			KdfSerParams::Pbkdf2(ref params) => params.serialize(serializer),
-			KdfSerParams::Scrypt(ref params) => params.serialize(serializer),
+		match self {
+			Self::Pbkdf2(params) => params.serialize(serializer),
+			Self::Scrypt(params) => params.serialize(serializer),
 		}
 	}
 }
@@ -146,8 +146,8 @@ impl<'a> Deserialize<'a> for KdfSerParams {
 
 		let v: Value = Deserialize::deserialize(deserializer)?;
 
-		from_value(v.clone()).map(KdfSerParams::Pbkdf2)
-			.or_else(|_| from_value(v).map(KdfSerParams::Scrypt))
+		from_value(v.clone()).map(Self::Pbkdf2)
+			.or_else(|_| from_value(v).map(Self::Scrypt))
 			.map_err(|_| D::Error::custom("Invalid KDF algorithm"))
 	}
 }

--- a/accounts/ethstore/src/json/key_file.rs
+++ b/accounts/ethstore/src/json/key_file.rs
@@ -37,7 +37,7 @@ impl Serialize for OpaqueKeyFile {
 
 impl<T> From<T> for OpaqueKeyFile where T: Into<KeyFile> {
 	fn from(val: T) -> Self {
-		OpaqueKeyFile { key_file: val.into() }
+		Self { key_file: val.into() }
 	}
 }
 
@@ -61,7 +61,7 @@ enum KeyFileField {
 }
 
 impl<'a> Deserialize<'a> for KeyFileField {
-	fn deserialize<D>(deserializer: D) -> Result<KeyFileField, D::Error>
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 		where D: Deserializer<'a>
 	{
 		deserializer.deserialize_any(KeyFileFieldVisitor)
@@ -94,15 +94,15 @@ impl<'a> Visitor<'a> for KeyFileFieldVisitor {
 }
 
 impl<'a> Deserialize<'a> for KeyFile {
-	fn deserialize<D>(deserializer: D) -> Result<KeyFile, D::Error>
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 		where D: Deserializer<'a>
 	{
-		static FIELDS: &'static [&'static str] = &["id", "version", "crypto", "Crypto", "address"];
+		static FIELDS: &[&str] = &["id", "version", "crypto", "Crypto", "address"];
 		deserializer.deserialize_struct("KeyFile", FIELDS, KeyFileVisitor)
 	}
 }
 
-fn none_if_empty<'a, T>(v: Option<serde_json::Value>) -> Option<T> where
+fn none_if_empty<T>(v: Option<serde_json::Value>) -> Option<T> where
 	T: DeserializeOwned
 {
 	v.and_then(|v| if v.is_null() {
@@ -159,12 +159,12 @@ impl<'a> Visitor<'a> for KeyFileVisitor {
 		};
 
 		let result = KeyFile {
-			id: id,
-			version: version,
-			crypto: crypto,
-			address: address,
-			name: name,
-			meta: meta,
+			id,
+			version,
+			crypto,
+			address,
+			name,
+			meta,
 		};
 
 		Ok(result)
@@ -224,7 +224,7 @@ mod tests {
 				}),
 				ciphertext: "7203da0676d141b138cd7f8e1a4365f59cc1aa6978dc5443f364ca943d7cb4bc".into(),
 				kdf: Kdf::Scrypt(Scrypt {
-					n: 262144,
+					n: 262_144,
 					dklen: 32,
 					p: 1,
 					r: 8,
@@ -275,7 +275,7 @@ mod tests {
 				}),
 				ciphertext: "7203da0676d141b138cd7f8e1a4365f59cc1aa6978dc5443f364ca943d7cb4bc".into(),
 				kdf: Kdf::Scrypt(Scrypt {
-					n: 262144,
+					n: 262_144,
 					dklen: 32,
 					p: 1,
 					r: 8,
@@ -303,7 +303,7 @@ mod tests {
 				}),
 				ciphertext: "7203da0676d141b138cd7f8e1a4365f59cc1aa6978dc5443f364ca943d7cb4bc".into(),
 				kdf: Kdf::Scrypt(Scrypt {
-					n: 262144,
+					n: 262_144,
 					dklen: 32,
 					p: 1,
 					r: 8,

--- a/accounts/ethstore/src/json/vault_key_file.rs
+++ b/accounts/ethstore/src/json/vault_key_file.rs
@@ -22,7 +22,7 @@ use serde_json::error;
 use super::{Uuid, Version, Crypto, H160};
 
 /// Meta key name for vault field
-const VAULT_NAME_META_KEY: &'static str = "vault";
+const VAULT_NAME_META_KEY: &str = "vault";
 
 /// Key file as stored in vaults
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -92,7 +92,7 @@ impl VaultKeyFile {
 
 impl VaultKeyMeta {
 	pub fn load(bytes: &[u8]) -> Result<Self, serde_json::Error> {
-		serde_json::from_slice(&bytes)
+		serde_json::from_slice(bytes)
 	}
 
 	pub fn write(&self) -> Result<Vec<u8>, serde_json::Error> {

--- a/accounts/ethstore/src/json/version.rs
+++ b/accounts/ethstore/src/json/version.rs
@@ -27,14 +27,14 @@ pub enum Version {
 impl Serialize for Version {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where S: Serializer {
-		match *self {
-			Version::V3 => serializer.serialize_u64(3)
+		match self {
+			Self::V3 => serializer.serialize_u64(3)
 		}
 	}
 }
 
 impl<'a> Deserialize<'a> for Version {
-	fn deserialize<D>(deserializer: D) -> Result<Version, D::Error>
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where D: Deserializer<'a> {
 		deserializer.deserialize_any(VersionVisitor)
 	}

--- a/accounts/ethstore/src/lib.rs
+++ b/accounts/ethstore/src/lib.rs
@@ -18,6 +18,54 @@
 
 #![warn(missing_docs)]
 
+#![warn(
+	clippy::all,
+	clippy::pedantic,
+	clippy::nursery,
+)]
+#![allow(
+	clippy::blacklisted_name,
+	clippy::cast_lossless,
+	clippy::cast_possible_truncation,
+	clippy::cast_possible_wrap,
+	clippy::cast_precision_loss,
+	clippy::cast_ptr_alignment,
+	clippy::cast_sign_loss,
+	clippy::cognitive_complexity,
+	clippy::default_trait_access,
+	clippy::enum_glob_use,
+	clippy::eval_order_dependence,
+	clippy::fallible_impl_from,
+	clippy::float_cmp,
+	clippy::identity_op,
+	clippy::if_not_else,
+	clippy::indexing_slicing,
+	clippy::inline_always,
+	clippy::items_after_statements,
+	clippy::large_enum_variant,
+	clippy::many_single_char_names,
+	clippy::match_same_arms,
+	clippy::missing_errors_doc,
+	clippy::missing_safety_doc,
+	clippy::module_inception,
+	clippy::module_name_repetitions,
+	clippy::must_use_candidate,
+	clippy::needless_pass_by_value,
+	clippy::needless_update,
+	clippy::non_ascii_literal,
+	clippy::option_option,
+	clippy::pub_enum_variant_names,
+	clippy::same_functions_in_if_condition,
+	clippy::shadow_unrelated,
+	clippy::similar_names,
+	clippy::single_component_path_imports,
+	clippy::too_many_arguments,
+	clippy::too_many_lines,
+	clippy::type_complexity,
+	clippy::unused_self,
+	clippy::used_underscore_binding,
+)]
+
 extern crate dir;
 extern crate itertools;
 extern crate libc;
@@ -92,7 +140,7 @@ impl From<json::H160> for Address {
 
 impl<'a> From<&'a json::H160> for Address {
 	fn from(json: &'a json::H160) -> Self {
-		let mut a = [0u8; 20];
+		let mut a = [0_u8; 20];
 		a.copy_from_slice(json);
 		From::from(a)
 	}

--- a/accounts/ethstore/src/presale.rs
+++ b/accounts/ethstore/src/presale.rs
@@ -31,15 +31,15 @@ pub struct PresaleWallet {
 
 impl From<json::PresaleWallet> for PresaleWallet {
 	fn from(wallet: json::PresaleWallet) -> Self {
-		let mut iv = [0u8; 16];
+		let mut iv = [0_u8; 16];
 		iv.copy_from_slice(&wallet.encseed[..16]);
 
-		let mut ciphertext = vec![];
+		let mut ciphertext = Vec::new();
 		ciphertext.extend_from_slice(&wallet.encseed[16..]);
 
-		PresaleWallet {
-			iv: iv,
-			ciphertext: ciphertext,
+		Self {
+			iv,
+			ciphertext,
 			address: Address::from(wallet.address),
 		}
 	}
@@ -51,12 +51,12 @@ impl PresaleWallet {
 		let file = fs::File::open(path)?;
 		let presale = json::PresaleWallet::load(file)
 			.map_err(|e| Error::InvalidKeyFile(format!("{}", e)))?;
-		Ok(PresaleWallet::from(presale))
+		Ok(Self::from(presale))
 	}
 
 	/// Decrypt the wallet.
 	pub fn decrypt(&self, password: &Password) -> Result<KeyPair, Error> {
-		let mut derived_key = [0u8; 32];
+		let mut derived_key = [0_u8; 32];
 		let salt = pbkdf2::Salt(password.as_bytes());
 		let sec = pbkdf2::Secret(password.as_bytes());
 		pbkdf2::sha256(2000, salt, sec, &mut derived_key);

--- a/accounts/ethstore/src/random.rs
+++ b/accounts/ethstore/src/random.rs
@@ -22,7 +22,7 @@ pub trait Random {
 
 impl Random for [u8; 16] {
 	fn random() -> Self {
-		let mut result = [0u8; 16];
+		let mut result = [0_u8; 16];
 		let mut rng = OsRng;
 		rng.fill_bytes(&mut result);
 		result
@@ -31,7 +31,7 @@ impl Random for [u8; 16] {
 
 impl Random for [u8; 32] {
 	fn random() -> Self {
-		let mut result = [0u8; 32];
+		let mut result = [0_u8; 32];
 		let mut rng = OsRng;
 		rng.fill_bytes(&mut result);
 		result

--- a/accounts/ethstore/src/secret_store.rs
+++ b/accounts/ethstore/src/secret_store.rs
@@ -43,7 +43,7 @@ pub struct StoreAccountRef {
 }
 
 impl PartialOrd for StoreAccountRef {
-	fn partial_cmp(&self, other: &StoreAccountRef) -> Option<Ordering> {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
 		Some(self.address.cmp(&other.address).then_with(|| self.vault.cmp(&other.vault)))
 	}
 }
@@ -148,24 +148,25 @@ pub trait SecretStore: SimpleSecretStore {
 
 impl StoreAccountRef {
 	/// Create reference to root account with given address
-	pub fn root(address: Address) -> Self {
-		StoreAccountRef::new(SecretVaultRef::Root, address)
+	pub const fn root(address: Address) -> Self {
+		Self::new(SecretVaultRef::Root, address)
 	}
 
 	/// Create reference to vault account with given address
 	pub fn vault(vault_name: &str, address: Address) -> Self {
-		StoreAccountRef::new(SecretVaultRef::Vault(vault_name.to_owned()), address)
+		Self::new(SecretVaultRef::Vault(vault_name.to_owned()), address)
 	}
 
 	/// Create new account reference
-	pub fn new(vault_ref: SecretVaultRef, address: Address) -> Self {
-		StoreAccountRef {
-			vault: vault_ref,
-			address: address,
+	pub const fn new(vault: SecretVaultRef, address: Address) -> Self {
+		Self {
+			vault,
+			address,
 		}
 	}
 }
 
+#[allow(clippy::derive_hash_xor_eq)]
 impl Hash for StoreAccountRef {
 	fn hash<H: Hasher>(&self, state: &mut H) {
 		self.address.hash(state);

--- a/accounts/ethstore/tests/api.rs
+++ b/accounts/ethstore/tests/api.rs
@@ -14,6 +14,54 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
+#![warn(
+	clippy::all,
+	clippy::pedantic,
+	clippy::nursery,
+)]
+#![allow(
+	clippy::blacklisted_name,
+	clippy::cast_lossless,
+	clippy::cast_possible_truncation,
+	clippy::cast_possible_wrap,
+	clippy::cast_precision_loss,
+	clippy::cast_ptr_alignment,
+	clippy::cast_sign_loss,
+	clippy::cognitive_complexity,
+	clippy::default_trait_access,
+	clippy::enum_glob_use,
+	clippy::eval_order_dependence,
+	clippy::fallible_impl_from,
+	clippy::float_cmp,
+	clippy::identity_op,
+	clippy::if_not_else,
+	clippy::indexing_slicing,
+	clippy::inline_always,
+	clippy::items_after_statements,
+	clippy::large_enum_variant,
+	clippy::many_single_char_names,
+	clippy::match_same_arms,
+	clippy::missing_errors_doc,
+	clippy::missing_safety_doc,
+	clippy::module_inception,
+	clippy::module_name_repetitions,
+	clippy::must_use_candidate,
+	clippy::needless_pass_by_value,
+	clippy::needless_update,
+	clippy::non_ascii_literal,
+	clippy::option_option,
+	clippy::pub_enum_variant_names,
+	clippy::same_functions_in_if_condition,
+	clippy::shadow_unrelated,
+	clippy::similar_names,
+	clippy::single_component_path_imports,
+	clippy::too_many_arguments,
+	clippy::too_many_lines,
+	clippy::type_complexity,
+	clippy::unused_self,
+	clippy::used_underscore_binding,
+)]
+
 extern crate rand;
 extern crate ethstore;
 extern crate ethereum_types;

--- a/accounts/ethstore/tests/util/transient_dir.rs
+++ b/accounts/ethstore/tests/util/transient_dir.rs
@@ -35,9 +35,9 @@ pub struct TransientDir {
 impl TransientDir {
 	pub fn create() -> Result<Self, Error> {
 		let path = random_dir();
-		let result = TransientDir {
+		let result = Self {
 			dir: RootDiskDirectory::create(&path)?,
-			path: path,
+			path,
 		};
 
 		Ok(result)
@@ -45,9 +45,9 @@ impl TransientDir {
 
 	pub fn open() -> Self {
 		let path = random_dir();
-		TransientDir {
+		Self {
 			dir: RootDiskDirectory::at(&path),
-			path: path,
+			path,
 		}
 	}
 }

--- a/accounts/src/account_data.rs
+++ b/accounts/src/account_data.rs
@@ -24,7 +24,7 @@ use std::{
 use parity_crypto::publickey::Address;
 use ethkey::Password;
 use serde_derive::{Serialize, Deserialize};
-use serde_json;
+
 
 /// Type of unlock.
 #[derive(Clone, PartialEq)]
@@ -57,14 +57,14 @@ pub struct AccountMeta {
 }
 
 impl AccountMeta {
-	/// Read a hash map of Address -> AccountMeta
+	/// Read a hash map of `Address` -> `AccountMeta`
 	pub fn read<R>(reader: R) -> Result<HashMap<Address, Self>, serde_json::Error> where
 		R: ::std::io::Read,
 	{
 		serde_json::from_reader(reader)
 	}
 
-	/// Write a hash map of Address -> AccountMeta
+	/// Write a hash map of `Address` -> `AccountMeta`
 	pub fn write<W>(m: &HashMap<Address, Self>, writer: &mut W) -> Result<(), serde_json::Error> where
 		W: ::std::io::Write,
 	{

--- a/accounts/src/error.rs
+++ b/accounts/src/error.rs
@@ -31,16 +31,16 @@ pub enum SignError {
 
 impl fmt::Display for SignError {
 	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-		match *self {
-			SignError::NotUnlocked => write!(f, "Account is locked"),
-			SignError::NotFound => write!(f, "Account does not exist"),
-			SignError::SStore(ref e) => write!(f, "{}", e),
+		match self {
+			Self::NotUnlocked => write!(f, "Account is locked"),
+			Self::NotFound => write!(f, "Account does not exist"),
+			Self::SStore(e) => write!(f, "{}", e),
 		}
 	}
 }
 
 impl From<SSError> for SignError {
 	fn from(e: SSError) -> Self {
-		SignError::SStore(e)
+		Self::SStore(e)
 	}
 }

--- a/accounts/src/stores.rs
+++ b/accounts/src/stores.rs
@@ -33,7 +33,7 @@ pub struct AddressBook {
 impl AddressBook {
 	/// Creates new address book at given directory.
 	pub fn new(path: &Path) -> Self {
-		let mut r = AddressBook {
+		let mut r = Self {
 			cache: DiskMap::new(path, "address_book.json")
 		};
 		r.cache.revert(AccountMeta::read);
@@ -42,7 +42,7 @@ impl AddressBook {
 
 	/// Creates transient address book (no changes are saved to disk).
 	pub fn transient() -> Self {
-		AddressBook {
+		Self {
 			cache: DiskMap::transient()
 		}
 	}
@@ -60,7 +60,7 @@ impl AddressBook {
 	pub fn set_name(&mut self, a: Address, name: String) {
 		{
 			let x = self.cache.entry(a)
-				.or_insert_with(|| AccountMeta {name: Default::default(), meta: "{}".to_owned(), uuid: None});
+				.or_insert_with(|| AccountMeta { name: String::new(), meta: "{}".to_owned(), uuid: None });
 			x.name = name;
 		}
 		self.save();
@@ -70,7 +70,7 @@ impl AddressBook {
 	pub fn set_meta(&mut self, a: Address, meta: String) {
 		{
 			let x = self.cache.entry(a)
-				.or_insert_with(|| AccountMeta {name: "Anonymous".to_owned(), meta: Default::default(), uuid: None});
+				.or_insert_with(|| AccountMeta { name: "Anonymous".to_owned(), meta: String::new(), uuid: None });
 			x.meta = meta;
 		}
 		self.save();
@@ -83,7 +83,7 @@ impl AddressBook {
 	}
 }
 
-/// Disk-serializable HashMap
+/// Disk-serializable hash map
 #[derive(Debug)]
 struct DiskMap<K: hash::Hash + Eq, V> {
 	path: PathBuf,
@@ -109,15 +109,15 @@ impl<K: hash::Hash + Eq, V> DiskMap<K, V> {
 		let mut path = path.to_owned();
 		path.push(file_name);
 		trace!(target: "diskmap", "path={:?}", path);
-		DiskMap {
-			path: path,
+		Self {
+			path,
 			cache: HashMap::new(),
 			transient: false,
 		}
 	}
 
 	pub fn transient() -> Self {
-		let mut map = DiskMap::new(&PathBuf::new(), "diskmap.json".into());
+		let mut map = Self::new(&PathBuf::new(), "diskmap.json");
 		map.transient = true;
 		map
 	}
@@ -178,7 +178,7 @@ mod tests {
 		b.set_name(Address::from_low_u64_be(1), "One".to_owned());
 		b.set_name(Address::from_low_u64_be(2), "Two".to_owned());
 		b.set_name(Address::from_low_u64_be(3), "Three".to_owned());
-		b.remove(Address::from_low_u64_be(2).into());
+		b.remove(Address::from_low_u64_be(2));
 
 		let b = AddressBook::new(tempdir.path());
 		assert_eq!(b.get(), vec![


### PR DESCRIPTION
This is the initial batch of style fixes as suggested by clippy as well as the general patterns of modern Rust. A couple of notes:
- This is based on all possible clippy hints including pedantic and nursery ones. I assembled a uniform blacklist of common lint occurrences that cannot (easily) be fixed which would be the same for all crates in the repo. This would ease its maintenance in the future.
- Besides the fixes suggested by clippy, I also removed the match by reference semantics in favor of explicit pre-match borrowing (or `as_ref` helper method).