### PR TITLE
Avoid copies

### DIFF
--- a/util/journaldb/src/overlayrecentdb.rs
+++ b/util/journaldb/src/overlayrecentdb.rs
@@ -20,7 +20,6 @@ use std::{
 	collections::{HashMap, hash_map::Entry},
 	io,
 	sync::Arc,
-	time::Duration,
 };
 
 use ethereum_types::H256;

--- a/util/journaldb/src/overlayrecentdb.rs
+++ b/util/journaldb/src/overlayrecentdb.rs
@@ -294,7 +294,7 @@ impl JournalDB for OverlayRecentDB {
 			let pkey = &key[..DB_PREFIX_LEN];
 			self.backing
 				.get_by_prefix(self.column, &pkey)
-				.map(|b| b.to_vec())
+				.map(|b| b.into_vec())
 		})
 	}
 


### PR DESCRIPTION
Prefer `into_vec()` over `to_vec()` of owned data to avoid unecessary copies. Maybe the compiler already sees this and optimizes it away, but yeah, better be explicit.