### PR TITLE
[ci benches]: use `all-features`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,7 +96,7 @@ cargo-check-benches:
   stage:                           test
   <<:                              *docker-cache-status
   script:
-    - time cargo check --all --benches --target $CARGO_TARGET --locked --verbose --color=always
+    - time cargo check --workspace --benches --target $CARGO_TARGET --locked --verbose --color=always --all-features
     - sccache --show-stats
 
 cargo-audit:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,13 +102,6 @@ slow-blocks = ["ethcore/slow-blocks"]
 secretstore = ["parity-secretstore", "accounts", "ethabi", "ethcore-call-contract"]
 final = ["parity-version/final"]
 deadlock_detection = ["parking_lot/deadlock_detection"]
-# to create a memory profile (requires nightly rust), use e.g.
-# `heaptrack /path/to/parity <parity params>`,
-# to visualize a memory profile, use `heaptrack_gui`
-# or
-# `valgrind --tool=massif /path/to/parity <parity params>`
-# and `massif-visualizer` for visualization
-memory_profiling = []
 # hardcode version number 1.3.7 of parity to force an update
 # in order to manually test that parity fall-over to the local version
 # in case of invalid or deprecated command line arguments are entered

--- a/ethcore/verification/benches/verification.rs
+++ b/ethcore/verification/benches/verification.rs
@@ -122,34 +122,20 @@ fn block_verification(c: &mut Criterion) {
 	let preverified = verification::verify_block_unordered(block, &ethash, true).expect(PROOF);
 	let parent = Unverified::from_rlp(rlp_8481475.clone()).expect(PROOF);
 
-	// "partial" means we skip uncle and tx verification
-	c.bench_function("verify_block_family (partial)", |b| {
-		b.iter(|| {
-			if let Err(e) = verification::verify_block_family::<TestBlockChainClient>(
-				&preverified.header,
-				&parent.header,
-				&ethash,
-				None
-			) {
-				panic!("verify_block_family (partial) ERROR: {:?}", e);
-			}
-		});
-	});
-
 	let mut block_provider = TestBlockChain::new();
 	block_provider.insert(rlp_8481476.clone()); // block to verify
 	block_provider.insert(rlp_8481475.clone()); // parent
 	block_provider.insert(rlp_8481474.clone()); // uncle's parent
 
 	let client = TestBlockChainClient::default();
-	c.bench_function("verify_block_family (full)", |b| {
+	c.bench_function("verify_block_family", |b| {
 		b.iter(|| {
 			let full = FullFamilyParams { block: &preverified, block_provider: &block_provider, client: &client };
 			if let Err(e) = verification::verify_block_family::<TestBlockChainClient>(
 				&preverified.header,
 				&parent.header,
 				&ethash,
-				Some(full),
+				full,
 			) {
 				panic!("verify_block_family (full) ERROR: {:?}", e)
 			}

--- a/parity/lib.rs
+++ b/parity/lib.rs
@@ -133,17 +133,10 @@ use configuration::{Cmd, Execute};
 use deprecated::find_deprecated;
 use hash::keccak_buffer;
 
-#[cfg(feature = "memory_profiling")]
-use std::alloc::System;
-
 pub use self::configuration::Configuration;
 pub use self::run::RunningClient;
 pub use parity_rpc::PubSubSession;
 pub use ethcore_logger::{Config as LoggerConfig, setup_log, RotatingLogger};
-
-#[cfg(feature = "memory_profiling")]
-#[global_allocator]
-static A: System = System;
 
 fn print_hash_of(maybe_file: Option<String>) -> Result<String, String> {
 	if let Some(file) = maybe_file {


### PR DESCRIPTION
Our benches are hidden behind feature flags, this PR enables to type check on those.

`--all` is deprecated
