### PR TITLE
sync: remove broken eth_protocol_version method

### DIFF
--- a/ethcore/sync/src/sync_io.rs
+++ b/ethcore/sync/src/sync_io.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use std::collections::HashMap;
 
 use crate::chain::sync_packet::{PacketInfo, SyncPacket};
+use crate::ETH_PROTOCOL;
 
 use bytes::Bytes;
 use client_traits::BlockChainClient;
@@ -142,7 +143,7 @@ impl<'s> SyncIo for NetSyncIo<'s> {
 	}
 
 	fn eth_protocol_version(&self, peer_id: PeerId) -> u8 {
-		self.network.protocol_version(self.network.subprotocol_name(), peer_id).unwrap_or(0)
+		self.network.protocol_version(ETH_PROTOCOL, peer_id).unwrap_or(0)
 	}
 
 	fn protocol_version(&self, protocol: &ProtocolId, peer_id: PeerId) -> u8 {

--- a/ethcore/sync/src/sync_io.rs
+++ b/ethcore/sync/src/sync_io.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use std::collections::HashMap;
 
 use crate::chain::sync_packet::{PacketInfo, SyncPacket};
-use crate::ETH_PROTOCOL;
 
 use bytes::Bytes;
 use client_traits::BlockChainClient;
@@ -55,8 +54,6 @@ pub trait SyncIo {
 	fn peer_enode(&self, peer_id: PeerId) -> Option<String>;
 	/// Returns information on p2p session
 	fn peer_session_info(&self, peer_id: PeerId) -> Option<SessionInfo>;
-	/// Maximum mutually supported ETH protocol version
-	fn eth_protocol_version(&self, peer_id: PeerId) -> u8;
 	/// Maximum mutually supported version of a gien protocol.
 	fn protocol_version(&self, protocol: &ProtocolId, peer_id: PeerId) -> u8;
 	/// Returns if the chain block queue empty
@@ -140,10 +137,6 @@ impl<'s> SyncIo for NetSyncIo<'s> {
 
 	fn peer_session_info(&self, peer_id: PeerId) -> Option<SessionInfo> {
 		self.network.session_info(peer_id)
-	}
-
-	fn eth_protocol_version(&self, peer_id: PeerId) -> u8 {
-		self.network.protocol_version(ETH_PROTOCOL, peer_id).unwrap_or(0)
 	}
 
 	fn protocol_version(&self, protocol: &ProtocolId, peer_id: PeerId) -> u8 {

--- a/ethcore/sync/src/tests/helpers.rs
+++ b/ethcore/sync/src/tests/helpers.rs
@@ -155,12 +155,8 @@ impl<'p, C> SyncIo for TestIo<'p, C> where C: FlushingBlockChainClient, C: 'p {
 		None
 	}
 
-	fn eth_protocol_version(&self, _peer: PeerId) -> u8 {
-		ETH_PROTOCOL_VERSION_63.0
-	}
-
-	fn protocol_version(&self, protocol: &ProtocolId, peer_id: PeerId) -> u8 {
-		if protocol == &WARP_SYNC_PROTOCOL_ID { PAR_PROTOCOL_VERSION_4.0 } else { self.eth_protocol_version(peer_id) }
+	fn protocol_version(&self, protocol: &ProtocolId, _peer_id: PeerId) -> u8 {
+		if protocol == &WARP_SYNC_PROTOCOL_ID { PAR_PROTOCOL_VERSION_4.0 } else { ETH_PROTOCOL_VERSION_63.0 }
 	}
 
 	fn is_expired(&self) -> bool {


### PR DESCRIPTION
It seems that this method is currently unused, but could be used in #11472.
ATM, it returns the same version as 
`if warp_protocol { io.protocol_version(&WARP_SYNC_PROTOCOL_ID, peer) } else { ETH_PROTOCOL_VERSION_63.0 };`
