### PR TITLE
cargo update -p cmake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.35"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ec65ee4f9c9d16f335091d23693457ed4928657ba4982289d7fafee03bc614a"
+checksum = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
This should fix building of parity-snappy on windows-server-2019 
https://github.com/General-Beck/parity-ethereum/runs/443545675?check_suite_focus=true#step:8:339
cc @General-Beck 