### PR TITLE
Activate on-chain randomness in POA Sokol

### DIFF
--- a/ethcore/res/ethereum/poasokol.json
+++ b/ethcore/res/ethereum/poasokol.json
@@ -25,7 +25,10 @@
 					}
 				},
 				"blockRewardContractAddress": "0x3145197AD50D7083D0222DE4fCCf67d9BD05C30D",
-				"blockRewardContractTransition": 4639000
+				"blockRewardContractTransition": 4639000,
+				"randomnessContractAddress": {
+					"13391641": "0x8f2b78169B0970F11a762e56659Db52B59CBCf1B"
+				}
 			}
 		}
 	},


### PR DESCRIPTION
We activated [Randomness](https://github.com/paritytech/parity-ethereum/pull/10946) in our `Sokol` network at block `13391641`. POA Sokol validators now use Parity v2.7.2 with this [spec.json](https://github.com/poanetwork/poa-chain-spec/blob/5d4d6b5d4af1cd4426113a740132b5ad57534953/spec.json).

The proposed changes correspond to [the changes](https://github.com/poanetwork/poa-chain-spec/pull/137) in our `spec.json` for `Sokol`.