### PR TITLE
update Dockerfile (#11461)

### DIFF
--- a/scripts/docker/hub/Dockerfile
+++ b/scripts/docker/hub/Dockerfile
@@ -21,10 +21,11 @@ ENV RUST_BACKTRACE 1
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		file curl jq; \
+		file curl jq ca-certificates; \
 # apt cleanup
 	apt-get autoremove -y; \
 	apt-get clean; \
+  update-ca-certificates; \
 	rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*; \
 # add user
 	groupadd -g 1000 parity; \


### PR DESCRIPTION
This change forces the updating of CA certificates - fixes the issue of these errors:
`2020-02-06 16:16:27 UTC Failed to auto-update latest ETH price: Hyper(Error { kind: Connect, cause: Custom { kind: Other, error: Custom { kind: InvalidData, error: WebPKIError(UnknownIssuer) } } })` with our latest docker images.